### PR TITLE
Removed Duplicates & Added Google Translate Definition

### DIFF
--- a/words.tsv
+++ b/words.tsv
@@ -1,1661 +1,1501 @@
-Lesson	Simplified Chinese	Traditional Chinese	Primary pinyin	CC-CEDICT pinyin	Primary English definition	CC-CEDICT English definition	Labels
-Greeting 1	你		nǐ		you		
-Greeting 1	好		hǎo   hào		good		
-Greeting 1	再见	再見	zài jiàn		see you again later		
-Greeting 1	再		zài		again		
-Greeting 1	见	見	jiàn		to see		
-Numbers	三		sān		3		
-Numbers	一		yī		1		
-Numbers	七		qī		7		
-Numbers	八		bā		8		
-Numbers	十		shí		10		
-Numbers	零		líng		zero		
-Numbers	元		Yuán		Chinese yuan currency unit		
-Numbers	五		wǔ		5		
-Numbers	九		jiǔ		9		
-Numbers	百		bǎi		100		
-Numbers	二		èr		2		
-Numbers	四		sì		4		
-Numbers	六		liù		6		
-Name	叫		jiào		to be called		
-Name	我		wǒ		I		
-Name	张	張	Zhāng		surname Zhang		
-Name	李		Lǐ		surname Li		
-Name	华	華	Huá		given name Huá		
-Name	明		míng				Meaning off-topic
-Name	名字		míng zi		name		
-Name	什么	什麼	shén me		what?		
-Name	名		míng				Meaning off-topic
-Name	字		zì		letter		
-Name	什		shén   shí				Meaning off-topic
-Name	么	麼	má   ma   me				Meaning off-topic
-Name	姓		xìng		Family name		
-Name	王		Wáng		surname Wang		
-Name	呢		ne		question particle		
-Name	李		Lǐ   lǐ		surname Li  plum		
-Greeting 2	很		hěn		very		
-Greeting 2	高兴	高興	gāo xìng		happy		
-Greeting 2	高		gāo		tall		
-Greeting 2	兴	興	xìng				Meaning off-topic
-Greeting 2	认识	認識	rèn shi		to know		
-Greeting 2	也		yě		too		
-Greeting 2	认	認	rèn				Meaning off-topic
-Greeting 2	识	識	shí   zhì				Meaning off-topic
-Food 1	吃		chī	chī	to eat	to eat / to consume / to eat at (a cafeteria etc) / to eradicate / to destroy / to absorb / to suffer / to stammer (Taiwan pr. for this sense is [ji2])	
-Food 1	饭	飯	fàn	fàn	food	food / cuisine / cooked rice / meal / CL: 碗, 頓｜顿	
-Food 1	鱼	魚	yú	Yú   yú	fish	surname Yu  fish / CL: 條｜条, 尾	
-Food 1	面		miàn	miàn   miàn	noodles	face / side / surface / aspect / top / classifier for flat surfaces such as drums, mirrors, flags etc  flour / noodles / (of food) soft (not crunchy) / (slang) (of a person) ineffectual / spineless	
-Food 1	喝		hē	hē   hè	to drink	to drink / My goodness!  to shout loudly	
-Food 1	水		shuǐ	Shuǐ   shuǐ	water	surname Shui  water / river / liquid / beverage / additional charges or income / (of clothes) classifier for number of washes	
-Food 1	茶		chá	chá	tea	tea / tea plant / CL: 杯, 壺｜壶	
-Food 1	不		bù	bù	not	(negative prefix) / not / no	
-Occupation	是		shì	shì	to be	is / are / am / yes / to be	
-Occupation	他		tā	tā	he	he or him / (used for either sex when the sex is unknown or unimportant) / (used before sb's name for emphasis) / (used as a meaningless mock object) / other / another	
-Occupation	学生	學生	xué sheng	xué sheng	student	student / schoolchild	
-Occupation	学	學	xué	xué	to learn	to learn / to study / to imitate / science / -ology	
-Occupation	生		shēng	shēng		to be born / to give birth / life / to grow / raw / uncooked / student	Meaning off-topic
-Occupation	吗	嗎	mǎ	mǎ   ma	question particle for 'yes-no' questions	see 嗎啡｜吗啡, morphine  (question particle for 'yes-no' questions)	
-Occupation	她		tā	tā	she	she	
-Occupation	你们	你們	nǐ men	nǐ men	you (plural)	you (plural)	
-Occupation	我们	我們	wǒ men	wǒ men	we	we / us / ourselves / our	
-Occupation	他们	他們	tā men	tā men	they	they	
-Occupation	们	們	men	men	plural marker for pronouns	plural marker for pronouns, and nouns referring to individuals	
-Occupation	老师	老師	lǎo shī	lǎo shī	teacher	teacher / CL: 個｜个, 位	
-Occupation	医生	醫生	yī shēng	yī shēng	doctor	doctor / CL: 個｜个, 位, 名	
-Occupation	她们	她們	tā men	tā men	they (females)	they / them (for females)	
-Occupation	老		lǎo	lǎo		prefix used before the surname of a person or a numeral indicating the order of birth of the children in a family or to indicate affection or familiarity / old (of people) / venerable (person) / experienced / of long standing / always / all the time / of the past / very / outdated / (of meat etc) tough	Meaning off-topic
-Occupation	师	師	Shī   shī	Shī   shī		surname Shi  teacher / master / expert / model / army division / (old) troops / to dispatch troops	Meaning off-topic
-Occupation	医	醫	yī	yī		medical / medicine / doctor / to cure / to treat	Meaning off-topic
-Contact	的		de	de   dī   dí   dì	of	of / ~'s (possessive particle) / (used after an attribute) / (used to form a nominal expression) / (used at the end of a declarative sentence for emphasis)  see 的士  really and truly  aim / clear	
-Contact	电话	電話	diàn huà	diàn huà	telephone	telephone / CL: 部 / phone call / CL: 通 / phone number	
-Contact	电	電	diàn	diàn	electricity	electric / electricity / electrical	
-Contact	话	話	huà	huà	language	dialect / language / spoken words / speech / talk / words / conversation / what sb said / CL: 種｜种, 席, 句, 口, 番	
-Contact	号码	號碼	hào mǎ	hào mǎ	number	number / CL: 堆, 個｜个	
-Contact	多少		duō shǎo	duō shǎo   duō shao	how many	number / amount / somewhat  how much / how many / which (number) / as much as	
-Contact	多		duō	duō	many	many / much / often / a lot of / numerous / more / in excess / how (to what extent) / multi- / Taiwan pr. [duo2] when it means 'how'	
-Contact	少		shǎo	shǎo   shào	few	few / less / to lack / to be missing / to stop (doing sth) / seldom  young	
-Contact	号	號	háo   hào	háo   hào		roar / cry / CL: 個｜个  ordinal number / day of a month / mark / sign / business establishment / size / ship suffix / horn (wind instrument) / bugle call / assumed name / to take a pulse / classifier used to indicate number of people	Meaning off-topic
-Contact	码	碼	mǎ	mǎ		weight / number / code / to pile / to stack / classifier for length or distance (yard), happenings etc	Meaning off-topic
-Nation	中国	中國	Zhōng guó	Zhōng guó	China	China	
-Nation	人		rén	rén	person	man / person / people / CL: 個｜个, 位	
-Nation	中		zhōng	Zhōng   zhōng   zhòng	middle	China / Chinese / surname Zhong  within / among / in / middle / center / while (doing sth) / during / (dialect) OK / all right  to hit (the mark) / to be hit by / to suffer / to win (a prize, a lottery)	
-Nation	国	國	guó	Guó   guó	country	surname Guo  country / nation / state / national / CL: 個｜个	
-Nation	哪		nǎ	nǎ   na   něi	how / which	how / which  (particle equivalent to 啊 after noun ending in -n)  which? (interrogative, followed by classifier or numeral-classifier)	
-Nation	英国	英國	Yīng guó	Yīng guó	United Kingdom	United Kingdom 聯合王國｜联合王国 / United Kingdom of Great Britain and Northern Ireland / abbr. for England 英格蘭｜英格兰	
-Nation	美国	美國	Měi guó	Měi guó	USA	United States / USA / US	
-Nation	英		Yīng   yīng	Yīng   yīng	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	
-Nation	美		Měi   měi	Měi   měi	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself	
-Nation	都		Dū   dōu   dū	Dū   dōu   dū	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	
-Nation	对	對	duì	duì	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	
-Nation	加拿大		Jiā ná dà	Jiā ná dà	Canada / Canadian	Canada / Canadian	
-Nation	加		Jiā   jiā	Jiā   jiā	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	
-Nation	拿		ná	ná	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	
-Nation	大		dà   dài	dà   dài	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	
-Greeting 3	忙		máng	máng	busy / hurriedly / to hurry / to rush	busy / hurriedly / to hurry / to rush	
-Greeting 3	早上		zǎo shang	zǎo shang	early morning / CL: 個｜个	early morning / CL: 個｜个	
-Greeting 3	早		zǎo	zǎo	early / morning / Good morning! / long ago / prematurely	early / morning / Good morning! / long ago / prematurely	
-Greeting 3	上		shǎng   shàng	shǎng   shàng	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	
-Greeting 3	怎么样	怎麼樣	zěn me yàng	zěn me yàng	how? / how about? / how was it? / how are things?	how? / how about? / how was it? / how are things?	
-Greeting 3	今天		jīn tiān	jīn tiān	today / at the present / now	today / at the present / now	
-Greeting 3	怎		zěn	zěn	how	how	
-Greeting 3	样	樣	yàng	yàng	manner / pattern / way / appearance / shape / classifier: kind, type	manner / pattern / way / appearance / shape / classifier: kind, type	
-Greeting 3	今		jīn	jīn	today / modern / present / current / this / now	today / modern / present / current / this / now	
-Greeting 3	天		tiān	tiān	day / sky / heaven	day / sky / heaven	
-Location 1	家	傢	jiā   Jiā   jiā	jiā   Jiā   jiā	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	
-Location 1	北京		Běi jīng	Běi jīng	Beijing, capital of People's Republic of China / Peking / PRC government	Beijing, capital of People's Republic of China / Peking / PRC government	
-Location 1	在		zài	zài	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	
-Location 1	北		běi	běi	north / to be defeated (classical)	north / to be defeated (classical)	
-Location 1	京		Jīng   jīng	Jīng   jīng	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)	
-Location 1	哪儿	哪兒	nǎr	nǎr	where? / wherever / anywhere	where? / wherever / anywhere	
-Location 1	纽约	紐約	Niǔ yuē	Niǔ yuē	New York	New York	
-Location 1	香港		Xiāng gǎng	Xiāng gǎng	Hong Kong	Hong Kong	
-Location 1	儿	兒	ér   r	ér   r	child / son  non-syllabic diminutive suffix / retroflex final	child / son  non-syllabic diminutive suffix / retroflex final	
-Location 1	纽	紐	niǔ	niǔ	to turn / to wrench / button / nu (Greek letter Νν)	to turn / to wrench / button / nu (Greek letter Νν)	
-Location 1	约	約	yāo   yuē	yāo   yuē	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise	
-Location 1	香		xiāng	xiāng	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	
-Location 1	港		Gǎng   gǎng	Gǎng   gǎng	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个	
-Location 1	住		zhù	zhù	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	
-Location 1	伦敦	倫敦	Lún dūn	Lún dūn	London, capital of United Kingdom	London, capital of United Kingdom	
-Location 1	台湾	臺灣	Tái wān	Tái wān	Taiwan	Taiwan	
-Location 1	伦	倫	lún	lún	human relationship / order / coherence	human relationship / order / coherence	
-Location 1	敦		dūn	dūn	kindhearted / place name	kindhearted / place name	
-Location 1	台		Tái   tái   tái   Tái   tái   tái	Tái   tái   tái   Tái   tái   tái	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon	
-Location 1	湾	灣	wān	wān	bay / gulf / to cast anchor / to moor (a boat)	bay / gulf / to cast anchor / to moor (a boat)	
-Phrases 1	谢谢	謝謝	xiè xie	xiè xie	to thank / thanks / thank you	to thank / thanks / thank you	
-Phrases 1	不客气	不客氣	bù kè qi	bù kè qi	you're welcome / don't mention it / impolite / rude / blunt	you're welcome / don't mention it / impolite / rude / blunt	
-Phrases 1	谢	謝	Xiè   xiè	Xiè   xiè	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline	
-Phrases 1	客		kè	kè	customer / visitor / guest	customer / visitor / guest	
-Phrases 1	气	氣	qì	qì	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi	
-Phrases 1	对不起	對不起	duì bu qǐ	duì bu qǐ	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	
-Phrases 1	没关系	沒關係	méi guān xi	méi guān xi	it doesn't matter	it doesn't matter	
-Phrases 1	起		qǐ	qǐ	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	
-Phrases 1	没	沒	méi   mò	méi   mò	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	
-Phrases 1	关	關	Guān   guān	Guān   guān	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	
-Phrases 1	系	係	xì   xì   jì   xì	xì   xì   jì   xì	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry	
-Family 1	爸爸		bà ba	bà ba	(informal) father / CL: 個｜个, 位	(informal) father / CL: 個｜个, 位	
-Family 1	妈妈	媽媽	mā ma	mā ma	mama / mommy / mother / CL: 個｜个, 位	mama / mommy / mother / CL: 個｜个, 位	
-Family 1	爱	愛	ài	ài	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)	
-Family 1	家人		jiā rén	jiā rén	household / (one's) family	household / (one's) family	
-Family 1	爸		bà	bà	father / dad / pa / papa	father / dad / pa / papa	
-Family 1	妈	媽	mā	mā	ma / mom / mother	ma / mom / mother	
-Family 1	谁	誰	shéi	shéi	who / also pr. [shui2]	who / also pr. [shui2]	
-Family 1	那		Nā   Nuó   nà   nuó	Nā   Nuó   nà   nuó	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪	
-Family 1	个	個	gè	gè	individual / this / that / size / classifier for people or objects in general	individual / this / that / size / classifier for people or objects in general	
-Family 1	这	這	zhè	zhè	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)	
-Family 1	哥哥		gē ge	gē ge	older brother / CL: 個｜个, 位	older brother / CL: 個｜个, 位	
-Family 1	姐姐		jiě jie	jiě jie	older sister / CL: 個｜个	older sister / CL: 個｜个	
-Family 1	有		yǒu	yǒu	to have / there is / there are / to exist / to be	to have / there is / there are / to exist / to be	
-Family 1	哥		gē	gē	elder brother	elder brother	
-Family 1	姐		jiě	jiě	older sister	older sister	
-Family 1	弟弟		dì di	dì di	younger brother / CL: 個｜个, 位	younger brother / CL: 個｜个, 位	
-Family 1	和		Hé   hé   hè   hú   huó   huò	Hé   hé   hè   hú   huó   huò	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	
-Family 1	妹妹		mèi mei	mèi mei	younger sister / young woman / CL: 個｜个	younger sister / young woman / CL: 個｜个	
-Family 1	没	沒	méi   mò	méi   mò	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	
-Family 1	弟		dì	dì	younger brother / junior male / I (modest word in letter)	younger brother / junior male / I (modest word in letter)	
-Family 1	妹		mèi	mèi	younger sister	younger sister	
-Phrases 2	请问	請問	qǐng wèn	qǐng wèn	Excuse me, may I ask...?	Excuse me, may I ask...?	
-Phrases 2	知道		zhī dào	zhī dào	to know / to become aware of / also pr. [zhi1 dao5]	to know / to become aware of / also pr. [zhi1 dao5]	
-Phrases 2	问	問	wèn	wèn	to ask	to ask	
-Phrases 2	请	請	qǐng	qǐng	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	
-Phrases 2	知		zhī	zhī	to know / to be aware	to know / to be aware	
-Phrases 2	道		dào	dào	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)	
-Phrases 2	说	說	shuì   shuō	shuì   shuō	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)	
-Phrases 2	英语	英語	Yīng yǔ	Yīng yǔ	English (language)	English (language)	
-Phrases 2	汉语	漢語	Hàn yǔ	Hàn yǔ	Chinese language / CL: 門｜门	Chinese language / CL: 門｜门	
-Phrases 2	汉	漢	Hàn   hàn	Hàn   hàn	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man	
-Phrases 2	语	語	yǔ   yù	yǔ   yù	dialect / language / speech  to tell to	dialect / language / speech  to tell to	
-Phrases 2	帮助	幫助	bāng zhù	bāng zhù	assistance / aid / to help / to assist	assistance / aid / to help / to assist	
-Phrases 2	再		zài	zài	again / once more / re- / second / another / then (after sth, and not until then)	again / once more / re- / second / another / then (after sth, and not until then)	
-Phrases 2	次		cì	cì	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	
-Phrases 2	帮	幫	bāng	bāng	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	
-Phrases 2	助		zhù	zhù	to help / to assist	to help / to assist	
-Greeting 4	早安		zǎo ān	zǎo ān	Good morning!	Good morning!	
-Greeting 4	晚安		wǎn ān	wǎn ān	Good night! / Good evening!	Good night! / Good evening!	
-Greeting 4	一会儿	一會兒	yī huìr	yī huìr	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	
-Greeting 4	见	見	jiàn   xiàn	jiàn   xiàn	to see / to meet / to appear (to be sth) / to interview  to appear / also written 現｜现	to see / to meet / to appear (to be sth) / to interview  to appear / also written 現｜现	
-Greeting 4	会	會	huì   kuài	huì   kuài	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	
-Greeting 4	安		Ān   ān	Ān   ān	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere	
-Greeting 4	最近		zuì jìn	zuì jìn	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	
-Greeting 4	好久不见	好久不見	hǎo jiǔ bu jiàn	hǎo jiǔ bu jiàn	long time no see	long time no see	
-Greeting 4	不错	不錯	bù cuò	bù cuò	correct / right / not bad / pretty good	correct / right / not bad / pretty good	
-Greeting 4	最		zuì	zuì	most / the most / -est (superlative suffix)	most / the most / -est (superlative suffix)	
-Greeting 4	近		jìn	jìn	near / close to / approximately	near / close to / approximately	
-Greeting 4	久		jiǔ	jiǔ	(long) time / (long) duration of time	(long) time / (long) duration of time	
-Greeting 4	错	錯	Cuò   cuò	Cuò   cuò	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	
-Drink	要		yāo   yào	yāo   yào	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if	
-Drink	热	熱	rè	rè	to warm up / to heat up / hot (of weather) / heat / fervent	to warm up / to heat up / hot (of weather) / heat / fervent	
-Drink	冰		bīng	bīng	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine	
-Drink	牛奶		niú nǎi	niú nǎi	cow's milk / CL: 瓶, 杯	cow's milk / CL: 瓶, 杯	
-Drink	咖啡		kā fēi	kā fēi	coffee (loanword) / CL: 杯	coffee (loanword) / CL: 杯	
-Drink	牛		Niú   niú	Niú   niú	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome	
-Drink	奶		nǎi   nǎi	nǎi   nǎi	breast / milk / to breastfeed  mother / variant of 奶	breast / milk / to breastfeed  mother / variant of 奶	
-Drink	咖		kā	kā	coffee / class / grade	coffee / class / grade	
-Drink	啡		fēi	fēi	(phonetic component)	(phonetic component)	
-Location 2	洗手间	洗手間	xǐ shǒu jiān	xǐ shǒu jiān	toilet / lavatory / washroom	toilet / lavatory / washroom	
-Location 2	医院	醫院	yī yuàn	yī yuàn	hospital / CL: 所, 家, 座	hospital / CL: 所, 家, 座	
-Location 2	洗		xǐ	xǐ	to wash / to bathe / to develop (photo)	to wash / to bathe / to develop (photo)	
-Location 2	手		shǒu	shǒu	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	
-Location 2	间	間	jiān   jiàn	jiān   jiàn	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	
-Location 2	院		yuàn	yuàn	courtyard / institution / CL: 個｜个	courtyard / institution / CL: 個｜个	
-Location 2	这儿	這兒	zhèr	zhèr	here	here	
-Location 2	那儿	那兒	nàr	nàr	there	there	
-Location 2	饭馆	飯館	fàn guǎn	fàn guǎn	restaurant / CL: 家	restaurant / CL: 家	
-Location 2	馆	館	guǎn	guǎn	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	
-Time 1	年		Nián   nián   nián	Nián   nián   nián	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年	
-Time 1	月		yuè	yuè	moon / month / monthly / CL: 個｜个, 輪｜轮	moon / month / monthly / CL: 個｜个, 輪｜轮	
-Time 1	号	號	háo   hào	háo   hào	roar / cry / CL: 個｜个  ordinal number / day of a month / mark / sign / business establishment / size / ship suffix / horn (wind instrument) / bugle call / assumed name / to take a pulse / classifier used to indicate number of people	roar / cry / CL: 個｜个  ordinal number / day of a month / mark / sign / business establishment / size / ship suffix / horn (wind instrument) / bugle call / assumed name / to take a pulse / classifier used to indicate number of people	
-Time 1	几		jī   jī   jǐ	jī   jī   jǐ	small table  almost  how much / how many / several / a few	small table  almost  how much / how many / several / a few	
-Time 1	〇		líng	líng	zero	zero	
-Time 1	星期		xīng qī	xīng qī	week / CL: 個｜个 / day of the week / Sunday	week / CL: 個｜个 / day of the week / Sunday	
-Time 1	明天		míng tiān	míng tiān	tomorrow	tomorrow	
-Time 1	天		tiān	tiān	day / sky / heaven	day / sky / heaven	
-Time 1	日		Rì   rì	Rì   rì	abbr. for 日本, Japan  sun / day / date, day of the month	abbr. for 日本, Japan  sun / day / date, day of the month	
-Time 1	星		xīng	xīng	star / heavenly body / satellite / small amount	star / heavenly body / satellite / small amount	
-Time 1	期		qī	qī	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]	
-Time 1	明		Míng   míng	Míng   míng	Ming Dynasty (1368-1644) / surname Ming / Ming (c. 2000 BC), fourth of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  bright / opposite: dark 暗 / (of meaning) clear / to understand / next / public or open / wise / generic term for a sacrifice to the gods	Ming Dynasty (1368-1644) / surname Ming / Ming (c. 2000 BC), fourth of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  bright / opposite: dark 暗 / (of meaning) clear / to understand / next / public or open / wise / generic term for a sacrifice to the gods	
-Time 1	点	點	diǎn	diǎn	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	
-Time 1	现在	現在	xiàn zài	xiàn zài	now / at present / at the moment / modern / current / nowadays	now / at present / at the moment / modern / current / nowadays	
-Time 1	半		bàn	bàn	half / semi- / incomplete / (after a number) and a half	half / semi- / incomplete / (after a number) and a half	
-Time 1	现	現	xiàn	xiàn	to appear / present / now / existing / current	to appear / present / now / existing / current	
-Family 2	孩子		hái zi	hái zi	child	child	
-Family 2	两	兩	liǎng	liǎng	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	
-Family 2	孩		hái	hái	child	child	
-Family 2	子		zǐ   zi	zǐ   zi	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)	
-Family 2	女儿	女兒	nǚ ér	nǚ ér	daughter	daughter	
-Family 2	儿子	兒子	ér zi	ér zi	son	son	
-Family 2	岁	歲	suì	suì	classifier for years (of age) / year / year (of crop harvests)	classifier for years (of age) / year / year (of crop harvests)	
-Family 2	女		nǚ	nǚ	female / woman / daughter	female / woman / daughter	
-Family 2	儿	兒	ér   r	ér   r	child / son  non-syllabic diminutive suffix / retroflex final	child / son  non-syllabic diminutive suffix / retroflex final	
-Family 2	妻子		qī zǐ   qī zi	qī zǐ   qī zi	wife and children  wife / CL: 個｜个	wife and children  wife / CL: 個｜个	
-Family 2	丈夫		zhàng fu	zhàng fu	husband / CL: 個｜个	husband / CL: 個｜个	
-Family 2	妻		qī   qì	qī   qì	wife  to marry off (a daughter)	wife  to marry off (a daughter)	
-Family 2	丈		zhàng	zhàng	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male	
-Family 2	夫		fū   fú	fū   fú	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)	
-Family 2	猫	貓	māo	māo	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem	
-Family 2	它		tā	tā	it	it	
-Family 2	狗		gǒu	gǒu	dog / CL: 隻｜只, 條｜条	dog / CL: 隻｜只, 條｜条	
-Telephone	喂		wéi   wèi   wèi	wéi   wèi   wèi	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	
-Telephone	慢		màn	màn	slow	slow	
-Telephone	一点儿		yī diǎnr	yī diǎnr	erhua variant of 一點｜一点	erhua variant of 一點｜一点	
-Telephone	快		kuài	kuài	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant	
-Telephone	得		dé   de   děi	dé   de   děi	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	
-Telephone	明白		míng bai	míng bai	clear / obvious / unequivocal / to understand / to realize	clear / obvious / unequivocal / to understand / to realize	
-Telephone	白		Bái   bái	Bái   bái	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	
-People 1	漂亮		piào liang	piào liang	pretty / beautiful	pretty / beautiful	
-People 1	高		Gāo   gāo	Gāo   gāo	surname Gao  high / tall / above average / loud / your (honorific)	surname Gao  high / tall / above average / loud / your (honorific)	
-People 1	漂		piāo   piǎo   piào	piāo   piǎo   piào	to float / to drift  to bleach  elegant / polished	to float / to drift  to bleach  elegant / polished	
-People 1	亮		liàng	liàng	bright / clear / resonant / to shine / to show / to reveal	bright / clear / resonant / to shine / to show / to reveal	
-People 1	朋友		péng you	péng you	friend / CL: 個｜个, 位	friend / CL: 個｜个, 位	
-People 1	男		nán	nán	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个	
-People 1	矮		ǎi	ǎi	low / short (in length)	low / short (in length)	
-People 1	朋		péng	péng	friend	friend	
-People 1	友		yǒu	yǒu	friend	friend	
-People 1	女		nǚ	nǚ	female / woman / daughter	female / woman / daughter	
-People 1	可爱	可愛	kě ài	kě ài	adorable / cute / lovely	adorable / cute / lovely	
-People 1	非常		fēi cháng	fēi cháng	very / very much / unusual / extraordinary	very / very much / unusual / extraordinary	
-People 1	可		kě   kè	kě   kè	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗	
-People 1	非		Fēi   fēi	Fēi   fēi	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must	
-People 1	常		Cháng   cháng	Cháng   cháng	surname Chang  always / ever / often / frequently / common / general / constant	surname Chang  always / ever / often / frequently / common / general / constant	
-Time 2	上午		shàng wǔ	shàng wǔ	morning / CL: 個｜个	morning / CL: 個｜个	
-Time 2	分		fēn   fèn	fēn   fèn	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	
-Time 2	下午		xià wǔ	xià wǔ	afternoon / CL: 個｜个 / p.m.	afternoon / CL: 個｜个 / p.m.	
-Time 2	晚上		wǎn shang	wǎn shang	evening / night / CL: 個｜个 / in the evening	evening / night / CL: 個｜个 / in the evening	
-Time 2	午		wǔ	wǔ	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)	
-Time 2	晚		wǎn	wǎn	evening / night / late	evening / night / late	
-Time 2	下		xià	xià	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	
-Time 2	每		měi	měi	each / every	each / every	
-Time 2	中午		zhōng wǔ	zhōng wǔ	noon / midday / CL: 個｜个	noon / midday / CL: 個｜个	
-Time 2	周末	週末	zhōu mò	zhōu mò	weekend	weekend	
-Time 2	天		tiān	tiān	day / sky / heaven	day / sky / heaven	
-Time 2	周		Zhōu   zhōu   zhōu	Zhōu   zhōu   zhōu	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周	
-Time 2	末		mò	mò	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man	
-Time 2	昨天		zuó tiān	zuó tiān	yesterday	yesterday	
-Time 2	上		shǎng   shàng	shǎng   shàng	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	
-Time 2	了		le   liǎo   liǎo	le   liǎo   liǎo	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	
-Time 2	做		zuò	zuò	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	
-Time 2	昨		zuó	zuó	yesterday	yesterday	
-Time 2	今年		jīn nián	jīn nián	this year	this year	
-Time 2	去年		qù nián	qù nián	last year	last year	
-Time 2	明年		míng nián	míng nián	next year	next year	
-Time 2	会	會	huì   kuài	huì   kuài	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	
-Time 2	去		qù	qù	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	
-Location 3	旁边	旁邊	páng biān	páng biān	lateral / side / to the side / beside	lateral / side / to the side / beside	
-Location 3	左边	左邊	zuǒ bian	zuǒ bian	left / the left side / to the left of	left / the left side / to the left of	
-Location 3	右边	右邊	yòu bian	yòu bian	right side / right, to the right	right side / right, to the right	
-Location 3	旁		páng	páng	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic	
-Location 3	左		Zuǒ   zuǒ	Zuǒ   zuǒ	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	
-Location 3	右		yòu	yòu	right (-hand) / the Right (politics) / west (old)	right (-hand) / the Right (politics) / west (old)	
-Location 3	边	邊	biān   bian	biān   bian	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality	
-Location 3	前面		qián miàn	qián miàn	ahead / in front / preceding / above / also pr. [qian2 mian5]	ahead / in front / preceding / above / also pr. [qian2 mian5]	
-Location 3	后面	後面	hòu miàn	hòu miàn	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	
-Location 3	学校	學校	xué xiào	xué xiào	school / CL: 所	school / CL: 所	
-Location 3	前		qián	qián	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	
-Location 3	后		Hòu   hòu   hòu	Hòu   hòu   hòu	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	
-Location 3	校		jiào   xiào	jiào   xiào	to proofread / to check / to compare  school / military officer / CL: 所	to proofread / to check / to compare  school / military officer / CL: 所	
-Location 3	走		zǒu	zǒu	to walk / to go / to run / to move (of vehicle) / to visit / to leave / to go away / to die (euph.) / from / through / away (in compound verbs, such as 撤走) / to change (shape, form, meaning)	to walk / to go / to run / to move (of vehicle) / to visit / to leave / to go away / to die (euph.) / from / through / away (in compound verbs, such as 撤走) / to change (shape, form, meaning)	
-Location 3	到		dào	dào	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)	
-Location 3	路		Lù   lù	Lù   lù	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	
-Location 3	怎么	怎麼	zěn me	zěn me	how? / what? / why?	how? / what? / why?	
-Location 3	哪里	哪裏	nǎ lǐ   nǎ lǐ	nǎ lǐ   nǎ lǐ	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	
-Location 3	这里	這裡	zhè lǐ	zhè lǐ	here	here	
-Location 3	那里	那裏	nà li   nà li	nà li   nà li	there / that place / also written 那裡｜那里  there / that place	there / that place / also written 那裡｜那里  there / that place	
-Location 3	往		wǎng	wǎng	to go (in a direction) / to / towards / (of a train) bound for / past / previous	to go (in a direction) / to / towards / (of a train) bound for / past / previous	
-Location 3	里	裡	lǐ   Lǐ   lǐ	lǐ   Lǐ   lǐ	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	
-Hobbies 1	喜欢	喜歡	xǐ huan	xǐ huan	to like / to be fond of	to like / to be fond of	
-Hobbies 1	看		kān   kàn	kān   kàn	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)	
-Hobbies 1	书	書	Shū   shū	Shū   shū	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write	
-Hobbies 1	在		zài	zài	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	
-Hobbies 1	喜		xǐ	xǐ	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad	
-Hobbies 1	欢	歡	huān   huān   huān	huān   huān   huān	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢	
-Hobbies 1	玩		wán	wán	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	
-Hobbies 1	电脑	電腦	diàn nǎo	diàn nǎo	computer / CL: 臺｜台	computer / CL: 臺｜台	
-Hobbies 1	游戏	遊戲	yóu xì	yóu xì	game / CL: 場｜场 / to play	game / CL: 場｜场 / to play	
-Hobbies 1	最		zuì	zuì	most / the most / -est (superlative suffix)	most / the most / -est (superlative suffix)	
-Hobbies 1	脑	腦	nǎo	nǎo	brain / mind / head / essence	brain / mind / head / essence	
-Hobbies 1	游		Yóu   yóu   yóu	Yóu   yóu   yóu	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	
-Hobbies 1	戏	戲	xì	xì	trick / drama / play / show / CL: 出, 場｜场, 臺｜台	trick / drama / play / show / CL: 出, 場｜场, 臺｜台	
-Hobbies 1	听		yǐn   tīng   tìng	yǐn   tīng   tìng	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	
-Hobbies 1	音乐	音樂	yīn yuè	yīn yuè	music / CL: 張｜张, 曲, 段	music / CL: 張｜张, 曲, 段	
-Hobbies 1	歌		gē	gē	song / CL: 支, 首 / to sing	song / CL: 支, 首 / to sing	
-Hobbies 1	音		yīn	yīn	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)	
-Hobbies 1	乐	樂	Lè   Yuè   lè   yuè	Lè   Yuè   lè   yuè	surname Le  surname Yue  happy / cheerful / to laugh  music	surname Le  surname Yue  happy / cheerful / to laugh  music	
-Hobbies 1	跳舞		tiào wǔ	tiào wǔ	to dance	to dance	
-Hobbies 1	会	會	huì   kuài	huì   kuài	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	
-Hobbies 1	唱		chàng	chàng	to sing / to call loudly / to chant	to sing / to call loudly / to chant	
-Hobbies 1	跳		tiào	tiào	to jump / to hop / to skip over / to bounce / to palpitate	to jump / to hop / to skip over / to bounce / to palpitate	
-Hobbies 1	舞		wǔ	wǔ	to dance / to wield / to brandish	to dance / to wield / to brandish	
-Daily Routine 1	起床		qǐ chuáng	qǐ chuáng	to get out of bed / to get up	to get out of bed / to get up	
-Daily Routine 1	上学	上學	shàng xué	shàng xué	to go to school / to attend school	to go to school / to attend school	
-Daily Routine 1	上班		shàng bān	shàng bān	to go to work / to be on duty / to start work / to go to the office	to go to work / to be on duty / to start work / to go to the office	
-Daily Routine 1	早饭	早飯	zǎo fàn	zǎo fàn	breakfast / CL: 份, 頓｜顿, 次, 餐	breakfast / CL: 份, 頓｜顿, 次, 餐	
-Daily Routine 1	做		zuò	zuò	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	
-Daily Routine 1	起		qǐ	qǐ	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	
-Daily Routine 1	床		chuáng	chuáng	bed / couch / classifier for beds / CL: 張｜张	bed / couch / classifier for beds / CL: 張｜张	
-Daily Routine 1	班		Bān   bān	Bān   bān	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	
-Daily Routine 1	从	從	Cóng   cóng   zòng	Cóng   cóng   zòng	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin	
-Daily Routine 1	睡觉	睡覺	shuì jiào	shuì jiào	to go to bed / to sleep	to go to bed / to sleep	
-Daily Routine 1	午饭	午飯	wǔ fàn	wǔ fàn	lunch / CL: 份, 頓｜顿, 次, 餐	lunch / CL: 份, 頓｜顿, 次, 餐	
-Daily Routine 1	睡		shuì	shuì	to sleep / to lie down	to sleep / to lie down	
-Daily Routine 1	觉	覺	jiào   jué	jiào   jué	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	
-Daily Routine 1	放学	放學	fàng xué	fàng xué	to dismiss students at the end of the school day	to dismiss students at the end of the school day	
-Daily Routine 1	下班		xià bān	xià bān	to finish work / to get off work	to finish work / to get off work	
-Daily Routine 1	回		huí   huí	huí   huí	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	
-Daily Routine 1	晚饭	晚飯	wǎn fàn	wǎn fàn	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	
-Daily Routine 1	放		fàng	fàng	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	
-Payment	钱	錢	Qián   qián	Qián   qián	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两	
-Payment	块	塊	kuài	kuài	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	
-Payment	只		zhǐ   zhǐ   zhī	zhǐ   zhǐ   zhī	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	
-Payment	买	買	mǎi	mǎi	to buy / to purchase	to buy / to purchase	
-Payment	一共		yī gòng	yī gòng	altogether	altogether	
-Payment	毛		Máo   máo	Máo   máo	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	
-Payment	分		fēn   fèn	fēn   fèn	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	
-Payment	共		gòng	gòng	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party	
-Payment	信用卡		xìn yòng kǎ	xìn yòng kǎ	credit card	credit card	
-Payment	收		shōu	shōu	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)	
-Payment	千		qiān   qiān	qiān   qiān	thousand  see 鞦韆｜秋千	thousand  see 鞦韆｜秋千	
-Payment	信		xìn	xìn	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	
-Payment	用		yòng	yòng	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	
-Payment	卡		kǎ   qiǎ	kǎ   qiǎ	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]	
-Payment	贵	貴	guì	guì	expensive / noble / precious / (honorific) your	expensive / noble / precious / (honorific) your	
-Payment	便宜		biàn yí   pián yi	biàn yí   pián yi	convenient  cheap / inexpensive / small advantages / to let sb off lightly	convenient  cheap / inexpensive / small advantages / to let sb off lightly	
-Payment	现金	現金	xiàn jīn	xiàn jīn	cash	cash	
-Payment	便		biàn   pián	biàn   pián	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	
-Payment	宜		Yí   yí	Yí   yí	surname Yi  proper / should / suitable / appropriate	surname Yi  proper / should / suitable / appropriate	
-Payment	金		Jīn   jīn	Jīn   jīn	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音	
-Payment	太		tài	tài	highest / greatest / too (much) / very / extremely	highest / greatest / too (much) / very / extremely	
-Payment	万		Mò   Wàn   wàn	Mò   Wàn   wàn	see 万俟  surname Wan  ten thousand / a great number	see 万俟  surname Wan  ten thousand / a great number	
-Payment	行		háng   xíng	háng   xíng	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	
-Payment	了		le   liǎo   liǎo	le   liǎo   liǎo	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	
-Entertainment	想		xiǎng	xiǎng	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	
-Entertainment	干	乾	Gān   gān   gān   gàn	Gān   gān   gān   gàn	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	
-Entertainment	影		yǐng	yǐng	picture / image / film / movie / photograph / reflection / shadow / trace	picture / image / film / movie / photograph / reflection / shadow / trace	
-Entertainment	视	視	shì	shì	to look at / to regard / to inspect	to look at / to regard / to inspect	
-Entertainment	电视	電視	diàn shì	diàn shì	television / TV / CL: 臺｜台, 個｜个	television / TV / CL: 臺｜台, 個｜个	
-Entertainment	电影	電影	diàn yǐng	diàn yǐng	movie / film / CL: 部, 片, 幕, 場｜场	movie / film / CL: 部, 片, 幕, 場｜场	
-Entertainment	报纸	報紙	bào zhǐ	bào zhǐ	newspaper / newsprint / CL: 份, 期, 張｜张	newspaper / newsprint / CL: 份, 期, 張｜张	
-Entertainment	上网	上網	shàng wǎng	shàng wǎng	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	
-Entertainment	报	報	bào	bào	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张	
-Entertainment	纸	紙	zhǐ	zhǐ	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	
-Entertainment	网	網	wǎng	wǎng	net / network	net / network	
-Entertainment	手机	手機	shǒu jī	shǒu jī	cell phone / mobile phone / CL: 部, 支	cell phone / mobile phone / CL: 部, 支	
-Entertainment	用		yòng	yòng	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	
-Entertainment	新闻	新聞	xīn wén	xīn wén	news / CL: 條｜条, 個｜个	news / CL: 條｜条, 個｜个	
-Entertainment	机	機	Jī   jī	Jī   jī	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台	
-Entertainment	新		Xīn   xīn	Xīn   xīn	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	
-Entertainment	闻	聞	Wén   wén	Wén   wén	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at	
-Entertainment	明星		míng xīng	míng xīng	star / celebrity	star / celebrity	
-Entertainment	体育	體育	tǐ yù	tǐ yù	sports / physical education	sports / physical education	
-Entertainment	节目	節目	jié mù	jié mù	program / item (on a program) / CL: 臺｜台, 個｜个, 套	program / item (on a program) / CL: 臺｜台, 個｜个, 套	
-Entertainment	韩国	韓國	Hán guó	Hán guó	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	
-Entertainment	体	體	tǐ	tǐ	body / form / style / system / substance / to experience / aspect (linguistics)	body / form / style / system / substance / to experience / aspect (linguistics)	
-Entertainment	节	節	jiē   jié	jiē   jié	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个	
-Entertainment	韩	韓	Hán	Hán	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han	
-Entertainment	育		yù	yù	to have children / to raise or bring up / to educate	to have children / to raise or bring up / to educate	
-Entertainment	目		mù	mù	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title	
-Location 4	桌		zhuō	zhuō	table / desk / classifier for tables of guests at a banquet etc	table / desk / classifier for tables of guests at a banquet etc	
-Location 4	找		zhǎo	zhǎo	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	
-Location 4	桌子		zhuō zi	zhuō zi	table / desk / CL: 張｜张, 套	table / desk / CL: 張｜张, 套	
-Location 4	上		shǎng   shàng	shǎng   shàng	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	
-Location 4	椅子		yǐ zi	yǐ zi	chair / CL: 把, 套	chair / CL: 把, 套	
-Location 4	下		xià	xià	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	
-Location 4	见	見	jiàn   xiàn	jiàn   xiàn	to see / to meet / to appear (to be sth) / to interview  to appear / also written 現｜现	to see / to meet / to appear (to be sth) / to interview  to appear / also written 現｜现	
-Location 4	椅		yǐ	yǐ	chair	chair	
-Location 4	房间	房間	fáng jiān	fáng jiān	room / CL: 間｜间, 個｜个	room / CL: 間｜间, 個｜个	
-Location 4	冰箱		bīng xiāng	bīng xiāng	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	
-Location 4	里	裡	lǐ   Lǐ   lǐ	lǐ   Lǐ   lǐ	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	
-Location 4	外		wài	wài	outside / in addition / foreign / external	outside / in addition / foreign / external	
-Location 4	房		Fáng   fáng	Fáng   fáng	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)	
-Location 4	间	間	jiān   jiàn	jiān   jiàn	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	
-Location 4	箱		xiāng	xiāng	box / trunk / chest	box / trunk / chest	
-Restaurant	位		wèi	wèi	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential	
-Restaurant	等		děng	děng	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	
-Restaurant	一下		yī xià	yī xià	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	
-Restaurant	进	進	jìn	jìn	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	
-Restaurant	坐		Zuò   zuò	Zuò   zuò	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	
-Restaurant	菜单	菜單	cài dān	cài dān	menu / CL: 份, 張｜张	menu / CL: 份, 張｜张	
-Restaurant	英文		Yīng wén	Yīng wén	English (language)	English (language)	
-Restaurant	菜		cài	cài	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	
-Restaurant	单	單	Shàn   dān	Shàn   dān	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	
-Restaurant	英		Yīng   yīng	Yīng   yīng	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	
-Restaurant	文		Wén   wén	Wén   wén	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	
-Restaurant	服务员	服務員	fú wù yuán	fú wù yuán	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	
-Restaurant	点菜	點菜	diǎn cài	diǎn cài	to order dishes (in a restaurant)	to order dishes (in a restaurant)	
-Restaurant	买单	買單	mǎi dān	mǎi dān	to pay the restaurant bill	to pay the restaurant bill	
-Restaurant	订位	訂位	dìng wèi	dìng wèi	to reserve a seat / to book a table / reservation	to reserve a seat / to book a table / reservation	
-Restaurant	服		fú   fù	fú   fù	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]	
-Restaurant	务	務	wù	wù	affair / business / matter / to be engaged in / to attend to / by all means	affair / business / matter / to be engaged in / to attend to / by all means	
-Restaurant	员	員	yuán	yuán	person / employee / member	person / employee / member	
-Restaurant	订	訂	dìng	dìng	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	
-Supermarket	些		xiē	xiē	some / few / several / measure word indicating a small amount or small number (greater than 1)	some / few / several / measure word indicating a small amount or small number (greater than 1)	
-Supermarket	西		Xī   xī	Xī   xī	the West / abbr. for Spain 西班牙 / Spanish  west	the West / abbr. for Spain 西班牙 / Spanish  west	
-Supermarket	东	東	Dōng   dōng	Dōng   dōng	surname Dong  east / host (i.e. sitting on east side of guest) / landlord	surname Dong  east / host (i.e. sitting on east side of guest) / landlord	
-Supermarket	东西	東西	dōng xī   dōng xi	dōng xī   dōng xi	east and west  thing / stuff / person / CL: 個｜个, 件	east and west  thing / stuff / person / CL: 個｜个, 件	
-Supermarket	帮	幫	bāng	bāng	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	
-Supermarket	超市		chāo shì	chāo shì	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	
-Supermarket	水果		shuǐ guǒ	shuǐ guǒ	fruit / CL: 個｜个	fruit / CL: 個｜个	
-Supermarket	超		chāo	chāo	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-	
-Supermarket	市		shì	shì	market / city / CL: 個｜个	market / city / CL: 個｜个	
-Supermarket	果		guǒ	guǒ	fruit / result / resolute / indeed / if really	fruit / result / resolute / indeed / if really	
-Supermarket	给	給	gěi   jǐ	gěi   jǐ	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	
-Supermarket	苹果	蘋果	píng guǒ	píng guǒ	apple / CL: 個｜个, 顆｜颗	apple / CL: 個｜个, 顆｜颗	
-Supermarket	西瓜		xī guā	xī guā	watermelon / CL: 顆｜颗, 粒, 個｜个	watermelon / CL: 顆｜颗, 粒, 個｜个	
-Supermarket	苹		píng   pín   píng	píng   pín   píng	(artemisia) / duckweed  marsiliaceae / clover fern  apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple	
-Supermarket	瓜		guā	guā	melon / gourd / squash	melon / gourd / squash	
-Supermarket	鸡蛋	雞蛋	jī dàn	jī dàn	(chicken) egg / hen's egg / CL: 個｜个, 打	(chicken) egg / hen's egg / CL: 個｜个, 打	
-Supermarket	新鲜	新鮮	xīn xiān	xīn xiān	fresh (experience, food etc) / freshness / novel / uncommon	fresh (experience, food etc) / freshness / novel / uncommon	
-Supermarket	鸡	雞	jī	jī	fowl / chicken / CL: 隻｜只 / (slang) prostitute	fowl / chicken / CL: 隻｜只 / (slang) prostitute	
-Supermarket	蛋		dàn	dàn	egg / CL: 個｜个, 打 / oval-shaped thing	egg / CL: 個｜个, 打 / oval-shaped thing	
-Supermarket	鲜	鮮	xiān   xiǎn   xiān	xiān   xiǎn   xiān	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜	
-Supermarket	蔬菜		shū cài	shū cài	vegetables / produce / CL: 種｜种	vegetables / produce / CL: 種｜种	
-Supermarket	蔬		shū	shū	vegetables	vegetables	
-Supermarket	包		Bāo   bāo	Bāo   bāo	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只	
-Supermarket	米		Mǐ   mǐ	Mǐ   mǐ	surname Mi  rice / CL: 粒 / meter (classifier)	surname Mi  rice / CL: 粒 / meter (classifier)	
-Supermarket	面包	麵包	miàn bāo	miàn bāo	bread / CL: 片, 袋, 塊｜块	bread / CL: 片, 袋, 塊｜块	
-Supermarket	袋		dài	dài	pouch / bag / sack / pocket	pouch / bag / sack / pocket	
-Supermarket	糖		táng	táng	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	
-Hobbies 2	为	為	wéi   wèi	wéi   wèi	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	
-Hobbies 2	文		Wén   wén	Wén   wén	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	
-Hobbies 2	习	習	Xí   xí	Xí   xí	surname Xi  to practice / to study / habit	surname Xi  to practice / to study / habit	
-Hobbies 2	学习	學習	xué xí	xué xí	to learn / to study	to learn / to study	
-Hobbies 2	中文		Zhōng wén	Zhōng wén	Chinese language	Chinese language	
-Hobbies 2	为什么	為什麼	wèi shén me	wèi shén me	why? / for what reason?	why? / for what reason?	
-Hobbies 2	去		qù	qù	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	
-Hobbies 2	因为	因為	yīn wèi	yīn wèi	because / owing to / on account of	because / owing to / on account of	
-Hobbies 2	所以		suǒ yǐ	suǒ yǐ	therefore / as a result / so / the reason why	therefore / as a result / so / the reason why	
-Hobbies 2	西班牙		Xī bān yá	Xī bān yá	Spain	Spain	
-Hobbies 2	因		yīn	yīn	cause / reason / because	cause / reason / because	
-Hobbies 2	所		suǒ	suǒ	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个	
-Hobbies 2	以		Yǐ   yǐ	Yǐ   yǐ	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)	
-Hobbies 2	西		Xī   xī	Xī   xī	the West / abbr. for Spain 西班牙 / Spanish  west	the West / abbr. for Spain 西班牙 / Spanish  west	
-Hobbies 2	班		Bān   bān	Bān   bān	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	
-Hobbies 2	牙		yá	yá	tooth / ivory / CL: 顆｜颗	tooth / ivory / CL: 顆｜颗	
-Hobbies 2	旅游	旅遊	lǚ yóu	lǚ yóu	trip / journey / tourism / travel / tour / to travel	trip / journey / tourism / travel / tour / to travel	
-Hobbies 2	爱好	愛好	ài hào	ài hào	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	
-Hobbies 2	新		Xīn   xīn	Xīn   xīn	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	
-Hobbies 2	西班牙语	西班牙語	Xī bān yá yǔ	Xī bān yá yǔ	Spanish language	Spanish language	
-Hobbies 2	轻松	輕鬆	qīng sōng	qīng sōng	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	
-Hobbies 2	旅		lǚ	lǚ	trip / travel / to travel / brigade (army)	trip / travel / to travel / brigade (army)	
-Hobbies 2	好		hǎo   hào	hǎo   hào	good / well / proper / good to / easy to / very / so / (suffix indicating completion or readiness) / (of two people) close / on intimate terms  to be fond of / to have a tendency to / to be prone to	good / well / proper / good to / easy to / very / so / (suffix indicating completion or readiness) / (of two people) close / on intimate terms  to be fond of / to have a tendency to / to be prone to	
-Hobbies 2	轻	輕	qīng	qīng	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	
-Hobbies 2	松		Sōng   sōng   sōng	Sōng   sōng   sōng	surname Song  pine / CL: 棵  loose / to loosen / to relax	surname Song  pine / CL: 棵  loose / to loosen / to relax	
-Hobbies 2	照相机	照相機	zhào xiàng jī	zhào xiàng jī	camera / CL: 個｜个, 架, 部, 台, 隻｜只	camera / CL: 個｜个, 架, 部, 台, 隻｜只	
-Hobbies 2	印度		Yìn dù	Yìn dù	India	India	
-Hobbies 2	拍照		pāi zhào	pāi zhào	to take a picture	to take a picture	
-Hobbies 2	拍		pāi	pāi	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)	
-Hobbies 2	照		zhào	zhào	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	
-Hobbies 2	印		Yìn   yìn	Yìn   yìn	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image	
-Hobbies 2	相		Xiāng   xiāng   xiàng	Xiāng   xiāng   xiàng	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	
-Hobbies 2	度		dù   duó	dù   duó	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	
-Dining 1	海		Hǎi   hǎi	Hǎi   hǎi	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous	
-Dining 1	本		běn	běn	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	
-Dining 1	还	還	Huán   hái   huán	Huán   hái   huán	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	
-Dining 1	上海		Shàng hǎi	Shàng hǎi	Shanghai municipality, central east China, abbr. to 滬｜沪	Shanghai municipality, central east China, abbr. to 滬｜沪	
-Dining 1	菜		cài	cài	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	
-Dining 1	还是	還是	hái shi	hái shi	or / still / nevertheless / had better	or / still / nevertheless / had better	
-Dining 1	日本		Rì běn	Rì běn	Japan / Japanese	Japan / Japanese	
-Dining 1	肉		ròu	ròu	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute	
-Dining 1	米饭	米飯	mǐ fàn	mǐ fàn	(cooked) rice	(cooked) rice	
-Dining 1	面条	麵條	miàn tiáo	miàn tiáo	noodles	noodles	
-Dining 1	鸡肉	雞肉	jī ròu	jī ròu	chicken meat	chicken meat	
-Dining 1	牛肉		niú ròu	niú ròu	beef	beef	
-Dining 1	猪肉	豬肉	zhū ròu	zhū ròu	pork	pork	
-Dining 1	羊肉		yáng ròu	yáng ròu	mutton / goat meat	mutton / goat meat	
-Dining 1	饮料	飲料	yǐn liào	yǐn liào	drink / beverage	drink / beverage	
-Dining 1	猪	豬	zhū	zhū	hog / pig / swine / CL: 口, 頭｜头	hog / pig / swine / CL: 口, 頭｜头	
-Dining 1	羊		Yáng   yáng	Yáng   yáng	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只	
-Dining 1	饮	飲	yǐn   yìn	yǐn   yìn	to drink  to give (animals) water to drink	to drink  to give (animals) water to drink	
-Dining 1	料		liào	liào	material / stuff / grain / feed / to expect / to anticipate / to guess	material / stuff / grain / feed / to expect / to anticipate / to guess	
-Health 1	作		zuō   zuò	zuō   zuò	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works	
-Health 1	得		dé   de   děi	dé   de   děi	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	
-Health 1	觉	覺	jiào   jué	jiào   jué	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	
-Health 1	工		gōng	gōng	work / worker / skill / profession / trade / craft / labor	work / worker / skill / profession / trade / craft / labor	
-Health 1	累		lěi   lèi   Léi   léi	lěi   lèi   Léi   léi	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	
-Health 1	工作		gōng zuò	gōng zuò	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	
-Health 1	觉得	覺得	jué de	jué de	to think / to feel	to think / to feel	
-Health 1	有点儿	有點兒	yǒu diǎnr	yǒu diǎnr	slightly / a little / somewhat	slightly / a little / somewhat	
-Health 1	胖		pán   pàng	pán   pàng	healthy / at ease  fat / plump	healthy / at ease  fat / plump	
-Health 1	健康		jiàn kāng	jiàn kāng	health / healthy	health / healthy	
-Health 1	不要		bù yào	bù yào	don't! / must not	don't! / must not	
-Health 1	健		jiàn	jiàn	healthy / to invigorate / to strengthen / to be good at / to be strong in	healthy / to invigorate / to strengthen / to be good at / to be strong in	
-Health 1	康		Kāng   kāng	Kāng   kāng	surname Kang  healthy / peaceful / abundant	surname Kang  healthy / peaceful / abundant	
-Health 1	身体	身體	shēn tǐ	shēn tǐ	the body / one's health / CL: 具, 個｜个 / in person	the body / one's health / CL: 具, 個｜个 / in person	
-Health 1	注意		zhù yì	zhù yì	to take note of / to pay attention to	to take note of / to pay attention to	
-Health 1	身		shēn	shēn	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158	
-Health 1	注		zhù   zhù	zhù   zhù	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment	
-Health 1	意		Yì   yì	Yì   yì	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate	
-Health 1	开始	開始	kāi shǐ	kāi shǐ	to begin / beginning / to start / initial / CL: 個｜个	to begin / beginning / to start / initial / CL: 個｜个	
-Health 1	锻炼	鍛鍊	duàn liàn	duàn liàn	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	
-Health 1	开	開	kāi	kāi	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	
-Health 1	锻	鍛	duàn	duàn	to forge / to discipline / wrought	to forge / to discipline / wrought	
-Health 1	始		shǐ	shǐ	to begin / to start / then / only then	to begin / to start / then / only then	
-Health 1	炼	煉	liàn	liàn	to refine / to smelt	to refine / to smelt	
-Transportation	铁	鐵	Tiě   tiě	Tiě   tiě	surname Tie  iron (metal) / arms / weapons / hard / strong / violent / unshakeable / determined / close / tight (slang)	surname Tie  iron (metal) / arms / weapons / hard / strong / violent / unshakeable / determined / close / tight (slang)	
-Transportation	店		diàn	diàn	inn / shop / store / CL: 家	inn / shop / store / CL: 家	
-Transportation	地		de   dì	de   dì	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	
-Transportation	酒		jiǔ	jiǔ	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	
-Transportation	酒店		jiǔ diàn	jiǔ diàn	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	
-Transportation	地铁	地鐵	dì tiě	dì tiě	subway / metro	subway / metro	
-Transportation	坐		Zuò   zuò	Zuò   zuò	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	
-Transportation	不准		bù zhǔn	bù zhǔn	not to allow / to forbid / to prohibit	not to allow / to forbid / to prohibit	
-Transportation	准		zhǔn   zhǔn	zhǔn   zhǔn	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	
-Transportation	出租车	出租車	chū zū chē	chū zū chē	taxi / (Taiwan) rental car	taxi / (Taiwan) rental car	
-Transportation	站		zhàn	zhàn	station / to stand / to halt / to stop / branch of a company or organization / website	station / to stand / to halt / to stop / branch of a company or organization / website	
-Transportation	下		xià	xià	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	
-Transportation	车	車	Chē   chē   jū	Chē   chē   jū	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)	
-Transportation	出		chū	chū	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	
-Transportation	租		zū	zū	to hire / to rent / to charter / to rent out / to lease out / rent / land tax	to hire / to rent / to charter / to rent out / to lease out / rent / land tax	
-Transportation	可以		kě yǐ	kě yǐ	can / may / possible / able to / not bad / pretty good	can / may / possible / able to / not bad / pretty good	
-Transportation	汽车	汽車	qì chē	qì chē	car / automobile / bus / CL: 輛｜辆	car / automobile / bus / CL: 輛｜辆	
-Transportation	公共		gōng gòng	gōng gòng	public / common / communal	public / common / communal	
-Transportation	船		chuán	chuán	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	
-Transportation	公		gōng	gōng	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)	
-Transportation	汽		qì	qì	steam / vapor	steam / vapor	
-Shopping 1	件		jiàn	jiàn	item / component / classifier for events, things, clothes etc	item / component / classifier for events, things, clothes etc	
-Shopping 1	衣		yī   yì	yī   yì	clothes / CL: 件  to dress / to wear / to put on (clothes)	clothes / CL: 件  to dress / to wear / to put on (clothes)	
-Shopping 1	商		Shāng   shāng	Shāng   shāng	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)	
-Shopping 1	商店		shāng diàn	shāng diàn	store / shop / CL: 家, 個｜个	store / shop / CL: 家, 個｜个	
-Shopping 1	衣服		yī fu	yī fu	clothes / CL: 件, 套	clothes / CL: 件, 套	
-Shopping 1	开	開	kāi	kāi	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	
-Shopping 1	关	關	Guān   guān	Guān   guān	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	
-Shopping 1	门	門	Mén   mén	Mén   mén	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	
-Shopping 1	欢迎	歡迎	huān yíng	huān yíng	to welcome / welcome	to welcome / welcome	
-Shopping 1	迎		yíng	yíng	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)	
-Shopping 1	您		nín	nín	you (courteous, as opposed to informal 你)	you (courteous, as opposed to informal 你)	
-Shopping 1	帮忙	幫忙	bāng máng	bāng máng	to help / to lend a hand / to do a favor / to do a good turn	to help / to lend a hand / to do a favor / to do a good turn	
-Shopping 1	需要		xū yào	xū yào	to need / to want / to demand / to require / requirement / need	to need / to want / to demand / to require / requirement / need	
-Shopping 1	需		xū	xū	to require / to need / to want / necessity / need	to require / to need / to want / necessity / need	
-Shopping 1	随便	隨便	suí biàn	suí biàn	as one wishes / as one pleases / at random / negligent / casual / wanton	as one wishes / as one pleases / at random / negligent / casual / wanton	
-Shopping 1	随	隨	Suí   suí	Suí   suí	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently	
-Shopping 1	便		biàn   pián	biàn   pián	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	
-Languages	字		zì	zì	letter / symbol / character / word / CL: 個｜个 / courtesy or style name traditionally given to males aged 20 in dynastic China	letter / symbol / character / word / CL: 個｜个 / courtesy or style name traditionally given to males aged 20 in dynastic China	
-Languages	读	讀	dòu   dú	dòu   dú	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	
-Languages	一点儿		yī diǎnr	yī diǎnr	erhua variant of 一點｜一点	erhua variant of 一點｜一点	
-Languages	意思		yì si	yì si	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc	
-Languages	写	寫	xiě	xiě	to write	to write	
-Languages	错	錯	Cuò   cuò	Cuò   cuò	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	
-Languages	难	難	nán   nàn	nán   nàn	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold	
-Languages	思		sī	sī	to think / to consider	to think / to consider	
-Time 3	秒		miǎo	miǎo	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	
-Time 3	刻		kè	kè	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	
-Time 3	差		chā   chà   chāi	chā   chà   chāi	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	
-Time 3	小时	小時	xiǎo shí	xiǎo shí	hour / CL: 個｜个	hour / CL: 個｜个	
-Time 3	分钟	分鐘	fēn zhōng	fēn zhōng	minute	minute	
-Time 3	小		xiǎo	xiǎo	small / tiny / few / young	small / tiny / few / young	
-Time 3	时	時	Shí   shí	Shí   shí	surname Shi  o'clock / time / when / hour / season / period	surname Shi  o'clock / time / when / hour / season / period	
-Time 3	钟	鍾	Zhōng   zhōng   zhōng	Zhōng   zhōng   zhōng	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座	
-Time 3	整		zhěng	zhěng	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	
-Time 3	早		zǎo	zǎo	early / morning / Good morning! / long ago / prematurely	early / morning / Good morning! / long ago / prematurely	
-Time 3	晚		wǎn	wǎn	evening / night / late	evening / night / late	
-Dining 2	杯		bēi	bēi	cup / trophy cup / classifier for certain containers of liquids: glass, cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup	
-Dining 2	啤		pí	pí	beer	beer	
-Dining 2	德		Dé   dé	Dé   dé	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind	
-Dining 2	德国	德國	Dé guó	Dé guó	Germany / German	Germany / German	
-Dining 2	啤酒		pí jiǔ	pí jiǔ	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	
-Dining 2	果汁		guǒ zhī	guǒ zhī	fruit juice	fruit juice	
-Dining 2	汁		zhī	zhī	juice	juice	
-Dining 2	香蕉		xiāng jiāo	xiāng jiāo	banana / CL: 枝, 根, 個｜个, 把	banana / CL: 枝, 根, 個｜个, 把	
-Dining 2	蛋糕		dàn gāo	dàn gāo	cake / CL: 塊｜块, 個｜个	cake / CL: 塊｜块, 個｜个	
-Dining 2	块	塊	kuài	kuài	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	
-Dining 2	香		xiāng	xiāng	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	
-Dining 2	蕉		jiāo   qiáo	jiāo   qiáo	banana  see 蕉萃	banana  see 蕉萃	
-Dining 2	糕		gāo	gāo	cake	cake	
-Dining 2	碗		wǎn	wǎn	bowl / cup / CL: 隻｜只, 個｜个	bowl / cup / CL: 隻｜只, 個｜个	
-Dining 2	杯子		bēi zi	bēi zi	cup / glass / CL: 個｜个, 隻｜只	cup / glass / CL: 個｜个, 隻｜只	
-Dining 2	盘子	盤子	pán zi	pán zi	tray / plate / dish / CL: 個｜个	tray / plate / dish / CL: 個｜个	
-Dining 2	盘	盤	pán	pán	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess	
-Dining 2	筷子		kuài zi	kuài zi	chopsticks / CL: 對｜对, 根, 把, 雙｜双	chopsticks / CL: 對｜对, 根, 把, 雙｜双	
-Dining 2	刀		Dāo   dāo	Dāo   dāo	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	
-Dining 2	叉		chā   chá   chǎ	chā   chá   chǎ	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	
-Dining 2	筷		kuài	kuài	chopstick	chopstick	
-Dining 2	勺子		sháo zi	sháo zi	scoop / ladle / CL: 把	scoop / ladle / CL: 把	
-Dining 2	勺		sháo	sháo	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)	
-Existence	室		Shì   shì	Shì   shì	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	
-Existence	办	辦	bàn	bàn	to do / to manage / to handle / to go about / to run / to set up / to deal with	to do / to manage / to handle / to go about / to run / to set up / to deal with	
-Existence	辆	輛	liàng	liàng	classifier for vehicles	classifier for vehicles	
-Existence	办公室	辦公室	bàn gōng shì	bàn gōng shì	office / business premises / bureau / CL: 間｜间	office / business premises / bureau / CL: 間｜间	
-Existence	本		běn	běn	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	
-Existence	瓶子		píng zi	píng zi	bottle / CL: 個｜个	bottle / CL: 個｜个	
-Existence	张	張	Zhāng   zhāng	Zhāng   zhāng	surname Zhang  to open up / to spread / sheet of paper / classifier for flat objects, sheet / classifier for votes	surname Zhang  to open up / to spread / sheet of paper / classifier for flat objects, sheet / classifier for votes	
-Existence	照片		zhào piàn	zhào piàn	photograph / picture / CL: 張｜张, 套, 幅	photograph / picture / CL: 張｜张, 套, 幅	
-Existence	瓶		píng	píng	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	
-Existence	片		piān   piàn	piān   piàn	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc	
-Existence	只		zhǐ   zhǐ   zhī	zhǐ   zhǐ   zhī	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	
-Existence	鸟	鳥	niǎo	niǎo	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam	
-Existence	树	樹	shù	shù	tree / CL: 棵 / to cultivate / to set up	tree / CL: 棵 / to cultivate / to set up	
-Sports 1	步		Bù   bù	Bù   bù	surname Bu  a step / a pace / walk / march / stages in a process / situation	surname Bu  a step / a pace / walk / march / stages in a process / situation	
-Sports 1	跑		páo   pǎo	páo   pǎo	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off	
-Sports 1	泳		yǒng	yǒng	swimming / to swim	swimming / to swim	
-Sports 1	游		Yóu   yóu   yóu	Yóu   yóu   yóu	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	
-Sports 1	游泳		yóu yǒng	yóu yǒng	swimming / to swim	swimming / to swim	
-Sports 1	跑步		pǎo bù	pǎo bù	to run / to jog / (military) to march at the double	to run / to jog / (military) to march at the double	
-Sports 1	踢		tī	tī	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	
-Sports 1	足球		zú qiú	zú qiú	soccer ball / a football / CL: 個｜个 / soccer / football	soccer ball / a football / CL: 個｜个 / soccer / football	
-Sports 1	打		dá   dǎ	dá   dǎ	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from	
-Sports 1	篮球	籃球	lán qiú	lán qiú	basketball / CL: 個｜个, 隻｜只	basketball / CL: 個｜个, 隻｜只	
-Sports 1	足		jù   zú	jù   zú	excessive  foot / to be sufficient / ample	excessive  foot / to be sufficient / ample	
-Sports 1	篮	籃	lán	lán	basket (receptacle) / basket (in basketball)	basket (receptacle) / basket (in basketball)	
-Sports 1	球		qiú	qiú	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场	
-Sports 1	运动	運動	yùn dòng	yùn dòng	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	
-Sports 1	马	馬	Mǎ   mǎ	Mǎ   mǎ	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess	
-Sports 1	骑	騎	jì   qí	jì   qí	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	
-Sports 1	运	運	yùn	yùn	to move / to transport / to use / to apply / fortune / luck / fate	to move / to transport / to use / to apply / fortune / luck / fate	
-Sports 1	动	動	dòng	dòng	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb	
-Invitiation 1	吧		bā   ba	bā   ba	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	
-Invitiation 1	出去		chū qù	chū qù	to go out	to go out	
-Invitiation 1	时间	時間	shí jiān	shí jiān	time / period / CL: 段	time / period / CL: 段	
-Invitiation 1	时候	時候	shí hou	shí hou	time / length of time / moment / period	time / length of time / moment / period	
-Invitiation 1	空		kōng   kòng	kōng   kòng	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	
-Invitiation 1	请	請	qǐng	qǐng	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	
-Invitiation 1	来	來	lái	lái	to come / to arrive / to come round / ever since / next	to come / to arrive / to come round / ever since / next	
-Invitiation 1	候		hòu	hòu	to wait / to inquire after / to watch / season / climate / (old) period of five days	to wait / to inquire after / to watch / season / climate / (old) period of five days	
-Invitiation 1	过	過	Guò   guò   guo	Guò   guò   guo	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	
-Invitiation 1	一起		yī qǐ	yī qǐ	in the same place / together / with / altogether (in total)	in the same place / together / with / altogether (in total)	
-Invitiation 1	家	傢	jiā   Jiā   jiā	jiā   Jiā   jiā	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	
-Invitiation 1	不好意思		bù hǎo yì si	bù hǎo yì si	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	
-Invitiation 1	给	給	gěi   jǐ	gěi   jǐ	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	
-Invitiation 1	告诉	告訴	gào sù   gào su	gào sù   gào su	to press charges / to file a complaint  to tell / to inform / to let know	to press charges / to file a complaint  to tell / to inform / to let know	
-Invitiation 1	告		gào	gào	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue	
-Invitiation 1	诉	訴	sù	sù	to complain / to sue / to tell	to complain / to sue / to tell	
-Invitiation 1	约会	約會	yuē huì	yuē huì	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	
-Invitiation 1	浪漫		làng màn	làng màn	romantic	romantic	
-Invitiation 1	浪		làng	làng	wave / breaker / unrestrained / dissipated	wave / breaker / unrestrained / dissipated	
-Invitiation 1	漫		màn	màn	free / unrestrained / to inundate	free / unrestrained / to inundate	
-Health 2	该	該	gāi	gāi	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned	
-Health 2	病		bìng	bìng	illness / CL: 場｜场 / disease / to fall ill / defect	illness / CL: 場｜场 / disease / to fall ill / defect	
-Health 2	舒		Shū   shū	Shū   shū	surname Shu  to stretch / to unfold / to relax / leisurely	surname Shu  to stretch / to unfold / to relax / leisurely	
-Health 2	应	應	Yìng   yīng   yìng	Yìng   yīng   yìng	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	
-Health 2	生病		shēng bìng	shēng bìng	to fall ill	to fall ill	
-Health 2	应该	應該	yīng gāi	yīng gāi	ought to / should / must	ought to / should / must	
-Health 2	舒服		shū fu	shū fu	comfortable / feeling well	comfortable / feeling well	
-Health 2	了		le   liǎo   liǎo	le   liǎo   liǎo	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	
-Health 2	疼		téng	téng	(it) hurts / sore / to love dearly	(it) hurts / sore / to love dearly	
-Health 2	头	頭	tóu   tou	tóu   tou	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns	
-Health 2	休息		xiū xi	xiū xi	rest / to rest	rest / to rest	
-Health 2	休		Xiū   xiū	Xiū   xiū	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't	
-Health 2	息		xī	xī	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]	
-Health 2	肚子		dù zi	dù zi	belly / abdomen / stomach / CL: 個｜个	belly / abdomen / stomach / CL: 個｜个	
-Health 2	肚		dǔ   dù	dǔ   dù	tripe  belly	tripe  belly	
-Health 2	药	葯	yào   yào	yào   yào	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	
-Health 2	一定		yī dìng	yī dìng	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	
-Health 2	感冒		gǎn mào	gǎn mào	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	
-Health 2	感		gǎn	gǎn	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~	
-Health 2	定		dìng	dìng	to set / to fix / to determine / to decide / to order	to set / to fix / to determine / to decide / to order	
-Health 2	冒		Mào   mào	Mào   mào	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover	
-Health 2	留		liú	liú	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve	
-Health 2	请假	請假	qǐng jià	qǐng jià	to request leave of absence	to request leave of absence	
-Health 2	发烧	發燒	fā shāo	fā shāo	to have a high temperature (from illness) / to have a fever	to have a high temperature (from illness) / to have a fever	
-Health 2	别	別	Bié   bié   biè	Bié   bié   biè	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc	
-Health 2	发	發	fā   fà	fā   fà	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	
-Health 2	假		jiǎ   jià	jiǎ   jià	fake / false / artificial / to borrow / if / suppose  vacation	fake / false / artificial / to borrow / if / suppose  vacation	
-Health 2	烧	燒	shāo	shāo	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head	
-Invitation 2	派		pài	pài	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie	
-Invitation 2	能		Néng   néng	Néng   néng	surname Neng  can / to be able to / might possibly / ability / (physics) energy	surname Neng  can / to be able to / might possibly / ability / (physics) energy	
-Invitation 2	生日		shēng rì	shēng rì	birthday / CL: 個｜个	birthday / CL: 個｜个	
-Invitation 2	派对	派對	pài duì	pài duì	party (loanword)	party (loanword)	
-Invitation 2	打扮		dǎ ban	dǎ ban	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	
-Invitation 2	扮		bàn	bàn	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)	
-Invitation 2	希望		xī wàng	xī wàng	to wish for / to desire / hope / CL: 個｜个	to wish for / to desire / hope / CL: 個｜个	
-Invitation 2	跟		gēn	gēn	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	
-Invitation 2	希		xī	xī	to hope / to admire / variant of 稀	to hope / to admire / variant of 稀	
-Invitation 2	望		wàng   wàng	wàng   wàng	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望	
-Invitation 2	大家		dà jiā	dà jiā	everyone / influential family / great expert	everyone / influential family / great expert	
-Invitation 2	公司		gōng sī	gōng sī	(business) company / company / firm / corporation / incorporated / CL: 家	(business) company / company / firm / corporation / incorporated / CL: 家	
-Invitation 2	正在		zhèng zài	zhèng zài	just at (that time) / right in (that place) / right in the middle of (doing sth)	just at (that time) / right in (that place) / right in the middle of (doing sth)	
-Invitation 2	正		zhēng   zhèng	zhēng   zhèng	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive	
-Invitation 2	司		Sī   sī	Sī   sī	surname Si  to take charge of / to manage / department (under a ministry)	surname Si  to take charge of / to manage / department (under a ministry)	
-Invitation 2	事情		shì qing	shì qing	affair / matter / thing / business / CL: 件, 樁｜桩	affair / matter / thing / business / CL: 件, 樁｜桩	
-Invitation 2	才		cái   cái	cái   cái	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only	
-Invitation 2	多		duō	duō	many / much / often / a lot of / numerous / more / in excess / how (to what extent) / multi- / Taiwan pr. [duo2] when it means 'how'	many / much / often / a lot of / numerous / more / in excess / how (to what extent) / multi- / Taiwan pr. [duo2] when it means 'how'	
-Invitation 2	事		shì	shì	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	
-Invitation 2	情		qíng	qíng	feeling / emotion / passion / situation	feeling / emotion / passion / situation	
-Dining 3	费	費	Fèi   fèi	Fèi   fèi	surname Fei  to cost / to spend / fee / wasteful / expenses	surname Fei  to cost / to spend / fee / wasteful / expenses	
-Dining 3	完		wán	wán	to finish / to be over / whole / complete / entire	to finish / to be over / whole / complete / entire	
-Dining 3	经	經	Jīng   jīng	Jīng   jīng	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	
-Dining 3	已		yǐ	yǐ	already / to stop / then / afterwards	already / to stop / then / afterwards	
-Dining 3	已经	已經	yǐ jīng	yǐ jīng	already	already	
-Dining 3	请	請	qǐng	qǐng	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	
-Dining 3	小费	小費	xiǎo fèi	xiǎo fèi	tip / gratuity	tip / gratuity	
-Dining 3	饱	飽	bǎo	bǎo	to eat till full / satisfied	to eat till full / satisfied	
-Dining 3	好吃		hǎo chī   hào chī	hǎo chī   hào chī	tasty / delicious  to be fond of eating / to be gluttonous	tasty / delicious  to be fond of eating / to be gluttonous	
-Dining 3	真		zhēn	zhēn	really / truly / indeed / real / true / genuine	really / truly / indeed / real / true / genuine	
-Dining 3	饿	餓	è	è	to be hungry / hungry / to starve (sb)	to be hungry / hungry / to starve (sb)	
-Dining 3	少		shǎo   shào	shǎo   shào	few / less / to lack / to be missing / to stop (doing sth) / seldom  young	few / less / to lack / to be missing / to stop (doing sth) / seldom  young	
-Dining 3	好喝		hǎo hē	hǎo hē	tasty (drinks)	tasty (drinks)	
-Dining 3	渴		kě	kě	thirsty	thirsty	
-Dining 3	酒		jiǔ	jiǔ	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	
-Dining 3	巧克力		qiǎo kè lì	qiǎo kè lì	chocolate (loanword) / CL: 塊｜块	chocolate (loanword) / CL: 塊｜块	
-Dining 3	味道		wèi dao	wèi dao	flavor / smell / hint of	flavor / smell / hint of	
-Dining 3	甜点	甜點	tián diǎn	tián diǎn	dessert	dessert	
-Dining 3	甜		tián	tián	sweet	sweet	
-Dining 3	巧		qiǎo	qiǎo	opportunely / coincidentally / as it happens / skillful / timely	opportunely / coincidentally / as it happens / skillful / timely	
-Dining 3	克		kè   Kè   kēi	kè   Kè   kēi	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat	
-Dining 3	力		Lì   lì	Lì   lì	surname Li  power / force / strength / ability / strenuously	surname Li  power / force / strength / ability / strenuously	
-Shopping 2	试	試	shì	shì	to test / to try / experiment / examination / test	to test / to try / experiment / examination / test	
-Shopping 2	蓝	藍	Lán   lán	Lán   lán	surname Lan  blue / indigo plant	surname Lan  blue / indigo plant	
-Shopping 2	条	條	tiáo	tiáo	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)	
-Shopping 2	裙		qún	qún	skirt / CL: 條｜条	skirt / CL: 條｜条	
-Shopping 2	裙子		qún zi	qún zi	skirt / CL: 條｜条	skirt / CL: 條｜条	
-Shopping 2	双	雙	Shuāng   shuāng	Shuāng   shuāng	surname Shuang  two / double / pair / both / even (number)	surname Shuang  two / double / pair / both / even (number)	
-Shopping 2	还	還	Huán   hái   huán	Huán   hái   huán	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	
-Shopping 2	鞋子		xié zi	xié zi	shoe	shoe	
-Shopping 2	意大利		Yì dà lì	Yì dà lì	Italy / Italian	Italy / Italian	
-Shopping 2	色		sè   shǎi	sè   shǎi	color / CL: 種｜种 / look / appearance / sex  color / dice	color / CL: 種｜种 / look / appearance / sex  color / dice	
-Shopping 2	鞋		xié	xié	shoe / CL: 雙｜双, 隻｜只	shoe / CL: 雙｜双, 隻｜只	
-Shopping 2	利		Lì   lì	Lì   lì	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	
-Shopping 2	小		xiǎo	xiǎo	small / tiny / few / young	small / tiny / few / young	
-Shopping 2	比		Bǐ   bǐ   bì	Bǐ   bǐ   bì	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near	
-Shopping 2	衬衫	襯衫	chèn shān	chèn shān	shirt / blouse / CL: 件	shirt / blouse / CL: 件	
-Shopping 2	衬	襯	chèn	chèn	(of garments) against the skin / to line / lining / to contrast with / to assist financially	(of garments) against the skin / to line / lining / to contrast with / to assist financially	
-Shopping 2	衫		shān	shān	garment / jacket with open slits in place of sleeves	garment / jacket with open slits in place of sleeves	
-Shopping 2	大		dà   dài	dà   dài	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	
-Shopping 2	裤子	褲子	kù zi	kù zi	trousers / pants / CL: 條｜条	trousers / pants / CL: 條｜条	
-Shopping 2	好看		hǎo kàn	hǎo kàn	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	
-Shopping 2	裤	褲	kù	kù	underpants / trousers / pants	underpants / trousers / pants	
-Shopping 2	质	質	zhì	zhì	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]	
-Shopping 2	量		liáng   liàng	liáng   liàng	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word	
-Shopping 2	质量	質量	zhì liàng	zhì liàng	quality / (physics) mass / CL: 個｜个	quality / (physics) mass / CL: 個｜个	
-Body Parts	朵		duǒ	duǒ	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc	
-Body Parts	睛		jīng	jīng	eye / eyeball	eye / eyeball	
-Body Parts	绿	綠	lǜ	lǜ	green	green	
-Body Parts	耳		ěr	ěr	ear / handle (archaeology) / and that is all (classical Chinese)	ear / handle (archaeology) / and that is all (classical Chinese)	
-Body Parts	眼		yǎn	yǎn	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)	
-Body Parts	耳朵		ěr duo	ěr duo	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	
-Body Parts	眼睛		yǎn jing	yǎn jing	eye / CL: 隻｜只, 雙｜双	eye / CL: 隻｜只, 雙｜双	
-Body Parts	头发	頭髮	tóu fa	tóu fa	hair (on the head)	hair (on the head)	
-Body Parts	脸	臉	liǎn	liǎn	face / CL: 張｜张, 個｜个	face / CL: 張｜张, 個｜个	
-Body Parts	又		yòu	yòu	(once) again / also / both... and... / and yet / (used for emphasis) anyway	(once) again / also / both... and... / and yet / (used for emphasis) anyway	
-Body Parts	黑		Hēi   hēi	Hēi   hēi	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)	
-Body Parts	发	發	fā   fà	fā   fà	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	
-Body Parts	嘴巴		zuǐ ba	zuǐ ba	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	
-Body Parts	鼻子		bí zi	bí zi	nose / CL: 個｜个, 隻｜只	nose / CL: 個｜个, 隻｜只	
-Body Parts	脚	腳	jiǎo	jiǎo	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	
-Body Parts	手		shǒu	shǒu	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	
-Body Parts	嘴		zuǐ	zuǐ	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个	
-Body Parts	鼻		bí	bí	nose	nose	
-Body Parts	巴		Bā   bā	Bā   bā	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail	
-Travel	远	遠	yuǎn   yuàn	yuǎn   yuàn	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	
-Travel	离		chī   Lí   lí	chī   Lí   lí	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲	
-Travel	路		Lù   lù	Lù   lù	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	
-Travel	走路		zǒu lù	zǒu lù	to walk / to go on foot	to walk / to go on foot	
-Travel	近		jìn	jìn	near / close to / approximately	near / close to / approximately	
-Travel	开车	開車	kāi chē	kāi chē	to drive a car	to drive a car	
-Travel	飞机	飛機	fēi jī	fēi jī	airplane / CL: 架	airplane / CL: 架	
-Travel	机场	機場	jī chǎng	jī chǎng	airport / airfield / CL: 家, 處｜处	airport / airfield / CL: 家, 處｜处	
-Travel	飞	飛	fēi	fēi	to fly	to fly	
-Travel	场	場	cháng   chǎng	cháng   chǎng	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams	
-Travel	靠		kào	kào	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	
-Travel	停		tíng	tíng	to stop / to halt / to park (a car)	to stop / to halt / to park (a car)	
-Travel	火车	火車	huǒ chē	huǒ chē	train / CL: 列, 節｜节, 班, 趟	train / CL: 列, 節｜节, 班, 趟	
-Travel	得		dé   de   děi	dé   de   děi	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	
-Travel	票		piào	piào	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions	
-Travel	机票	機票	jī piào	jī piào	air ticket / passenger ticket / CL: 張｜张	air ticket / passenger ticket / CL: 張｜张	
-Travel	火		Huǒ   huǒ	Huǒ   huǒ	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)	
-Travel	迟到	遲到	chí dào	chí dào	to arrive late	to arrive late	
-Travel	让	讓	ràng	ràng	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	
-Travel	上		shǎng   shàng	shǎng   shàng	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	
-Travel	怎么办	怎麼辦	zěn me bàn	zěn me bàn	what's to be done	what's to be done	
-Travel	迟	遲	Chí   chí	Chí   chí	surname Chi  late / delayed / slow	surname Chi  late / delayed / slow	
-Travel	办	辦	bàn	bàn	to do / to manage / to handle / to go about / to run / to set up / to deal with	to do / to manage / to handle / to go about / to run / to set up / to deal with	
-Weather	冷		Lěng   lěng	Lěng   lěng	surname Leng  cold	surname Leng  cold	
-Weather	晴		qíng	qíng	clear / fine (weather)	clear / fine (weather)	
-Weather	天气	天氣	tiān qì	tiān qì	weather	weather	
-Weather	雨		yǔ   yù	yǔ   yù	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	
-Weather	雪		Xuě   xuě	Xuě   xuě	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	
-Weather	阴	陰	Yīn   yīn	Yīn   yīn	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	
-Weather	下		xià	xià	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	
-Weather	着	著	zhāo   zháo   zhe   zhuó	zhāo   zháo   zhe   zhuó	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	
-Weather	伞	傘	sǎn   sǎn	sǎn   sǎn	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	
-Weather	带	帶	dài	dài	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	
-Weather	外面		wài miàn	wài miàn	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	
-Weather	可能		kě néng	kě néng	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	
-Weather	刮		guā   guā	guā   guā	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	
-Weather	风	風	fēng	fēng	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝	
-Weather	如果		rú guǒ	rú guǒ	if / in case / in the event that	if / in case / in the event that	
-Weather	就		jiù	jiù	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	
-Weather	从来	從來	cóng lái	cóng lái	always / at all times / never (if used in negative sentence)	always / at all times / never (if used in negative sentence)	
-Weather	如		rú	rú	as / as if / such as	as / as if / such as	
-Weather	里面	裡面	lǐ miàn	lǐ miàn	inside / interior / also pr. [li3 mian5]	inside / interior / also pr. [li3 mian5]	
-Shopping 3	然		rán	rán	correct / right / so / thus / like this / -ly	correct / right / so / thus / like this / -ly	
-Shopping 3	但		dàn	dàn	but / yet / however / only / merely / still	but / yet / however / only / merely / still	
-Shopping 3	虽	雖	suī	suī	although / even though	although / even though	
-Shopping 3	短		duǎn	duǎn	short / brief / to lack / weak point / fault	short / brief / to lack / weak point / fault	
-Shopping 3	长	長	cháng   zhǎng	cháng   zhǎng	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	
-Shopping 3	虽然	雖然	suī rán	suī rán	although / even though / even if	although / even though / even if	
-Shopping 3	但是		dàn shì	dàn shì	but / however	but / however	
-Shopping 3	红	紅	Hóng   hóng	Hóng   hóng	surname Hong  red / popular / revolutionary / bonus	surname Hong  red / popular / revolutionary / bonus	
-Shopping 3	颜色	顏色	yán sè	yán sè	color / countenance / appearance / facial expression / pigment / dyestuff	color / countenance / appearance / facial expression / pigment / dyestuff	
-Shopping 3	穿		chuān	chuān	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	
-Shopping 3	颜	顏	Yán   yán	Yán   yán	surname Yan  color / face / countenance	surname Yan  color / face / countenance	
-Shopping 3	色		sè   shǎi	sè   shǎi	color / CL: 種｜种 / look / appearance / sex  color / dice	color / CL: 種｜种 / look / appearance / sex  color / dice	
-Shopping 3	洗		xǐ	xǐ	to wash / to bathe / to develop (photo)	to wash / to bathe / to develop (photo)	
-Shopping 3	黄	黃	Huáng   huáng	Huáng   huáng	surname Huang or Hwang  yellow / pornographic / to fall through	surname Huang or Hwang  yellow / pornographic / to fall through	
-Shopping 3	白		Bái   bái	Bái   bái	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	
-Shopping 3	手表	手錶	shǒu biǎo	shǒu biǎo	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	
-Shopping 3	卖	賣	mài	mài	to sell / to betray / to spare no effort / to show off or flaunt	to sell / to betray / to spare no effort / to show off or flaunt	
-Shopping 3	帽子		mào zi	mào zi	hat / cap / (fig.) label / bad name / CL: 頂｜顶	hat / cap / (fig.) label / bad name / CL: 頂｜顶	
-Shopping 3	帽		mào	mào	hat / cap	hat / cap	
-Shopping 3	表		biǎo   biǎo	biǎo   biǎo	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch	
-Shopping 3	紫		zǐ	zǐ	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	
-People 2	绍	紹	Shào   shào	Shào   shào	surname Shao  to continue / to carry on	surname Shao  to continue / to carry on	
-People 2	介		jiè	jiè	to introduce / to lie between / between / shell / armor	to introduce / to lie between / between / shell / armor	
-People 2	介绍	介紹	jiè shào	jiè shào	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	
-People 2	帅	帥	Shuài   shuài	Shuài   shuài	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!	
-People 2	笑		xiào	xiào	laugh / smile / CL: 個｜个	laugh / smile / CL: 個｜个	
-People 2	说话	說話	shuō huà	shuō huà	to speak / to say / to talk / to gossip / to tell stories / talk / word	to speak / to say / to talk / to gossip / to tell stories / talk / word	
-People 2	话	話	huà	huà	dialect / language / spoken words / speech / talk / words / conversation / what sb said / CL: 種｜种, 席, 句, 口, 番	dialect / language / spoken words / speech / talk / words / conversation / what sb said / CL: 種｜种, 席, 句, 口, 番	
-People 2	聪明	聰明	cōng ming	cōng ming	intelligent / clever / bright / smart / acute (of sight and hearing)	intelligent / clever / bright / smart / acute (of sight and hearing)	
-People 2	别人	別人	bié ren	bié ren	other people / others / other person	other people / others / other person	
-People 2	不但		bù dàn	bù dàn	not only (... but also...)	not only (... but also...)	
-People 2	而且		ér qiě	ér qiě	(not only ...) but also / moreover / in addition / furthermore	(not only ...) but also / moreover / in addition / furthermore	
-People 2	聪	聰	cōng	cōng	quick at hearing / wise / clever / sharp-witted / intelligent / acute	quick at hearing / wise / clever / sharp-witted / intelligent / acute	
-People 2	而		ér	ér	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)	
-People 2	且		qiě	qiě	and / moreover / yet / for the time being / to be about to / both (... and...)	and / moreover / yet / for the time being / to be about to / both (... and...)	
-Celebration	春		Chūn   chūn	Chūn   chūn	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	
-Celebration	乐	樂	Lè   Yuè   lè   yuè	Lè   Yuè   lè   yuè	surname Le  surname Yue  happy / cheerful / to laugh  music	surname Le  surname Yue  happy / cheerful / to laugh  music	
-Celebration	快乐	快樂	kuài lè	kuài lè	happy / merry	happy / merry	
-Celebration	节日	節日	jié rì	jié rì	holiday / festival / CL: 個｜个	holiday / festival / CL: 個｜个	
-Celebration	春节	春節	Chūn jié	Chūn jié	Spring Festival (Chinese New Year)	Spring Festival (Chinese New Year)	
-Celebration	礼物	禮物	lǐ wù	lǐ wù	gift / present / CL: 件, 個｜个, 份	gift / present / CL: 件, 個｜个, 份	
-Celebration	送		sòng	sòng	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	
-Celebration	新年		xīn nián	xīn nián	New Year / CL: 個｜个	New Year / CL: 個｜个	
-Celebration	瓶		píng	píng	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	
-Celebration	白酒		bái jiǔ	bái jiǔ	baijiu, a spirit usually distilled from sorghum	baijiu, a spirit usually distilled from sorghum	
-Celebration	礼	禮	Lǐ   lǐ	Lǐ   lǐ	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy	
-Celebration	物		wù	wù	thing / object / matter / abbr. for physics 物理	thing / object / matter / abbr. for physics 物理	
-Celebration	过	過	Guò   guò   guo	Guò   guò   guo	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	
-Celebration	干杯	乾杯	gān bēi	gān bēi	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	
-Celebration	祝		Zhù   zhù	Zhù   zhù	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	
-Celebration	法国	法國	Fǎ guó	Fǎ guó	France / French	France / French	
-Celebration	红酒		hóng jiǔ	hóng jiǔ	Red wine	Red wine	
-Celebration	干	乾	Gān   gān   gān   gàn	Gān   gān   gān   gàn	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	
-Celebration	法		Fǎ   fǎ	Fǎ   fǎ	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	
-Sports 2	赛	賽	sài	sài	to compete / competition / match / to surpass / better than / superior to / to excel	to compete / competition / match / to surpass / better than / superior to / to excel	
-Sports 2	练	練	liàn	liàn	to practice / to train / to drill / to perfect (one's skill) / exercise	to practice / to train / to drill / to perfect (one's skill) / exercise	
-Sports 2	练习	練習	liàn xí	liàn xí	to practice / exercise / drill / practice / CL: 個｜个	to practice / exercise / drill / practice / CL: 個｜个	
-Sports 2	比赛	比賽	bǐ sài	bǐ sài	competition (sports etc) / match / CL: 場｜场, 次 / to compete	competition (sports etc) / match / CL: 場｜场, 次 / to compete	
-Sports 2	好在		hǎo zài	hǎo zài	luckily / fortunately	luckily / fortunately	
-Sports 2	乒乓球		pīng pāng qiú	pīng pāng qiú	table tennis / ping-pong / table tennis ball / CL: 個｜个	table tennis / ping-pong / table tennis ball / CL: 個｜个	
-Sports 2	乒		pīng	pīng	(onom.) ping / bing	(onom.) ping / bing	
-Sports 2	乓		pāng	pāng	(onom.) bang	(onom.) bang	
-Sports 2	参加	參加	cān jiā	cān jiā	to participate / to take part / to join	to participate / to take part / to join	
-Sports 2	第		dì	dì	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	
-Sports 2	参	參	cān   shēn	cān   shēn	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations	
-Sports 2	网球	網球	wǎng qiú	wǎng qiú	tennis / tennis ball / CL: 個｜个	tennis / tennis ball / CL: 個｜个	
-Sports 2	排球		pái qiú	pái qiú	volleyball / CL: 個｜个	volleyball / CL: 個｜个	
-Sports 2	加油		jiā yóu	jiā yóu	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	
-Sports 2	排		pái	pái	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	
-Sports 2	油		yóu	yóu	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	
-Sports 2	输	輸	shū	shū	to lose / to transport / to donate / to enter (a password)	to lose / to transport / to donate / to enter (a password)	
-Sports 2	赢	贏	yíng	yíng	to beat / to win / to profit	to beat / to win / to profit	
-Sports 2	失望		shī wàng	shī wàng	disappointed / to lose hope / to despair	disappointed / to lose hope / to despair	
-Sports 2	信心		xìn xīn	xìn xīn	confidence / faith (in sb or sth) / CL: 個｜个	confidence / faith (in sb or sth) / CL: 個｜个	
-Sports 2	失		shī	shī	to lose / to miss / to fail	to lose / to miss / to fail	
-Sports 2	信		xìn	xìn	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	
-Sports 2	心		xīn	xīn	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个	
-School	同	仝	tóng   tóng   tòng	tóng   tóng   tòng	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同	
-School	课	課	kè	kè	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination	
-School	室		Shì   shì	Shì   shì	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	
-School	教		Jiào   jiāo   jiào	Jiào   jiāo   jiào	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	
-School	教室		jiào shì	jiào shì	classroom / CL: 間｜间	classroom / CL: 間｜间	
-School	同学	同學	tóng xué	tóng xué	to study at the same school / fellow student / classmate / CL: 位, 個｜个	to study at the same school / fellow student / classmate / CL: 位, 個｜个	
-School	地理		dì lǐ	dì lǐ	geography	geography	
-School	理		lǐ	lǐ	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up	
-School	懂		dǒng	dǒng	to understand / to comprehend	to understand / to comprehend	
-School	问题	問題	wèn tí	wèn tí	question / problem / issue / topic / CL: 個｜个	question / problem / issue / topic / CL: 個｜个	
-School	笔	筆	bǐ	bǐ	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝	
-School	题	題	Tí   tí	Tí   tí	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道	
-School	美术	美術	měi shù	měi shù	art / fine arts / painting / CL: 種｜种	art / fine arts / painting / CL: 種｜种	
-School	术	術	shù   zhú	shù   zhú	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea	
-School	上		shǎng   shàng	shǎng   shàng	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	
-School	考试	考試	kǎo shì	kǎo shì	to take an exam / exam / CL: 次	to take an exam / exam / CL: 次	
-School	准备	準備	zhǔn bèi	zhǔn bèi	preparation / to prepare / to intend / to be about to / reserve (fund)	preparation / to prepare / to intend / to be about to / reserve (fund)	
-School	考	攷	kǎo   kǎo	kǎo   kǎo	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	
-School	准		zhǔn   zhǔn	zhǔn   zhǔn	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	
-School	备	備	bèi	bèi	to prepare / get ready / to provide or equip	to prepare / get ready / to provide or equip	
-School	科学	科學	kē xué	kē xué	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	
-School	科		kē	kē	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个	
-School	下课	下課	xià kè	xià kè	to finish class / to get out of class	to finish class / to get out of class	
-Family 3	爷爷	爺爺	yé ye	yé ye	(coll.) father's father / paternal grandfather / CL: 個｜个	(coll.) father's father / paternal grandfather / CL: 個｜个	
-Family 3	奶奶		nǎi nai	nǎi nai	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	
-Family 3	阿姨		ā yí	ā yí	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	
-Family 3	爷	爺	yé	yé	grandpa / old gentleman	grandpa / old gentleman	
-Family 3	阿		Ā   ā   ē	Ā   ā   ē	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter	
-Family 3	姨		yí	yí	mother's sister / aunt	mother's sister / aunt	
-Family 3	兄弟姐妹		xiōng dì jiě mèi	xiōng dì jiě mèi	Brothers and Sisters	Brothers and Sisters	
-Family 3	关系	關係	guān xi	guān xi	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个	
-Family 3	叔叔		shū shu	shū shu	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	
-Family 3	父母		fù mǔ	fù mǔ	father and mother / parents	father and mother / parents	
-Family 3	兄		xiōng	xiōng	elder brother	elder brother	
-Family 3	叔		shū	shū	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]	
-Family 3	父		fù	fù	father	father	
-Family 3	母		mǔ	mǔ	mother / elderly female relative / origin / source / (of animals) female	mother / elderly female relative / origin / source / (of animals) female	
-Family 3	像		xiàng	xiàng	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	
-Family 3	一样	一樣	yī yàng	yī yàng	same / like / equal to / the same as / just like	same / like / equal to / the same as / just like	
-Family 3	亲戚	親戚	qīn qi	qīn qi	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	
-Family 3	戚		Qī   qī	Qī   qī	surname Qi  relative / parent / grief / sorrow / battle-axe	surname Qi  relative / parent / grief / sorrow / battle-axe	
-Family 3	亲	親	qīn   qìng	qīn   qìng	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring	
-Gourmet 1	拉面	拉麵	lā miàn	lā miàn	pulled noodles / ramen	pulled noodles / ramen	
-Gourmet 1	点心	點心	diǎn xin	diǎn xin	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	
-Gourmet 1	小笼包	小籠包	xiǎo lóng bāo	xiǎo lóng bāo	steamed dumpling	steamed dumpling	
-Gourmet 1	拉		lā	lā	to pull / to play (a bowed instrument) / to drag / to draw / to chat	to pull / to play (a bowed instrument) / to drag / to draw / to chat	
-Gourmet 1	笼	籠	lóng   lǒng	lóng   lǒng	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]	
-Gourmet 1	粥		yù   zhōu	yù   zhōu	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	
-Gourmet 1	油条	油條	yóu tiáo	yóu tiáo	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	
-Gourmet 1	豆浆	豆漿	dòu jiāng	dòu jiāng	soy milk	soy milk	
-Gourmet 1	油		yóu	yóu	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	
-Gourmet 1	豆		dòu	dòu	bean / pea / CL: 棵, 粒 / sacrificial vessel	bean / pea / CL: 棵, 粒 / sacrificial vessel	
-Gourmet 1	浆	漿	jiāng   jiàng	jiāng   jiàng	broth / serum / to starch  starch paste	broth / serum / to starch  starch paste	
-Gourmet 1	火锅	火鍋	huǒ guō	huǒ guō	hotpot	hotpot	
-Gourmet 1	包子		bāo zi	bāo zi	steamed stuffed bun / CL: 個｜个	steamed stuffed bun / CL: 個｜个	
-Gourmet 1	炒饭	炒飯	chǎo fàn	chǎo fàn	fried rice / (slang) (Tw) to have sex	fried rice / (slang) (Tw) to have sex	
-Gourmet 1	锅	鍋	guō	guō	pot / pan / boiler / CL: 口, 隻｜只	pot / pan / boiler / CL: 口, 隻｜只	
-Gourmet 1	炒		chǎo	chǎo	to sauté / to stir-fry / to speculate / to hype / to fire (sb)	to sauté / to stir-fry / to speculate / to hype / to fire (sb)	
-Time 4	夏		Xià   xià	Xià   xià	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	
-Time 4	冬		dōng   Dōng   dōng	dōng   Dōng   dōng	winter  surname Dong  (onom.) beating a drum / rat-a-tat	winter  surname Dong  (onom.) beating a drum / rat-a-tat	
-Time 4	秋		Qiū   qiū   qiū	Qiū   qiū   qiū	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千	
-Time 4	春		Chūn   chūn	Chūn   chūn	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	
-Time 4	后		Hòu   hòu   hòu	Hòu   hòu   hòu	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	
-Time 4	前		qián	qián	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	
-Time 4	季		Jì   jì	Jì   jì	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields	
-Time 4	澳		Ào   ào	Ào   ào	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor	
-Time 4	亚	亞	yà	yà	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]	
-Time 4	季节	季節	jì jié	jì jié	time / season / period / CL: 個｜个	time / season / period / CL: 個｜个	
-Time 4	澳大利亚	澳大利亞	Ào dà lì yà	Ào dà lì yà	Australia	Australia	
-Time 4	越来越	越來越	yuè lái yuè	yuè lái yuè	more and more	more and more	
-Time 4	前天		qián tiān	qián tiān	the day before yesterday	the day before yesterday	
-Time 4	后天	後天	hòu tiān	hòu tiān	the day after tomorrow / acquired (not innate) / a posteriori	the day after tomorrow / acquired (not innate) / a posteriori	
-Time 4	堵车	堵車	dǔ chē	dǔ chē	traffic jam / choking	traffic jam / choking	
-Time 4	大概		dà gài	dà gài	roughly / probably / rough / approximate / about / general idea	roughly / probably / rough / approximate / about / general idea	
-Time 4	准时	準時	zhǔn shí	zhǔn shí	on time / punctual / on schedule	on time / punctual / on schedule	
-Time 4	刚	剛	gāng	gāng	hard / firm / strong / just / barely / exactly	hard / firm / strong / just / barely / exactly	
-Time 4	堵		dǔ	dǔ	to stop up / (to feel) stifled or suffocated / wall / classifier for walls	to stop up / (to feel) stifled or suffocated / wall / classifier for walls	
-Time 4	概		gài	gài	general / approximate	general / approximate	
-Location 5	城		chéng	chéng	city walls / city / town / CL: 座, 道, 個｜个	city walls / city / town / CL: 座, 道, 個｜个	
-Location 5	市		shì	shì	market / city / CL: 個｜个	market / city / CL: 個｜个	
-Location 5	附		fù	fù	to add / to attach / to be close to / to be attached	to add / to attach / to be close to / to be attached	
-Location 5	园	園	Yuán   yuán	Yuán   yuán	surname Yuan  land used for growing plants / site used for public recreation	surname Yuan  land used for growing plants / site used for public recreation	
-Location 5	城市		chéng shì	chéng shì	city / town / CL: 座	city / town / CL: 座	
-Location 5	附近		fù jìn	fù jìn	(in the) vicinity / nearby / neighboring / next to	(in the) vicinity / nearby / neighboring / next to	
-Location 5	公园	公園	gōng yuán	gōng yuán	park (for public recreation) / CL: 個｜个, 座	park (for public recreation) / CL: 個｜个, 座	
-Location 5	图	圖	tú	tú	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek	
-Location 5	馆	館	guǎn	guǎn	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	
-Location 5	方		Fāng   fāng	Fāng   fāng	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter	
-Location 5	中间	中間	zhōng jiān	zhōng jiān	between / intermediate / mid / middle	between / intermediate / mid / middle	
-Location 5	图书馆	圖書館	tú shū guǎn	tú shū guǎn	library / CL: 家, 個｜个	library / CL: 家, 個｜个	
-Location 5	地方		dì fāng   dì fang	dì fāng   dì fang	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	
-Location 5	上面		shàng miàn	shàng miàn	on top of / above-mentioned / also pr. [shang4 mian5]	on top of / above-mentioned / also pr. [shang4 mian5]	
-Location 5	下面		xià miàn   xià miàn	xià miàn   xià miàn	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	
-Location 5	咖啡馆	咖啡館	kā fēi guǎn	kā fēi guǎn	café / coffee shop / CL: 家	café / coffee shop / CL: 家	
-Shopping 4	折		shé   zhē   zhé	shé   zhē   zhé	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book	
-Shopping 4	角		Jué   jiǎo   jué	Jué   jiǎo   jué	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	
-Shopping 4	花		Huā   huā	Huā   huā	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	
-Shopping 4	打折		dǎ zhé	dǎ zhé	to give a discount	to give a discount	
-Shopping 4	旧	舊	jiù	jiù	old / opposite: new 新 / former / worn (with age)	old / opposite: new 新 / former / worn (with age)	
-Shopping 4	皮		Pí   pí	Pí   pí	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty	
-Shopping 4	换	換	huàn	huàn	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)	
-Shopping 4	经	經	Jīng   jīng	Jīng   jīng	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	
-Shopping 4	皮鞋		pí xié	pí xié	leather shoes	leather shoes	
-Shopping 4	经过	經過	jīng guò	jīng guò	to pass / to go through / process / course / CL: 個｜个	to pass / to go through / process / course / CL: 個｜个	
-Shopping 4	退货	退貨	tuì huò	tuì huò	to return merchandise / to withdraw a product	to return merchandise / to withdraw a product	
-Shopping 4	退款		tuì kuǎn	tuì kuǎn	to refund / refund	to refund / refund	
-Shopping 4	退		tuì	tuì	to retreat / to decline / to move back / to withdraw	to retreat / to decline / to move back / to withdraw	
-Shopping 4	货	貨	huò	huò	goods / money / commodity / CL: 個｜个	goods / money / commodity / CL: 個｜个	
-Shopping 4	款		kuǎn	kuǎn	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)	
-Shopping 4	袋子		dài zi	dài zi	bag	bag	
-Daily Routine 2	惯	慣	guàn	guàn	accustomed to / used to / indulge / to spoil (a child)	accustomed to / used to / indulge / to spoil (a child)	
-Daily Routine 2	刷		shuā   shuà	shuā   shuà	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	
-Daily Routine 2	牙		yá	yá	tooth / ivory / CL: 顆｜颗	tooth / ivory / CL: 顆｜颗	
-Daily Routine 2	习惯	習慣	xí guàn	xí guàn	habit / custom / usual practice / to be used to / CL: 個｜个	habit / custom / usual practice / to be used to / CL: 個｜个	
-Daily Routine 2	刷牙		shuā yá	shuā yá	to brush one's teeth	to brush one's teeth	
-Daily Routine 2	马上	馬上	mǎ shàng	mǎ shàng	at once / right away / immediately / on horseback (i.e. by military force)	at once / right away / immediately / on horseback (i.e. by military force)	
-Daily Routine 2	以后	以後	yǐ hòu	yǐ hòu	after / later / afterwards / following / later on / in the future	after / later / afterwards / following / later on / in the future	
-Daily Routine 2	澡		zǎo	zǎo	bath	bath	
-Daily Routine 2	总	總	zǒng	zǒng	always / to assemble / gather / total / overall / head / chief / general / in every case	always / to assemble / gather / total / overall / head / chief / general / in every case	
-Daily Routine 2	洗澡		xǐ zǎo	xǐ zǎo	to bathe / to take a shower	to bathe / to take a shower	
-Daily Routine 2	一边	一邊	yī biān	yī biān	one side / either side / on the one hand / on the other hand / doing while	one side / either side / on the one hand / on the other hand / doing while	
-Daily Routine 2	总是	總是	zǒng shì	zǒng shì	always	always	
-Daily Routine 2	讲	講	jiǎng	jiǎng	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	
-Daily Routine 2	故		gù	gù	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead	
-Daily Routine 2	故事		gù shì   gù shi	gù shì   gù shi	old practice / CL: 個｜个  narrative / story / tale	old practice / CL: 個｜个  narrative / story / tale	
-Daily Routine 2	以前		yǐ qián	yǐ qián	before / formerly / previous / ago	before / formerly / previous / ago	
-Daily Routine 2	做梦	做夢	zuò mèng	zuò mèng	to dream / to have a dream / fig. illusion / fantasy / pipe dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream	
-Daily Routine 2	梦	夢	mèng	mèng	dream / CL: 場｜场, 個｜个	dream / CL: 場｜场, 個｜个	
-Food 3	除		chú	chú	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including	
-Food 3	其		qí	qí	his / her / its / their / that / such / it (refers to sth preceding it)	his / her / its / their / that / such / it (refers to sth preceding it)	
-Food 3	饺	餃	jiǎo	jiǎo	dumplings with meat filling	dumplings with meat filling	
-Food 3	北方		běi fāng	běi fāng	north / the northern part a country / China north of the Yellow River	north / the northern part a country / China north of the Yellow River	
-Food 3	除了		chú le	chú le	besides / apart from (... also...) / in addition to / except (for)	besides / apart from (... also...) / in addition to / except (for)	
-Food 3	其他		qí tā	qí tā	other / (sth or sb) else / the rest	other / (sth or sb) else / the rest	
-Food 3	饺子	餃子	jiǎo zi	jiǎo zi	dumpling / pot-sticker / CL: 個｜个, 隻｜只	dumpling / pot-sticker / CL: 個｜个, 隻｜只	
-Food 3	辣		là	là	hot (spicy) / pungent	hot (spicy) / pungent	
-Food 3	极	極	jí	jí	extremely / pole (geography, physics) / utmost / top	extremely / pole (geography, physics) / utmost / top	
-Food 3	苦		kǔ	kǔ	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly	
-Food 3	盐	鹽	yán	yán	salt / CL: 粒	salt / CL: 粒	
-Food 3	咸		Xián   xián   xián	Xián   xián   xián	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	
-Food 3	南		Nán   nán	Nán   nán	surname Nan  south	surname Nan  south	
-Food 3	甜		tián	tián	sweet	sweet	
-Food 3	南方		nán fāng	nán fāng	south / the southern part of the country / the South	south / the southern part of the country / the South	
-Food 3	难吃	難吃	nán chī	nán chī	unpalatable	unpalatable	
-People 3	长	長	cháng   zhǎng	cháng   zhǎng	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	
-People 3	级	級	jí	jí	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level	
-People 3	个子	個子	gè zi	gè zi	height / stature / build / size	height / stature / build / size	
-People 3	年级	年級	nián jí	nián jí	grade / year (in school, college etc) / CL: 個｜个	grade / year (in school, college etc) / CL: 個｜个	
-People 3	小学	小學	xiǎo xué	xiǎo xué	elementary school / primary school / CL: 個｜个	elementary school / primary school / CL: 個｜个	
-People 3	初中		chū zhōng	chū zhōng	junior high school / abbr. for 初級中學｜初级中学	junior high school / abbr. for 初級中學｜初级中学	
-People 3	初		chū	chū	at first / (at the) beginning / first / junior / basic	at first / (at the) beginning / first / junior / basic	
-People 3	轻	輕	qīng	qīng	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	
-People 3	较	較	jiào	jiào	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]	
-People 3	年轻	年輕	nián qīng	nián qīng	young	young	
-People 3	老		lǎo	lǎo	prefix used before the surname of a person or a numeral indicating the order of birth of the children in a family or to indicate affection or familiarity / old (of people) / venerable (person) / experienced / of long standing / always / all the time / of the past / very / outdated / (of meat etc) tough	prefix used before the surname of a person or a numeral indicating the order of birth of the children in a family or to indicate affection or familiarity / old (of people) / venerable (person) / experienced / of long standing / always / all the time / of the past / very / outdated / (of meat etc) tough	
-People 3	比较	比較	bǐ jiào	bǐ jiào	to compare / to contrast / comparatively / relatively / quite / comparison	to compare / to contrast / comparatively / relatively / quite / comparison	
-People 3	眼镜	眼鏡	yǎn jìng	yǎn jìng	spectacles / eyeglasses / CL: 副	spectacles / eyeglasses / CL: 副	
-People 3	戴		Dài   dài	Dài   dài	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	
-People 3	镜	鏡	jìng	jìng	mirror / lens	mirror / lens	
-Location 6	先		xiān	xiān	early / prior / former / in advance / first	early / prior / former / in advance / first	
-Location 6	然后	然後	rán hòu	rán hòu	after / then (afterwards) / after that / afterwards	after / then (afterwards) / after that / afterwards	
-Location 6	西边	西邊	xī biān	xī biān	west / west side / western part / to the west of	west / west side / western part / to the west of	
-Location 6	东边	東邊	dōng bian	dōng bian	east / east side / eastern part / to the east of	east / east side / eastern part / to the east of	
-Location 6	前		qián	qián	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	
-Location 6	左		Zuǒ   zuǒ	Zuǒ   zuǒ	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	
-Location 6	北边	北邊	běi biān	běi biān	north / north side / northern part / to the north of	north / north side / northern part / to the north of	
-Location 6	一直		yī zhí	yī zhí	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	
-Location 6	最后	最後	zuì hòu	zuì hòu	final / last / finally / ultimate	final / last / finally / ultimate	
-Location 6	南边	南邊	nán bian	nán bian	south / south side / southern part / to the south of	south / south side / southern part / to the south of	
-Location 6	直		Zhí   zhí	Zhí   zhí	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters	
-Location 6	右		yòu	yòu	right (-hand) / the Right (politics) / west (old)	right (-hand) / the Right (politics) / west (old)	
-Location 6	后		Hòu   hòu   hòu	Hòu   hòu   hòu	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	
-Location 6	迷路		mí lù	mí lù	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	
-Location 6	地址		dì zhǐ	dì zhǐ	address / CL: 個｜个	address / CL: 個｜个	
-Location 6	周围	周圍	zhōu wéi	zhōu wéi	surroundings / environment / to encompass	surroundings / environment / to encompass	
-Location 6	迷		mí	mí	to bewilder / crazy about / fan / enthusiast / lost / confused	to bewilder / crazy about / fan / enthusiast / lost / confused	
-Location 6	址		zhǐ	zhǐ	location / site	location / site	
-Location 6	围	圍	Wéi   wéi	Wéi   wéi	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)	
-Daily Routine 3	般		bān   pán	bān   pán	sort / kind / class / way / manner  see 般樂｜般乐	sort / kind / class / way / manner  see 般樂｜般乐	
-Daily Routine 3	聊		liáo	liáo	to chat / to depend upon (literary) / temporarily / just / slightly	to chat / to depend upon (literary) / temporarily / just / slightly	
-Daily Routine 3	聊天		liáo tiān	liáo tiān	to chat / to gossip	to chat / to gossip	
-Daily Routine 3	一般		yī bān	yī bān	same / ordinary / so-so / common / general / generally / in general	same / ordinary / so-so / common / general / generally / in general	
-Daily Routine 3	见面	見面	jiàn miàn	jiàn miàn	to meet / to see each other / CL: 次	to meet / to see each other / CL: 次	
-Daily Routine 3	自己		zì jǐ	zì jǐ	oneself / one's own	oneself / one's own	
-Daily Routine 3	一个人	一個人	yī gè rén	yī gè rén	by oneself (without assistance) / alone (without company)	by oneself (without assistance) / alone (without company)	
-Daily Routine 3	自		zì	zì	self / oneself / from / since / naturally / surely	self / oneself / from / since / naturally / surely	
-Daily Routine 3	己		jǐ	jǐ	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa	
-Travel 2	证	証	zhèng   zhèng	zhèng   zhèng	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症	
-Travel 2	签	簽	qiān   qiān	qiān   qiān	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag	
-Travel 2	照		zhào	zhào	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	
-Travel 2	护	護	hù	hù	to protect	to protect	
-Travel 2	护照	護照	hù zhào	hù zhào	passport / CL: 本, 個｜个	passport / CL: 本, 個｜个	
-Travel 2	签证	簽證	qiān zhèng	qiān zhèng	visa / certificate / to certify / CL: 個｜个	visa / certificate / to certify / CL: 個｜个	
-Travel 2	发现	發現	fā xiàn	fā xiàn	to find / to discover	to find / to discover	
-Travel 2	起飞	起飛	qǐ fēi	qǐ fēi	(of an aircraft) to take off	(of an aircraft) to take off	
-Travel 2	离开	離開	lí kāi	lí kāi	to depart / to leave	to depart / to leave	
-Travel 2	发	發	fā   fà	fā   fà	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	
-Travel 2	检查	檢查	jiǎn chá	jiǎn chá	inspection / to examine / to inspect / CL: 次	inspection / to examine / to inspect / CL: 次	
-Travel 2	行李		xíng li	xíng li	luggage / CL: 件	luggage / CL: 件	
-Travel 2	安全		ān quán	ān quán	safe / secure / safety / security	safe / secure / safety / security	
-Travel 2	检	檢	jiǎn	jiǎn	to check / to examine / to inspect / to exercise restraint	to check / to examine / to inspect / to exercise restraint	
-Travel 2	查		Zhā   chá   zhā	Zhā   chá   zhā	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查	
-Travel 2	几乎	幾乎	jī hū	jī hū	almost / nearly / practically	almost / nearly / practically	
-Travel 2	忘记	忘記	wàng jì	wàng jì	to forget	to forget	
-Travel 2	海关	海關	hǎi guān	hǎi guān	customs (i.e. border crossing inspection) / CL: 個｜个	customs (i.e. border crossing inspection) / CL: 個｜个	
-Travel 2	忘		wàng	wàng	to forget / to overlook / to neglect	to forget / to overlook / to neglect	
-Travel 2	记	記	jì	jì	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots	
-Travel 2	几		jī   jī   jǐ	jī   jī   jǐ	small table  almost  how much / how many / several / a few	small table  almost  how much / how many / several / a few	
-Travel 2	乎		hū	hū	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)	
-Languages 2	言		yán	yán	words / speech / to say / to talk	words / speech / to say / to talk	
-Languages 2	易		Yì   yì	Yì   yì	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange	
-Languages 2	容		Róng   róng	Róng   róng	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance	
-Languages 2	种	種	zhǒng   zhòng	zhǒng   zhòng	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	
-Languages 2	容易		róng yì	róng yì	easy / likely / liable (to)	easy / likely / liable (to)	
-Languages 2	久		jiǔ	jiǔ	(long) time / (long) duration of time	(long) time / (long) duration of time	
-Languages 2	语言	語言	yǔ yán	yǔ yán	language / CL: 門｜门, 種｜种	language / CL: 門｜门, 種｜种	
-Languages 2	学	學	xué	xué	to learn / to study / to imitate / science / -ology	to learn / to study / to imitate / science / -ology	
-Languages 2	更		gēng   gèng	gēng   gèng	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	
-Languages 2	努力		nǔ lì	nǔ lì	great effort / to strive / to try hard	great effort / to strive / to try hard	
-Languages 2	汉字	漢字	hàn zì	hàn zì	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	
-Languages 2	努		nǔ	nǔ	to exert / to strive	to exert / to strive	
-Languages 2	力		Lì   lì	Lì   lì	surname Li  power / force / strength / ability / strenuously	surname Li  power / force / strength / ability / strenuously	
-Languages 2	提高		tí gāo	tí gāo	to raise / to increase / to improve	to raise / to increase / to improve	
-Languages 2	水平		shuǐ píng	shuǐ píng	level (of achievement etc) / standard / horizontal	level (of achievement etc) / standard / horizontal	
-Languages 2	后来	後來	hòu lái	hòu lái	afterwards / later	afterwards / later	
-Languages 2	考	攷	kǎo   kǎo	kǎo   kǎo	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	
-Languages 2	提		tí	tí	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid	
-Languages 2	平		Píng   píng	Píng   píng	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声	
-Personality and Feelings	看起来	看起來	kàn qǐ lai	kàn qǐ lai	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	
-Personality and Feelings	奇怪		qí guài	qí guài	strange / odd / to marvel / to be baffled	strange / odd / to marvel / to be baffled	
-Personality and Feelings	生气	生氣	shēng qì	shēng qì	to get angry / to take offense / angry / vitality / liveliness	to get angry / to take offense / angry / vitality / liveliness	
-Personality and Feelings	紧张	緊張	jǐn zhāng	jǐn zhāng	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	
-Personality and Feelings	奇		jī   qí	jī   qí	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually	
-Personality and Feelings	怪		guài	guài	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather	
-Personality and Feelings	紧	緊	jǐn	jǐn	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten	
-Personality and Feelings	难过	難過	nán guò	nán guò	to feel sad / to feel unwell / (of life) to be difficult	to feel sad / to feel unwell / (of life) to be difficult	
-Personality and Feelings	地		de   dì	de   dì	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	
-Personality and Feelings	想		xiǎng	xiǎng	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	
-Personality and Feelings	哭		kū	kū	to cry / to weep	to cry / to weep	
-Personality and Feelings	可怕		kě pà	kě pà	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	
-Personality and Feelings	热情	熱情	rè qíng	rè qíng	cordial / enthusiastic / passion / passionate / passionately	cordial / enthusiastic / passion / passionate / passionately	
-Personality and Feelings	关心	關心	guān xīn	guān xīn	to be concerned about / to care about	to be concerned about / to care about	
-Personality and Feelings	经常	經常	jīng cháng	jīng cháng	frequently / constantly / regularly / often / day-to-day / everyday / daily	frequently / constantly / regularly / often / day-to-day / everyday / daily	
-Personality and Feelings	遇到		yù dào	yù dào	to meet / to run into / to come across	to meet / to run into / to come across	
-Personality and Feelings	好笑		hǎo xiào	hǎo xiào	laughable / funny / ridiculous	laughable / funny / ridiculous	
-Personality and Feelings	遇		Yù   yù	Yù   yù	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance	
-School 2	求		qiú	qiú	to seek / to look for / to request / to demand / to beseech	to seek / to look for / to request / to demand / to beseech	
-School 2	教		Jiào   jiāo   jiào	Jiào   jiāo   jiào	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	
-School 2	班		Bān   bān	Bān   bān	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	
-School 2	校长	校長	xiào zhǎng	xiào zhǎng	(college, university) president / headmaster / CL: 個｜个, 位, 名	(college, university) president / headmaster / CL: 個｜个, 位, 名	
-School 2	要求		yāo qiú	yāo qiú	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	
-School 2	食堂		shí táng	shí táng	dining hall / CL: 個｜个, 間｜间	dining hall / CL: 個｜个, 間｜间	
-School 2	食		shí   sì	shí   sì	to eat / food / animal feed / eclipse  to feed	to eat / food / animal feed / eclipse  to feed	
-School 2	堂		táng	táng	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture	
-School 2	必须	必須	bì xū	bì xū	to have to / must / compulsory / necessarily	to have to / must / compulsory / necessarily	
-School 2	完成		wán chéng	wán chéng	to complete / to accomplish	to complete / to accomplish	
-School 2	作业	作業	zuò yè	zuò yè	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	
-School 2	高中		gāo zhōng   gāo zhòng	gāo zhōng   gāo zhòng	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	
-School 2	必		bì	bì	certainly / must / will / necessarily	certainly / must / will / necessarily	
-School 2	成		Chéng   chéng	Chéng   chéng	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	
-School 2	须	須	xū   xū	xū   xū	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel	
-School 2	业	業	Yè   yè	Yè   yè	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already	
-School 2	向		Xiàng   xiàng   xiàng	Xiàng   xiàng   xiàng	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	
-School 2	借		jiè	jiè	to lend / to borrow / by means of / to take (an opportunity)	to lend / to borrow / by means of / to take (an opportunity)	
-School 2	笔记	筆記	bǐ jì	bǐ jì	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本	
-School 2	铅笔	鉛筆	qiān bǐ	qiān bǐ	(lead) pencil / CL: 支, 枝, 桿｜杆	(lead) pencil / CL: 支, 枝, 桿｜杆	
-School 2	铅	鉛	qiān	qiān	lead (chemistry)	lead (chemistry)	
-School 2	纸	紙	zhǐ	zhǐ	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	
-School 2	清楚		qīng chu	qīng chu	clear / distinct / to understand thoroughly / to be clear about	clear / distinct / to understand thoroughly / to be clear about	
-School 2	黑板		hēi bǎn	hēi bǎn	blackboard / CL: 塊｜块, 個｜个	blackboard / CL: 塊｜块, 個｜个	
-School 2	笔记本	筆記本	bǐ jì běn	bǐ jì běn	notebook (stationery) / CL: 本 / notebook (computing)	notebook (stationery) / CL: 本 / notebook (computing)	
-School 2	清		Qīng   qīng	Qīng   qīng	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge	
-School 2	楚		Chǔ   chǔ	Chǔ   chǔ	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)	
-School 2	板		bǎn   bǎn   pàn	bǎn   bǎn   pàn	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	
-School 2	体育馆	體育館	tǐ yù guǎn	tǐ yù guǎn	gym / gymnasium / stadium / CL: 個｜个	gym / gymnasium / stadium / CL: 個｜个	
-Future	化		huà	huà	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学	
-Future	算		suàn	suàn	to regard as / to figure / to calculate / to compute	to regard as / to figure / to calculate / to compute	
-Future	搬		bān	bān	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	
-Future	变	變	biàn	biàn	to change / to become different / to transform / to vary / rebellion	to change / to become different / to transform / to vary / rebellion	
-Future	打算		dǎ suàn	dǎ suàn	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	
-Future	变化	變化	biàn huà	biàn huà	change / variation / to change / to vary / CL: 個｜个	change / variation / to change / to vary / CL: 個｜个	
-Future	机会	機會	jī huì	jī huì	opportunity / chance / occasion / CL: 個｜个	opportunity / chance / occasion / CL: 個｜个	
-Future	留学	留學	liú xué	liú xué	to study abroad	to study abroad	
-Future	国家	國家	guó jiā	guó jiā	country / nation / state / CL: 個｜个	country / nation / state / CL: 個｜个	
-Future	选择	選擇	xuǎn zé	xuǎn zé	to select / to pick / choice / option / alternative	to select / to pick / choice / option / alternative	
-Future	选	選	xuǎn	xuǎn	to choose / to pick / to select / to elect	to choose / to pick / to select / to elect	
-Future	择	擇	zé	zé	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]	
-Future	结婚	結婚	jié hūn	jié hūn	to marry / to get married / CL: 次	to marry / to get married / CL: 次	
-Future	愿意	願意	yuàn yì	yuàn yì	to wish / to want / ready / willing (to do sth)	to wish / to want / ready / willing (to do sth)	
-Future	认真	認真	rèn zhēn	rèn zhēn	conscientious / earnest / serious / to take seriously / to take to heart	conscientious / earnest / serious / to take seriously / to take to heart	
-Future	结	結	jiē   jié	jiē   jié	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	
-Future	愿		yuàn   yuàn	yuàn   yuàn	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing	
-Future	婚		hūn	hūn	to marry / marriage / wedding / to take a wife	to marry / marriage / wedding / to take a wife	
-Future	当然	當然	dāng rán	dāng rán	only natural / as it should be / certainly / of course / without doubt	only natural / as it should be / certainly / of course / without doubt	
-Future	放心		fàng xīn	fàng xīn	to feel relieved / to feel reassured / to be at ease	to feel relieved / to feel reassured / to be at ease	
-Future	害怕		hài pà	hài pà	to be afraid / to be scared	to be afraid / to be scared	
-Future	当	噹	dāng   dāng   dàng	dāng   dāng   dàng	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)	
-Future	害		hài	hài	to do harm to / to cause trouble to / harm / evil / calamity	to do harm to / to cause trouble to / harm / evil / calamity	
-Future	怕		Pà   pà	Pà   pà	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps	
-Future	分手		fēn shǒu	fēn shǒu	to part company / to split up / to break up	to part company / to split up / to break up	
-Environment	境		jìng	jìng	border / place / condition / boundary / circumstances / territory	border / place / condition / boundary / circumstances / territory	
-Environment	环	環	Huán   huán	Huán   huán	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in	
-Environment	层	層	céng	céng	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	
-Environment	方便		fāng biàn	fāng biàn	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	
-Environment	环境	環境	huán jìng	huán jìng	environment / circumstances / surroundings / CL: 個｜个 / ambient	environment / circumstances / surroundings / CL: 個｜个 / ambient	
-Environment	花		Huā   huā	Huā   huā	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	
-Environment	草		cǎo	cǎo	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	
-Environment	太阳	太陽	tài yang	tài yang	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	
-Environment	星星		xīng xing	xīng xing	star in the sky	star in the sky	
-Environment	阳	陽	yáng	yáng	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯	
-Environment	安静	安靜	ān jìng	ān jìng	quiet / peaceful / calm	quiet / peaceful / calm	
-Environment	楼	樓	Lóu   lóu	Lóu   lóu	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	
-Environment	上		shǎng   shàng	shǎng   shàng	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	
-Environment	来	來	lái	lái	to come / to arrive / to come round / ever since / next	to come / to arrive / to come round / ever since / next	
-Environment	去		qù	qù	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	
-Environment	静	靜	jìng	jìng	still / calm / quiet / not moving	still / calm / quiet / not moving	
-Environment	声音	聲音	shēng yīn	shēng yīn	voice / sound / CL: 個｜个	voice / sound / CL: 個｜个	
-Environment	影响	影響	yǐng xiǎng	yǐng xiǎng	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	
-Environment	邻居	鄰居	lín jū	lín jū	neighbor / next door / CL: 個｜个	neighbor / next door / CL: 個｜个	
-Environment	下		xià	xià	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	
-Environment	声	聲	shēng	shēng	sound / voice / tone / noise / classifier for sounds	sound / voice / tone / noise / classifier for sounds	
-Environment	邻	鄰	lín	lín	neighbor / adjacent / close to	neighbor / adjacent / close to	
-Environment	响	響	xiǎng	xiǎng	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises	
-Environment	居		Jū   jī   jū	Jū   jī   jū	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms	
-Environment	垃圾		lā jī	lā jī	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	
-Environment	桶		tǒng	tǒng	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	
-Environment	丢	丟	diū	diū	to lose / to put aside / to throw	to lose / to put aside / to throw	
-Environment	脏	臟	zàng   zāng	zàng   zāng	viscera / (anatomy) organ  dirty / filthy	viscera / (anatomy) organ  dirty / filthy	
-Environment	垃		lā	lā	see 垃圾 / Taiwan pr. [le4]	see 垃圾 / Taiwan pr. [le4]	
-Environment	圾		jī	jī	see 垃圾 / Taiwan pr. [se4]	see 垃圾 / Taiwan pr. [se4]	
-Work	先生		Xiān sheng   xiān sheng	Xiān sheng   xiān sheng	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	
-Work	小姐		xiǎo jie	xiǎo jie	young lady / miss / (slang) prostitute / CL: 個｜个, 位	young lady / miss / (slang) prostitute / CL: 個｜个, 位	
-Work	经理	經理	jīng lǐ	jīng lǐ	manager / director / CL: 個｜个, 位, 名	manager / director / CL: 個｜个, 位, 名	
-Work	同事		tóng shì	tóng shì	colleague / co-worker / CL: 個｜个, 位	colleague / co-worker / CL: 個｜个, 位	
-Work	突然		tū rán	tū rán	sudden / abrupt / unexpected	sudden / abrupt / unexpected	
-Work	重要		zhòng yào	zhòng yào	important / significant / major	important / significant / major	
-Work	会议	會議	huì yì	huì yì	meeting / conference / CL: 場｜场, 屆｜届	meeting / conference / CL: 場｜场, 屆｜届	
-Work	突		tū	tū	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]	
-Work	重		chóng   zhòng	chóng   zhòng	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to	
-Work	议	議	yì	yì	to comment on / to discuss / to suggest	to comment on / to discuss / to suggest	
-Work	忘		wàng	wàng	to forget / to overlook / to neglect	to forget / to overlook / to neglect	
-Work	解决	解決	jiě jué	jiě jué	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	
-Work	办法	辦法	bàn fǎ	bàn fǎ	means / method / way (of doing sth) / CL: 條｜条, 個｜个	means / method / way (of doing sth) / CL: 條｜条, 個｜个	
-Work	相信		xiāng xìn	xiāng xìn	to be convinced (that sth is true) / to believe / to accept sth as true	to be convinced (that sth is true) / to believe / to accept sth as true	
-Work	决	決	jué	jué	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly	
-Work	法		Fǎ   fǎ	Fǎ   fǎ	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	
-Work	相		Xiāng   xiāng   xiàng	Xiāng   xiāng   xiàng	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	
-Work	解		Xiè   jiě   jiè   xiè	Xiè   jiě   jiè   xiè	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)	
-Culture	界		jiè	jiè	boundary / scope / extent / circles / group / kingdom (taxonomy)	boundary / scope / extent / circles / group / kingdom (taxonomy)	
-Culture	河		hé	hé	river / CL: 條｜条, 道	river / CL: 條｜条, 道	
-Culture	世		Shì   shì	Shì   shì	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble	
-Culture	黄河	黃河	Huáng Hé	Huáng Hé	Yellow River or Huang He	Yellow River or Huang He	
-Culture	动物	動物	dòng wù	dòng wù	animal / CL: 隻｜只, 群, 個｜个	animal / CL: 隻｜只, 群, 個｜个	
-Culture	有名		yǒu míng	yǒu míng	famous / well-known	famous / well-known	
-Culture	世界		shì jiè	shì jiè	world / CL: 個｜个	world / CL: 個｜个	
-Culture	长江	長江	Cháng Jiāng	Cháng Jiāng	Yangtze River, or Chang Jiang	Yangtze River, or Chang Jiang	
-Culture	江		Jiāng   jiāng	Jiāng   jiāng	surname Jiang  river / CL: 條｜条, 道	surname Jiang  river / CL: 條｜条, 道	
-Culture	多么	多麼	duō me	duō me	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	
-Culture	熊猫	熊貓	xióng māo	xióng māo	panda / CL: 隻｜只	panda / CL: 隻｜只	
-Culture	西安		Xī ān	Xī ān	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	
-Culture	啊		ā   á   ǎ   à   a	ā   á   ǎ   à   a	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	
-Culture	熊		Xióng   xióng	Xióng   xióng	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly	
-Culture	长城	長城	Cháng chéng	Cháng chéng	the Great Wall	the Great Wall	
-Culture	故宫	故宮	Gù gōng   gù gōng	Gù gōng   gù gōng	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	
-Culture	宫	宮	Gōng   gōng	Gōng   gōng	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale	
-Hobbies 3	山		Shān   shān	Shān   shān	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable	
-Hobbies 3	者		zhě	zhě	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this	
-Hobbies 3	爬		pá	pá	to crawl / to climb / to get up or sit up	to crawl / to climb / to get up or sit up	
-Hobbies 3	或		huò	huò	maybe / perhaps / might / possibly / or	maybe / perhaps / might / possibly / or	
-Hobbies 3	自行车	自行車	zì xíng chē	zì xíng chē	bicycle / bike / CL: 輛｜辆	bicycle / bike / CL: 輛｜辆	
-Hobbies 3	或者		huò zhě	huò zhě	or / possibly / maybe / perhaps	or / possibly / maybe / perhaps	
-Hobbies 3	爬山		pá shān	pá shān	to climb a mountain / to mountaineer / hiking / mountaineering	to climb a mountain / to mountaineer / hiking / mountaineering	
-Hobbies 3	功夫		gōng fu	gōng fu	skill / art / kung fu / labor / effort	skill / art / kung fu / labor / effort	
-Hobbies 3	功		gōng	gōng	meritorious deed or service / achievement / result / service / accomplishment / work (physics)	meritorious deed or service / achievement / result / service / accomplishment / work (physics)	
-Hobbies 3	对	對	duì	duì	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	
-Hobbies 3	文化		wén huà	wén huà	culture / civilization / cultural / CL: 個｜个, 種｜种	culture / civilization / cultural / CL: 個｜个, 種｜种	
-Hobbies 3	历史	歷史	lì shǐ	lì shǐ	history / CL: 門｜门, 段	history / CL: 門｜门, 段	
-Hobbies 3	兴趣	興趣	xìng qù	xìng qù	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个	
-Hobbies 3	感兴趣	感興趣	gǎn xìng qù	gǎn xìng qù	to be interested	to be interested	
-Hobbies 3	历	曆	lì   lì	lì   lì	calendar  to experience / to undergo / to pass through / all / each / every / history	calendar  to experience / to undergo / to pass through / all / each / every / history	
-Hobbies 3	趣		qù	qù	interesting / to interest	interesting / to interest	
-Hobbies 3	史		Shǐ   shǐ	Shǐ   shǐ	surname Shi  history / annals / title of an official historian in ancient China	surname Shi  history / annals / title of an official historian in ancient China	
-Hobbies 3	为了	為了	wèi le	wèi le	in order to / for the purpose of / so as to	in order to / for the purpose of / so as to	
-Hobbies 3	特别	特別	tè bié	tè bié	especially / special / particular / unusual	especially / special / particular / unusual	
-Hobbies 3	了解		liǎo jiě   liǎo jiě	liǎo jiě   liǎo jiě	to understand / to realize / to find out  to understand / to realize / to find out	to understand / to realize / to find out  to understand / to realize / to find out	
-Hobbies 3	麻将	麻將	má jiàng	má jiàng	mahjong / CL: 副	mahjong / CL: 副	
-Hobbies 3	特		tè	tè	special / unique / distinguished / especially / unusual / very	special / unique / distinguished / especially / unusual / very	
-Hobbies 3	麻		Má   má	Má   má	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb	
-Hobbies 3	将	將	jiāng   jiàng   qiāng	jiāng   jiàng   qiāng	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request	
-Hobbies 3	了		le   liǎo   liǎo	le   liǎo   liǎo	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	
-Health 3	顾	顧	Gù   gù	Gù   gù	surname Gu  to look after / to take into consideration / to attend to	surname Gu  to look after / to take into consideration / to attend to	
-Health 3	死		sǐ	sǐ	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	
-Health 3	闷	悶	mēn   mèn	mēn   mèn	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	
-Health 3	腿		tuǐ   tuǐ	tuǐ   tuǐ	leg / CL: 條｜条  hip bone / old variant of 腿	leg / CL: 條｜条  hip bone / old variant of 腿	
-Health 3	照		zhào	zhào	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	
-Health 3	照顾	照顧	zhào gu	zhào gu	to take care of / to show consideration / to attend to / to look after	to take care of / to show consideration / to attend to / to look after	
-Health 3	公斤		gōng jīn	gōng jīn	kilogram (kg)	kilogram (kg)	
-Health 3	着急	著急	zháo jí	zháo jí	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	
-Health 3	瘦		shòu	shòu	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	
-Health 3	斤		jīn	jīn	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g	
-Health 3	急		jí	jí	urgent / pressing / rapid / hurried / worried / to make (sb) anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious	
-Health 3	着	著	zhāo   zháo   zhe   zhuó	zhāo   zháo   zhe   zhuó	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	
-Health 3	咳嗽		ké sou	ké sou	to cough / CL: 陣｜阵	to cough / CL: 陣｜阵	
-Health 3	抽烟	抽煙	chōu yān	chōu yān	to smoke (a cigarette, tobacco)	to smoke (a cigarette, tobacco)	
-Health 3	咳		hāi   ké	hāi   ké	sound of sighing  cough	sound of sighing  cough	
-Health 3	嗽		sòu	sòu	cough	cough	
-Health 3	抽		chōu	chōu	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash	
-Health 3	烟	煙	yān	yān	cigarette or pipe tobacco / CL: 根 / smoke / mist / vapour / CL: 縷｜缕 / tobacco plant / (of the eyes) to be irritated by smoke	cigarette or pipe tobacco / CL: 根 / smoke / mist / vapour / CL: 縷｜缕 / tobacco plant / (of the eyes) to be irritated by smoke	
-Travel 3	际	際	jì	jì	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)	
-Travel 3	柜		jǔ   guì	jǔ   guì	Salix multinervis  cupboard / cabinet / wardrobe	Salix multinervis  cupboard / cabinet / wardrobe	
-Travel 3	转	轉	zhuǎi   zhuǎn   zhuàn	zhuǎi   zhuǎn   zhuàn	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions	
-Travel 3	转机	轉機	zhuǎn jī	zhuǎn jī	(to take) a turn for the better / to change planes	(to take) a turn for the better / to change planes	
-Travel 3	柜台	櫃檯	guì tái	guì tái	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	
-Travel 3	国际	國際	guó jì	guó jì	international	international	
-Travel 3	换钱	換錢	huàn qián	huàn qián	to change money / to sell	to change money / to sell	
-Travel 3	银行	銀行	yín háng	yín háng	bank / CL: 家, 個｜个	bank / CL: 家, 個｜个	
-Travel 3	充电	充電	chōng diàn	chōng diàn	to recharge batteries / fig. to rest and recuperate	to recharge batteries / fig. to rest and recuperate	
-Travel 3	国内	國內	guó nèi	guó nèi	domestic / internal (to a country) / civil	domestic / internal (to a country) / civil	
-Travel 3	银	銀	yín	yín	silver / silver-colored / relating to money or currency	silver / silver-colored / relating to money or currency	
-Travel 3	充		chōng	chōng	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full	
-Travel 3	内	內	nèi	nèi	inside / inner / internal / within / interior	inside / inner / internal / within / interior	
-Travel 3	行		háng   xíng	háng   xíng	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	
-Travel 3	充值		chōng zhí	chōng zhí	to recharge (money onto a card)	to recharge (money onto a card)	
-Travel 3	漫游	漫遊	màn yóu	màn yóu	to travel around / to roam / (mobile telephony) roaming	to travel around / to roam / (mobile telephony) roaming	
-Travel 3	电话卡	電話卡	diàn huà kǎ	diàn huà kǎ	telephone card	telephone card	
-Travel 3	值		zhí	zhí	value / (to be) worth / to happen to / to be on duty	value / (to be) worth / to happen to / to be on duty	
-Travel 3	订房	訂房	dìng fáng	dìng fáng	to reserve a room	to reserve a room	
-Travel 3	退房		tuì fáng	tuì fáng	to check out of a hotel room	to check out of a hotel room	
-Travel 3	取消		qǔ xiāo	qǔ xiāo	to cancel / cancellation	to cancel / cancellation	
-Travel 3	导游	導遊	dǎo yóu	dǎo yóu	tour guide / guidebook / to conduct a tour	tour guide / guidebook / to conduct a tour	
-Travel 3	订	訂	dìng	dìng	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	
-Travel 3	取		qǔ	qǔ	to take / to get / to choose / to fetch	to take / to get / to choose / to fetch	
-Travel 3	导	導	dǎo	dǎo	to transmit / to lead / to guide / to conduct / to direct	to transmit / to lead / to guide / to conduct / to direct	
-Travel 3	消		xiāo	xiāo	to disappear / to vanish / to eliminate / to spend (time) / have to / need	to disappear / to vanish / to eliminate / to spend (time) / have to / need	
-Languages 3	答		dā   dá	dā   dá	to answer / to agree  reply / answer / return / respond / echo	to answer / to agree  reply / answer / return / respond / echo	
-Languages 3	句		jù	jù	sentence / clause / phrase / classifier for phrases or lines of verse	sentence / clause / phrase / classifier for phrases or lines of verse	
-Languages 3	单	單	Shàn   dān	Shàn   dān	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	
-Languages 3	简	簡	jiǎn	jiǎn	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)	
-Languages 3	简单	簡單	jiǎn dān	jiǎn dān	simple / not complicated	simple / not complicated	
-Languages 3	句子		jù zi	jù zi	sentence / CL: 個｜个	sentence / CL: 個｜个	
-Languages 3	回答		huí dá	huí dá	to reply / to answer / the answer / CL: 個｜个	to reply / to answer / the answer / CL: 個｜个	
-Languages 3	词典	詞典	cí diǎn	cí diǎn	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	
-Languages 3	应用	應用	yìng yòng	yìng yòng	to use / to apply / application / applicable	to use / to apply / application / applicable	
-Languages 3	语法	語法	yǔ fǎ	yǔ fǎ	grammar	grammar	
-Languages 3	流利		liú lì	liú lì	fluent	fluent	
-Languages 3	词	詞	cí	cí	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首	
-Languages 3	流		liú	liú	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade	
-Languages 3	利		Lì   lì	Lì   lì	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	
-Languages 3	典		diǎn	diǎn	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn	
-Languages 3	应	應	Yìng   yīng   yìng	Yìng   yīng   yìng	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	
-Languages 3	下载	下載	xià zǎi	xià zǎi	to download / also pr. [xia4 zai4]	to download / also pr. [xia4 zai4]	
-Languages 3	多邻国		duō lín guó	duō lín guó	duolingo	duolingo	
-Languages 3	翻译	翻譯	fān yì	fān yì	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	
-Languages 3	翻		fān	fān	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross	
-Languages 3	载	載	zǎi   zài	zǎi   zài	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously	
-Languages 3	译	譯	yì	yì	to translate / to interpret	to translate / to interpret	
-House	把		bǎ   bà	bǎ   bà	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	
-House	灯	燈	dēng	dēng	lamp / light / lantern / CL: 盞｜盏	lamp / light / lantern / CL: 盞｜盏	
-House	空调	空調	kōng tiáo	kōng tiáo	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	
-House	空		kōng   kòng	kōng   kòng	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	
-House	放		fàng	fàng	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	
-House	画	畫	huà	huà	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	
-House	厨房	廚房	chú fáng	chú fáng	kitchen / CL: 間｜间	kitchen / CL: 間｜间	
-House	客厅	客廳	kè tīng	kè tīng	drawing room (room for arriving guests) / living room / CL: 間｜间	drawing room (room for arriving guests) / living room / CL: 間｜间	
-House	厨	廚	chú	chú	kitchen	kitchen	
-House	厅	廳	tīng	tīng	(reception) hall / living room / office / provincial government department	(reception) hall / living room / office / provincial government department	
-House	客人		kè rén	kè rén	visitor / guest / customer / client / CL: 位	visitor / guest / customer / client / CL: 位	
-House	打扫	打掃	dǎ sǎo	dǎ sǎo	to clean / to sweep	to clean / to sweep	
-House	干净	乾淨	gān jìng	gān jìng	clean / neat	clean / neat	
-House	扫	掃	sǎo   sào	sǎo   sào	to sweep  broom	to sweep  broom	
-House	净	淨	jìng	jìng	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role	
-House	电梯	電梯	diàn tī	diàn tī	elevator / escalator / CL: 臺｜台, 部	elevator / escalator / CL: 臺｜台, 部	
-House	坏	壞	huài	huài	bad / spoiled / broken / to break down / (suffix) to the utmost	bad / spoiled / broken / to break down / (suffix) to the utmost	
-House	被		bèi	bèi	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	
-House	厕所	廁所	cè suǒ	cè suǒ	toilet / lavatory / CL: 間｜间, 處｜处	toilet / lavatory / CL: 間｜间, 處｜处	
-House	厕	廁	cè   sì	cè   sì	restroom / toilet / lavatory  see 茅廁｜茅厕	restroom / toilet / lavatory  see 茅廁｜茅厕	
-House	梯		tī	tī	ladder / stairs	ladder / stairs	
-Exam	寒		hán	hán	cold / poor / to tremble	cold / poor / to tremble	
-Exam	暑		shǔ	shǔ	heat / hot weather / summer heat	heat / hot weather / summer heat	
-Exam	复	復	fù   fù	fù   fù	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate	
-Exam	记得	記得	jì de	jì de	to remember	to remember	
-Exam	复习	復習	fù xí	fù xí	to review / revision / CL: 次	to review / revision / CL: 次	
-Exam	数学	數學	shù xué	shù xué	mathematics / mathematical	mathematics / mathematical	
-Exam	放假		fàng jià	fàng jià	to have a holiday or vacation	to have a holiday or vacation	
-Exam	暑假		shǔ jià	shǔ jià	summer vacation / CL: 個｜个	summer vacation / CL: 個｜个	
-Exam	寒假		hán jià	hán jià	winter vacation	winter vacation	
-Exam	终于	終於	zhōng yú	zhōng yú	at last / in the end / finally / eventually	at last / in the end / finally / eventually	
-Exam	结束	結束	jié shù	jié shù	termination / to finish / to end / to conclude / to close	termination / to finish / to end / to conclude / to close	
-Exam	放松	放鬆	fàng sōng	fàng sōng	to loosen / to relax	to loosen / to relax	
-Exam	大学	大學	Dà xué   dà xué	Dà xué   dà xué	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	
-Exam	终	終	zhōng	zhōng	end / finish	end / finish	
-Exam	结	結	jiē   jié	jiē   jié	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	
-Exam	松		Sōng   sōng   sōng	Sōng   sōng   sōng	surname Song  pine / CL: 棵  loose / to loosen / to relax	surname Song  pine / CL: 棵  loose / to loosen / to relax	
-Exam	于		Yú   yú   yú	Yú   yú   yú	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of	
-Exam	束		Shù   shù	Shù   shù	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control	
-Exam	成绩	成績	chéng jì	chéng jì	achievement / performance records / grades / CL: 項｜项, 個｜个	achievement / performance records / grades / CL: 項｜项, 個｜个	
-Exam	担心	擔心	dān xīn	dān xīn	anxious / worried / uneasy / to worry / to be anxious	anxious / worried / uneasy / to worry / to be anxious	
-Exam	为	為	wéi   wèi	wéi   wèi	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	
-Exam	专业	專業	zhuān yè	zhuān yè	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	
-Exam	成		Chéng   chéng	Chéng   chéng	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	
-Exam	担	擔	dān   dàn	dān   dàn	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole	
-Exam	专	專	zhuān	zhuān	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized	
-Exam	绩	績	jì	jì	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]	
-Travel 4	景		Jǐng   jǐng	Jǐng   jǐng	surname Jing  bright / circumstance / scenery	surname Jing  bright / circumstance / scenery	
-Travel 4	街		jiē	jiē	street / CL: 條｜条	street / CL: 條｜条	
-Travel 4	地图	地圖	dì tú	dì tú	map / CL: 張｜张, 本	map / CL: 張｜张, 本	
-Travel 4	拿		ná	ná	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	
-Travel 4	出		chū	chū	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	
-Travel 4	街道		jiē dào	jiē dào	street / CL: 條｜条 / subdistrict / residential district	street / CL: 條｜条 / subdistrict / residential district	
-Travel 4	红绿灯	紅綠燈	hóng lǜ dēng	hóng lǜ dēng	traffic light / traffic signal	traffic light / traffic signal	
-Travel 4	风景	風景	fēng jǐng	fēng jǐng	scenery / landscape / CL: 個｜个	scenery / landscape / CL: 個｜个	
-Travel 4	司机	司機	sī jī	sī jī	chauffeur / driver / CL: 個｜个	chauffeur / driver / CL: 個｜个	
-Travel 4	接		jiē	jiē	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	
-Travel 4	免费	免費	miǎn fèi	miǎn fèi	free (of charge)	free (of charge)	
-Travel 4	打车	打車	dǎ chē	dǎ chē	to take a taxi (in town) / to hitch a lift	to take a taxi (in town) / to hitch a lift	
-Travel 4	观光	觀光	guān guāng	guān guāng	to tour / sightseeing / tourism	to tour / sightseeing / tourism	
-Travel 4	免		miǎn	miǎn	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	
-Travel 4	观	觀	Guàn   guān   guàn	Guàn   guān   guàn	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform	
-Travel 4	光		guāng	guāng	light / ray / CL: 道 / bright / only / merely / to use up	light / ray / CL: 道 / bright / only / merely / to use up	
-Travel 4	小心		xiǎo xīn	xiǎo xīn	to be careful / to take care	to be careful / to take care	
-Travel 4	过	過	Guò   guò   guo	Guò   guò   guo	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	
-Travel 4	时差	時差	shí chā	shí chā	time difference / time lag / jet lag	time difference / time lag / jet lag	
-Travel 4	马路	馬路	mǎ lù	mǎ lù	street / road / CL: 條｜条	street / road / CL: 條｜条	
-Travel 4	参观	參觀	cān guān	cān guān	to look around / to tour / to visit	to look around / to tour / to visit	
-Travel 4	博物馆	博物館	bó wù guǎn	bó wù guǎn	museum	museum	
-Travel 4	博		bó	bó	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble	
-Travel 4	差		chā   chà   chāi	chā   chà   chāi	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	
-Travel 4	安排		ān pái	ān pái	to arrange / to plan / to set up / arrangements / plans	to arrange / to plan / to set up / arrangements / plans	
-Travel 4	活动	活動	huó dòng	huó dòng	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	
-Travel 4	表演		biǎo yǎn	biǎo yǎn	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	
-Travel 4	海边	海邊	hǎi biān	hǎi biān	coast / seaside / seashore / beach	coast / seaside / seashore / beach	
-Travel 4	排		pái	pái	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	
-Travel 4	活		huó	huó	to live / alive / living / work / workmanship	to live / alive / living / work / workmanship	
-Travel 4	演		yǎn	yǎn	to develop / to evolve / to practice / to perform / to play / to act	to develop / to evolve / to practice / to perform / to play / to act	
-Communication 2	邮	郵	yóu	yóu	post (office) / mail	post (office) / mail	
-Communication 2	刚才	剛才	gāng cái   gāng cái	gāng cái   gāng cái	just now / a moment ago  (just) a moment ago	just now / a moment ago  (just) a moment ago	
-Communication 2	电子邮件	電子郵件	diàn zǐ yóu jiàn	diàn zǐ yóu jiàn	email / CL: 封, 份	email / CL: 封, 份	
-Communication 2	回		huí   huí	huí   huí	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	
-Communication 2	发	發	fā   fà	fā   fà	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	
-Communication 2	主要		zhǔ yào	zhǔ yào	main / principal / major / primary	main / principal / major / primary	
-Communication 2	短信		duǎn xìn	duǎn xìn	text message / SMS	text message / SMS	
-Communication 2	关于	關於	guān yú	guān yú	pertaining to / concerning / with regard to / about / a matter of	pertaining to / concerning / with regard to / about / a matter of	
-Communication 2	主		zhǔ	zhǔ	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)	
-Communication 2	登录	登錄	dēng lù	dēng lù	to register / to log in	to register / to log in	
-Communication 2	密码	密碼	mì mǎ	mì mǎ	secret code / ciphertext / password / PIN	secret code / ciphertext / password / PIN	
-Communication 2	信号	信號	xìn hào	xìn hào	signal	signal	
-Communication 2	登		dēng	dēng	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)	
-Communication 2	密		Mì   mì	Mì   mì	surname Mi / name of an ancient state  secret / confidential / close / thick / dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense	
-Communication 2	码	碼	mǎ	mǎ	weight / number / code / to pile / to stack / classifier for length or distance (yard), happenings etc	weight / number / code / to pile / to stack / classifier for length or distance (yard), happenings etc	
-Communication 2	录	錄	Lù   lù	Lù   lù	surname Lu  diary / record / to hit / to copy	surname Lu  diary / record / to hit / to copy	
-Communication 2	段		Duàn   duàn	Duàn   duàn	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	
-Communication 2	其实	其實	qí shí	qí shí	actually / in fact / really	actually / in fact / really	
-Communication 2	过去	過去	guò qù   guò qu	guò qù   guò qu	(in the) past / former / previous / to go over / to pass by  (verb suffix)	(in the) past / former / previous / to go over / to pass by  (verb suffix)	
-Communication 2	谈	談	Tán   tán	Tán   tán	surname Tan  to speak / to talk / to converse / to chat / to discuss	surname Tan  to speak / to talk / to converse / to chat / to discuss	
-Communication 2	实	實	shí	shí	real / true / honest / really / solid / fruit / seed / definitely	real / true / honest / really / solid / fruit / seed / definitely	
-Work 2	同意		tóng yì	tóng yì	to agree / to consent / to approve	to agree / to consent / to approve	
-Work 2	决定	決定	jué dìng	jué dìng	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	
-Work 2	根据	根據	gēn jù	gēn jù	according to / based on / basis / foundation / CL: 個｜个	according to / based on / basis / foundation / CL: 個｜个	
-Work 2	升职	升職	shēng zhí	shēng zhí	to get promoted (at work etc) / promotion	to get promoted (at work etc) / promotion	
-Work 2	定		dìng	dìng	to set / to fix / to determine / to decide / to order	to set / to fix / to determine / to decide / to order	
-Work 2	根		gēn	gēn	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)	
-Work 2	据		jū   jù	jū   jù	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	
-Work 2	升		shēng	shēng	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗	
-Work 2	职	職	zhí	zhí	office / duty	office / duty	
-Work 2	满意	滿意	mǎn yì	mǎn yì	satisfied / pleased / to one's satisfaction	satisfied / pleased / to one's satisfaction	
-Work 2	认为	認為	rèn wéi	rèn wéi	to believe / to think / to consider / to feel	to believe / to think / to consider / to feel	
-Work 2	出差		chū chāi	chū chāi	to go on an official or business trip	to go on an official or business trip	
-Work 2	表现	表現	biǎo xiàn	biǎo xiàn	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	
-Work 2	满	滿	Mǎn   mǎn	Mǎn   mǎn	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented	
-Work 2	为	為	wéi   wèi	wéi   wèi	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	
-Work 2	差		chā   chà   chāi	chā   chà   chāi	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	
-Work 2	老板	老闆	Lǎo bǎn   lǎo bǎn	Lǎo bǎn   lǎo bǎn	Robam (brand)  boss / business proprietor / CL: 個｜个	Robam (brand)  boss / business proprietor / CL: 個｜个	
-Work 2	麻烦	麻煩	má fan	má fan	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	
-Work 2	开会	開會	kāi huì	kāi huì	to hold a meeting / to attend a meeting	to hold a meeting / to attend a meeting	
-Work 2	面试	面試	miàn shì	miàn shì	to be interviewed (as a candidate) / interview	to be interviewed (as a candidate) / interview	
-Work 2	板		bǎn   bǎn   pàn	bǎn   bǎn   pàn	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	
-Work 2	烦	煩	fán	fán	to feel vexed / to bother / to trouble / superfluous and confusing / edgy	to feel vexed / to bother / to trouble / superfluous and confusing / edgy	
-Festivals	饼	餅	bǐng	bǐng	round flat cake / cookie / cake / pastry / CL: 張｜张	round flat cake / cookie / cake / pastry / CL: 張｜张	
-Festivals	园	園	Yuán   yuán	Yuán   yuán	surname Yuan  land used for growing plants / site used for public recreation	surname Yuan  land used for growing plants / site used for public recreation	
-Festivals	月亮		yuè liang	yuè liang	the moon	the moon	
-Festivals	月饼	月餅	yuè bǐng	yuè bǐng	mooncake (esp. for the Mid-Autumn Festival)	mooncake (esp. for the Mid-Autumn Festival)	
-Festivals	中秋节	中秋節	Zhōng qiū jié	Zhōng qiū jié	the Mid-Autumn Festival on 15th of 8th lunar month	the Mid-Autumn Festival on 15th of 8th lunar month	
-Festivals	圆	圓	yuán	yuán	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify	
-Festivals	恭喜		gōng xǐ	gōng xǐ	congratulations / greetings	congratulations / greetings	
-Festivals	红包	紅包	hóng bāo	hóng bāo	money wrapped in red as a gift / bonus payment / kickback / bribe	money wrapped in red as a gift / bonus payment / kickback / bribe	
-Festivals	汤圆	湯圓	tāng yuán	tāng yuán	boiled balls of glutinous rice flour, eaten during the Lantern Festival	boiled balls of glutinous rice flour, eaten during the Lantern Festival	
-Festivals	聚会	聚會	jù huì	jù huì	party / gathering / to meet / to get together	party / gathering / to meet / to get together	
-Festivals	发财	發財	fā cái	fā cái	to get rich	to get rich	
-Festivals	恭		gōng	gōng	respectful	respectful	
-Festivals	聚		jù	jù	to congregate / to assemble / to mass / to gather together / to amass / to polymerize	to congregate / to assemble / to mass / to gather together / to amass / to polymerize	
-Festivals	财	財	cái	cái	money / wealth / riches / property / valuables	money / wealth / riches / property / valuables	
-Festivals	端午节	端午節	Duān wǔ jié	Duān wǔ jié	Dragon Boat Festival (5th day of the 5th lunar month)	Dragon Boat Festival (5th day of the 5th lunar month)	
-Festivals	粽子		zòng zi	zòng zi	glutinous rice and choice of filling wrapped in leaves and boiled	glutinous rice and choice of filling wrapped in leaves and boiled	
-Festivals	划		huá   huá   huà	huá   huá   huà	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	
-Festivals	龙舟	龍舟	lóng zhōu	lóng zhōu	dragon boat / imperial boat	dragon boat / imperial boat	
-Festivals	端		duān	duān	end / extremity / item / port / to hold sth level with both hands / to carry / regular	end / extremity / item / port / to hold sth level with both hands / to carry / regular	
-Festivals	粽		zòng	zòng	rice dumplings wrapped in leaves	rice dumplings wrapped in leaves	
-Festivals	龙	龍	Lóng   lóng	Lóng   lóng	surname Long  dragon / CL: 條｜条 / imperial	surname Long  dragon / CL: 條｜条 / imperial	
-Festivals	舟		zhōu	zhōu	boat	boat	
-Gourmet 2	珠		zhū	zhū	bead / pearl / CL: 粒, 顆｜颗	bead / pearl / CL: 粒, 顆｜颗	
-Gourmet 2	汤	湯	Tāng   shāng   tāng	Tāng   shāng   tāng	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled	
-Gourmet 2	酸		suān	suān	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid	
-Gourmet 2	珍		zhēn	zhēn	precious thing / treasure / culinary delicacy / rare / valuable / to value highly	precious thing / treasure / culinary delicacy / rare / valuable / to value highly	
-Gourmet 2	珍珠奶茶		zhēn zhū nǎi chá	zhēn zhū nǎi chá	pearl milk tea / tapioca milk tea / bubble milk tea	pearl milk tea / tapioca milk tea / bubble milk tea	
-Gourmet 2	酸辣汤	酸辣湯	suān là tāng	suān là tāng	hot and sour soup / sour and spicy soup	hot and sour soup / sour and spicy soup	
-Gourmet 2	北京烤鸭	北京烤鴨	Běi jīng kǎo yā	Běi jīng kǎo yā	Peking Duck	Peking Duck	
-Gourmet 2	春卷	春捲	chūn juǎn	chūn juǎn	egg roll / spring roll	egg roll / spring roll	
-Gourmet 2	豆花		dòu huā	dòu huā	jellied tofu / soft bean curd	jellied tofu / soft bean curd	
-Gourmet 2	烤		kǎo	kǎo	to roast / to bake / to broil	to roast / to bake / to broil	
-Gourmet 2	鸭	鴨	yā	yā	duck / CL: 隻｜只 / (slang) male prostitute	duck / CL: 隻｜只 / (slang) male prostitute	
-Gourmet 2	卷		juǎn   juàn   juǎn	juǎn   juàn   juǎn	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll	
-Gourmet 2	宫保鸡丁	宮保雞丁	gōng bǎo jī dīng	gōng bǎo jī dīng	Kung Pao Chicken / spicy diced chicken	Kung Pao Chicken / spicy diced chicken	
-Gourmet 2	卤肉饭		lǔ ròu fàn	lǔ ròu fàn	Braised pork on rice	Braised pork on rice	
-Gourmet 2	馒头	饅頭	mán tou	mán tou	steamed roll / steamed bun / steamed bread / CL: 個｜个	steamed roll / steamed bun / steamed bread / CL: 個｜个	
-Gourmet 2	保		Bǎo   bǎo	Bǎo   bǎo	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure	
-Gourmet 2	卤	滷	lǔ   lǔ	lǔ   lǔ	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid	
-Gourmet 2	馒	饅	mán	mán	steamed bread	steamed bread	
-Gourmet 2	丁		Dīng   dīng	Dīng   dīng	surname Ding  fourth of the ten Heavenly Stems 十天干 / fourth in order / letter 'D' or roman 'IV' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 195° / butyl / cubes (of food)	surname Ding  fourth of the ten Heavenly Stems 十天干 / fourth in order / letter 'D' or roman 'IV' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 195° / butyl / cubes (of food)	
-Internet Slang	豪		háo	háo	grand / heroic	grand / heroic	
-Internet Slang	宅		zhái	zhái	residence / (coll.) to stay in at home / to hang around at home	residence / (coll.) to stay in at home / to hang around at home	
-Internet Slang	土		Tǔ   tǔ	Tǔ   tǔ	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音	
-Internet Slang	土豪		tǔ háo	tǔ háo	local tyrant / local strong man / (slang) nouveau riche	local tyrant / local strong man / (slang) nouveau riche	
-Internet Slang	吃货	吃貨	chī huò	chī huò	chowhound / foodie / a good-for-nothing	chowhound / foodie / a good-for-nothing	
-Internet Slang	宅男		zhái nán	zhái nán	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	
-Internet Slang	菜鸟	菜鳥	cài niǎo	cài niǎo	(coll.) sb new to a particular subject / rookie / beginner / newbie	(coll.) sb new to a particular subject / rookie / beginner / newbie	
-Internet Slang	美图		měi tú	měi tú			
-Internet Slang	萌		méng	méng	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	
-Internet Slang	自拍		zì pāi	zì pāi	to take a picture or video of oneself	to take a picture or video of oneself	
-Internet Slang	囧		jiǒng	jiǒng	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	
-Internet Slang	美眉		měi méi	měi méi	(coll.) pretty girl	(coll.) pretty girl	
-Internet Slang	高富帅	高富帥	gāo fù shuài	gāo fù shuài	'Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	'Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	
-Internet Slang	眉		méi	méi	eyebrow / upper margin	eyebrow / upper margin	
-Internet Slang	富		Fù   fù	Fù   fù	surname Fu  rich / abundant / wealthy	surname Fu  rich / abundant / wealthy	
-Internet Slang	刷		shuā   shuà	shuā   shuà	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	
-Internet Slang	微博		wēi bó	wēi bó	micro-blogging / microblog	micro-blogging / microblog	
-Internet Slang	微信		Wēi xìn	Wēi xìn	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	
-Internet Slang	朋友圈		Péng you quān	Péng you quān	Moments (social networking function of smartphone app WeChat 微信)	Moments (social networking function of smartphone app WeChat 微信)	
-Internet Slang	微		Wēi   wēi	Wēi   wēi	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]	
-Internet Slang	圈		juān   juàn   quān	juān   juàn   quān	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle	
-Internet Slang	关注	關注	guān zhù	guān zhù	to pay attention to / to follow sth closely / concern / interest / attention	to pay attention to / to follow sth closely / concern / interest / attention	
-Internet Slang	点	點	diǎn	diǎn	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	
-Internet Slang	赞	贊	zàn	zàn	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	
-Internet Slang	转发	轉發	zhuǎn fā	zhuǎn fā	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	
-Internet Slang	好友		hǎo yǒu	hǎo yǒu	close friend / pal / (social networking website) friend / CL: 個｜个	close friend / pal / (social networking website) friend / CL: 個｜个	
-Internet Slang	加		Jiā   jiā	Jiā   jiā	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	
-Internet Slang	粉丝	粉絲	fěn sī	fěn sī	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	
-Internet Slang	分享		fēn xiǎng	fēn xiǎng	to share (let others have some of sth good)	to share (let others have some of sth good)	
-Internet Slang	评论	評論	píng lùn	píng lùn	to comment on / to discuss / comment / commentary / CL: 篇	to comment on / to discuss / comment / commentary / CL: 篇	
-Internet Slang	粉		fěn	fěn	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink	
-Internet Slang	丝	絲	sī	sī	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc	
-Internet Slang	享		xiǎng	xiǎng	to enjoy / to benefit / to have the use of	to enjoy / to benefit / to have the use of	
-Internet Slang	评	評	píng	píng	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)	
-Internet Slang	论	論	Lún   lùn	Lún   lùn	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)	
-Business 1	销	銷	xiāo	xiāo	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin	
-Business 1	据		jū   jù	jū   jù	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	
-Business 1	收据	收據	shōu jù	shōu jù	receipt / CL: 張｜张	receipt / CL: 張｜张	
-Business 1	报销	報銷	bào xiāo	bào xiāo	to submit an expense account / to apply for reimbursement / to write off / to wipe out	to submit an expense account / to apply for reimbursement / to write off / to wipe out	
-Business 1	费用	費用	fèi yòng	fèi yòng	cost / expenditure / expense / CL: 筆｜笔, 個｜个	cost / expenditure / expense / CL: 筆｜笔, 個｜个	
-Business 1	尽快	儘快	jǐn kuài   jìn kuài	jǐn kuài   jìn kuài	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	
-Business 1	回复	回復	huí fù	huí fù	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	
-Business 1	报告	報告	bào gào	bào gào	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	
-Business 1	协议	協議	xié yì	xié yì	agreement / pact / protocol / CL: 項｜项	agreement / pact / protocol / CL: 項｜项	
-Business 1	尽	儘	jǐn   jìn	jǐn   jìn	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely	
-Business 1	协	協	xié	xié	to cooperate / to harmonize / to help / to assist / to join	to cooperate / to harmonize / to help / to assist / to join	
-Business 1	议	議	yì	yì	to comment on / to discuss / to suggest	to comment on / to discuss / to suggest	
-Business 1	合同		hé tong	hé tong	(business) contract / CL: 個｜个	(business) contract / CL: 個｜个	
-Business 1	项目	項目	xiàng mù	xiàng mù	item / project / (sports) event / CL: 個｜个	item / project / (sports) event / CL: 個｜个	
-Business 1	签名	簽名	qiān míng	qiān míng	to sign (one's name with a pen etc) / to autograph / signature	to sign (one's name with a pen etc) / to autograph / signature	
-Business 1	汇报	匯報	huì bào   huì bào	huì bào   huì bào	to report / to give an account of / to collect information and report back  to report / to give an account of / report	to report / to give an account of / to collect information and report back  to report / to give an account of / report	
-Business 1	合		gě   hé	gě   hé	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒	
-Business 1	项	項	Xiàng   xiàng	Xiàng   xiàng	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc	
-Business 1	汇	匯	huì   huì	huì   huì	to remit / to converge (of rivers) / to exchange  class / collection	to remit / to converge (of rivers) / to exchange  class / collection	
-Business 1	广告	廣告	guǎng gào	guǎng gào	to advertise / a commercial / advertisement / CL: 項｜项	to advertise / a commercial / advertisement / CL: 項｜项	
-Business 1	预算	預算	yù suàn	yù suàn	budget	budget	
-Business 1	资本	資本	zī běn	zī běn	capital (economics)	capital (economics)	
-Business 1	低		dī	dī	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	
-Business 1	广	廣	Guǎng   guǎng	Guǎng   guǎng	surname Guang  wide / numerous / to spread	surname Guang  wide / numerous / to spread	
-Business 1	资	資	zī	zī	resources / capital / to provide / to supply / to support / money / expense	resources / capital / to provide / to supply / to support / money / expense	
-Business 2	险	險	xiǎn	xiǎn	danger / dangerous / rugged	danger / dangerous / rugged	
-Business 2	投		tóu	tóu	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of	
-Business 2	保险	保險	bǎo xiǎn	bǎo xiǎn	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	
-Business 2	风险	風險	fēng xiǎn	fēng xiǎn	risk / hazard	risk / hazard	
-Business 2	投资	投資	tóu zī	tóu zī	investment / to invest	investment / to invest	
-Business 2	律师	律師	lǜ shī	lǜ shī	lawyer	lawyer	
-Business 2	版权	版權	bǎn quán	bǎn quán	copyright	copyright	
-Business 2	咨询	咨詢	zī xún	zī xún	to consult / to seek advice / consultation / (sales) inquiry (formal)	to consult / to seek advice / consultation / (sales) inquiry (formal)	
-Business 2	律		Lǜ   lǜ	Lǜ   lǜ	surname Lü  law	surname Lü  law	
-Business 2	版		bǎn	bǎn	a register / block of printing / edition / version / page	a register / block of printing / edition / version / page	
-Business 2	咨		zī	zī	to consult	to consult	
-Business 2	权	權	Quán   quán	Quán   quán	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary	
-Business 2	询	詢	xún	xún	to ask about / to inquire about	to ask about / to inquire about	
-Business 2	保持		bǎo chí	bǎo chí	to keep / to maintain / to hold / to preserve	to keep / to maintain / to hold / to preserve	
-Business 2	联系	聯繫	lián xì	lián xì	connection / contact / relation / to get in touch with / to integrate / to link / to touch	connection / contact / relation / to get in touch with / to integrate / to link / to touch	
-Business 2	贵	貴	guì	guì	expensive / noble / precious / (honorific) your	expensive / noble / precious / (honorific) your	
-Business 2	免		miǎn	miǎn	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	
-Business 2	联	聯	lián	lián	to ally / to unite / to join / (poetry) antithetical couplet	to ally / to unite / to join / (poetry) antithetical couplet	
-Business 2	持		chí	chí	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control	
-Business 2	合作		hé zuò	hé zuò	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	
-Business 2	愉快		yú kuài	yú kuài	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	
-Business 2	辛苦		xīn kǔ	xīn kǔ	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	
-Business 2	感谢	感謝	gǎn xiè	gǎn xiè	(express) thanks / gratitude / grateful / thankful / thanks	(express) thanks / gratitude / grateful / thankful / thanks	
-Business 2	愉		yú	yú	pleased	pleased	
-Business 2	辛		Xīn   xīn	Xīn   xīn	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa	
-Emergency	伤	傷	shāng	shāng	to injure / injury / wound	to injure / injury / wound	
-Emergency	受		shòu	shòu	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)	
-Emergency	护	護	hù	hù	to protect	to protect	
-Emergency	救		jiù	jiù	to save / to assist / to rescue	to save / to assist / to rescue	
-Emergency	警		jǐng	jǐng	to alert / to warn / police	to alert / to warn / police	
-Emergency	报警	報警	bào jǐng	bào jǐng	to sound an alarm / to report sth to the police	to sound an alarm / to report sth to the police	
-Emergency	救护车	救護車	jiù hù chē	jiù hù chē	ambulance / CL: 輛｜辆	ambulance / CL: 輛｜辆	
-Emergency	受伤	受傷	shòu shāng	shòu shāng	to sustain injuries / wounded (in an accident etc) / harmed	to sustain injuries / wounded (in an accident etc) / harmed	
-Emergency	救命		jiù mìng	jiù mìng	to save sb's life / (interj.) Help! / Save me!	to save sb's life / (interj.) Help! / Save me!	
-Emergency	发生	發生	fā shēng	fā shēng	to happen / to occur / to take place / to break out	to happen / to occur / to take place / to break out	
-Emergency	意外		yì wài	yì wài	unexpected / accident / mishap / CL: 個｜个	unexpected / accident / mishap / CL: 個｜个	
-Emergency	严重	嚴重	yán zhòng	yán zhòng	grave / serious / severe / critical	grave / serious / severe / critical	
-Emergency	严	嚴	Yán   yán	Yán   yán	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father	
-Emergency	命		mìng	mìng	life / fate / order or command / to assign a name, title etc	life / fate / order or command / to assign a name, title etc	
-Emergency	偷		tōu	tōu	to steal / to pilfer / to snatch / thief / stealthily	to steal / to pilfer / to snatch / thief / stealthily	
-Emergency	事		shì	shì	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	
-Emergency	警察		jǐng chá	jǐng chá	police / police officer / CL: 個｜个	police / police officer / CL: 個｜个	
-Emergency	察		Chá   chá	Chá   chá	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident	
-Work 3	奖	獎	jiǎng	jiǎng	prize / award / encouragement / CL: 個｜个	prize / award / encouragement / CL: 個｜个	
-Work 3	工资	工資	gōng zī	gōng zī	wages / pay / CL: 個｜个, 份, 月	wages / pay / CL: 個｜个, 份, 月	
-Work 3	加班		jiā bān	jiā bān	to work overtime	to work overtime	
-Work 3	奖金	獎金	jiǎng jīn	jiǎng jīn	premium / award money / bonus	premium / award money / bonus	
-Work 3	生意		shēng yì   shēng yi	shēng yì   shēng yi	life force / vitality  business / CL: 筆｜笔	life force / vitality  business / CL: 筆｜笔	
-Work 3	压力	壓力	yā lì	yā lì	pressure	pressure	
-Work 3	责任	責任	zé rèn	zé rèn	responsibility / blame / duty / CL: 個｜个	responsibility / blame / duty / CL: 個｜个	
-Work 3	商量		shāng liang	shāng liang	to consult / to talk over / to discuss	to consult / to talk over / to discuss	
-Work 3	意见	意見	yì jiàn	yì jiàn	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	
-Work 3	压	壓	yā   yà	yā   yà	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿	
-Work 3	责	責	zé	zé	duty / responsibility / to reproach / to blame	duty / responsibility / to reproach / to blame	
-Work 3	任		Rén   rèn	Rén   rèn	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)	
-Work 3	误会	誤會	wù huì	wù huì	to misunderstand / to mistake / misunderstanding / CL: 個｜个	to misunderstand / to mistake / misunderstanding / CL: 個｜个	
-Work 3	抱歉		bào qiàn	bào qiàn	to be sorry / to feel apologetic / sorry!	to be sorry / to feel apologetic / sorry!	
-Work 3	原谅	原諒	yuán liàng	yuán liàng	to excuse / to forgive / to pardon	to excuse / to forgive / to pardon	
-Work 3	误	誤	wù	wù	mistake / error / to miss / to harm / to delay / to neglect / mistakenly	mistake / error / to miss / to harm / to delay / to neglect / mistakenly	
-Work 3	抱		bào	bào	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish	
-Work 3	原		Yuán   yuán	Yuán   yuán	Hara (Japanese surname)  former / original / primary / raw / level / cause / source	Hara (Japanese surname)  former / original / primary / raw / level / cause / source	
-Work 3	歉		qiàn	qiàn	to apologize / to regret / deficient	to apologize / to regret / deficient	
-Work 3	谅	諒	liàng	liàng	to show understanding / to excuse / to presume / to expect	to show understanding / to excuse / to presume / to expect	
-Weather 2	干燥	乾燥	gān zào	gān zào	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	
-Weather 2	暖和		nuǎn huo	nuǎn huo	warm / nice and warm	warm / nice and warm	
-Weather 2	凉快	涼快	liáng kuai	liáng kuai	nice and cold / pleasantly cool	nice and cold / pleasantly cool	
-Weather 2	燥		zào	zào	dry / parched / impatient	dry / parched / impatient	
-Weather 2	暖		nuǎn	nuǎn	warm / to warm	warm / to warm	
-Weather 2	和		Hé   hé   hè   hú   huó   huò	Hé   hé   hè   hú   huó   huò	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	
-Weather 2	凉	涼	Liáng   liáng   liàng	Liáng   liáng   liàng	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down	
-Weather 2	温度	溫度	wēn dù	wēn dù	temperature / CL: 個｜个	temperature / CL: 個｜个	
-Weather 2	度		dù   duó	dù   duó	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	
-Weather 2	大约	大約	dà yuē	dà yuē	approximately / probably	approximately / probably	
-Weather 2	温	溫	Wēn   wēn	Wēn   wēn	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟	
-Duo	鹰	鷹	yīng	yīng	eagle / falcon / hawk	eagle / falcon / hawk	
-Duo	毛		Máo   máo	Máo   máo	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	
-Duo	羽		yǔ	yǔ	feather / 5th note in pentatonic scale	feather / 5th note in pentatonic scale	
-Duo	橙		chéng	chéng	orange tree / orange (color)	orange tree / orange (color)	
-Duo	猫头鹰	貓頭鷹	māo tóu yīng	māo tóu yīng	owl	owl	
-Duo	羽毛		yǔ máo	yǔ máo	feather / plumage / plume	feather / plumage / plume	
-Duo	多儿		duō er	duō er			
-Duo	鼓励	鼓勵	gǔ lì	gǔ lì	to encourage	to encourage	
-Duo	提醒		tí xǐng	tí xǐng	to remind / to call attention to / to warn of	to remind / to call attention to / to warn of	
-Duo	懒	懶	lǎn	lǎn	lazy	lazy	
-Duo	放弃	放棄	fàng qì	fàng qì	to renounce / to abandon / to give up	to renounce / to abandon / to give up	
-Duo	鼓		gǔ	gǔ	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell	
-Duo	励	勵	Lì   lì	Lì   lì	surname Li  to encourage / to urge	surname Li  to encourage / to urge	
-Duo	醒		xǐng	xǐng	to wake up / to be awake / to become aware / to sober up / to come to	to wake up / to be awake / to become aware / to sober up / to come to	
-Duo	弃	棄	qì	qì	to abandon / to relinquish / to discard / to throw away	to abandon / to relinquish / to discard / to throw away	
+Lesson	Simplified Chinese	Traditional Chinese	Primary pinyin	CC-CEDICT pinyin	Google_Translate_Definition	Primary English definition	CC-CEDICT English definition	Labels
+Greeting 1	你		nǐ		you	you		
+Greeting 1	好		hǎo   hào		it is good	good		
+Greeting 1	再见	再見	zài jiàn		Goodbye	see you again later		
+Greeting 1	再		zài		again	again		
+Greeting 1	见	見	jiàn		see	to see		
+Numbers	三		sān		three	3		
+Numbers	一		yī		One	1		
+Numbers	七		qī		Seven	7		
+Numbers	八		bā		Eight	8		
+Numbers	十		shí		ten	10		
+Numbers	零		líng		zero	zero		
+Numbers	元		Yuán		yuan	Chinese yuan currency unit		
+Numbers	五		wǔ		Fives	5		
+Numbers	九		jiǔ		nine	9		
+Numbers	百		bǎi		hundred	100		
+Numbers	二		èr		two	2		
+Numbers	四		sì		four	4		
+Numbers	六		liù		six	6		
+Name	叫		jiào		call	to be called		
+Name	我		wǒ		I	I		
+Name	张	張	Zhāng		Zhang	surname Zhang		
+Name	李		Lǐ		Plum	surname Li		
+Name	华	華	Huá		China	given name Huá		
+Name	明		míng		Bright			Meaning off-topic
+Name	名字		míng zi		first name	name		
+Name	什么	什麼	shén me		what	what?		
+Name	名		míng		name			Meaning off-topic
+Name	字		zì		word	letter		
+Name	什		shén   shí		Assorted			Meaning off-topic
+Name	么	麼	má   ma   me		What			Meaning off-topic
+Name	姓		xìng		surname	Family name		
+Name	王		Wáng		king	surname Wang		
+Name	呢		ne		It	question particle		
+Greeting 2	很		hěn		very	very		
+Greeting 2	高兴	高興	gāo xìng		happy	happy		
+Greeting 2	高		gāo		high	tall		
+Greeting 2	兴	興	xìng		Interest			Meaning off-topic
+Greeting 2	认识	認識	rèn shi		understanding	to know		
+Greeting 2	也		yě		and also	too		
+Greeting 2	认	認	rèn		recognize			Meaning off-topic
+Greeting 2	识	識	shí   zhì		knowledge			Meaning off-topic
+Food 1	吃		chī	chī	eat	to eat	to eat / to consume / to eat at (a cafeteria etc) / to eradicate / to destroy / to absorb / to suffer / to stammer (Taiwan pr. for this sense is [ji2])	
+Food 1	饭	飯	fàn	fàn	rice	food	food / cuisine / cooked rice / meal / CL: 碗, 頓｜顿	
+Food 1	鱼	魚	yú	Yú   yú	fish	fish	surname Yu  fish / CL: 條｜条, 尾	
+Food 1	面		miàn	miàn   miàn	surface	noodles	face / side / surface / aspect / top / classifier for flat surfaces such as drums, mirrors, flags etc  flour / noodles / (of food) soft (not crunchy) / (slang) (of a person) ineffectual / spineless	
+Food 1	喝		hē	hē   hè	drink	to drink	to drink / My goodness!  to shout loudly	
+Food 1	水		shuǐ	Shuǐ   shuǐ	water	water	surname Shui  water / river / liquid / beverage / additional charges or income / (of clothes) classifier for number of washes	
+Food 1	茶		chá	chá	tea	tea	tea / tea plant / CL: 杯, 壺｜壶	
+Food 1	不		bù	bù	Do not	not	(negative prefix) / not / no	
+Occupation	是		shì	shì	Yes	to be	is / are / am / yes / to be	
+Occupation	他		tā	tā	he	he	he or him / (used for either sex when the sex is unknown or unimportant) / (used before sb's name for emphasis) / (used as a meaningless mock object) / other / another	
+Occupation	学生	學生	xué sheng	xué sheng	student	student	student / schoolchild	
+Occupation	学	學	xué	xué	learn	to learn	to learn / to study / to imitate / science / -ology	
+Occupation	生		shēng	shēng	Raw		to be born / to give birth / life / to grow / raw / uncooked / student	Meaning off-topic
+Occupation	吗	嗎	mǎ	mǎ   ma	It	question particle for 'yes-no' questions	see 嗎啡｜吗啡, morphine  (question particle for 'yes-no' questions)	
+Occupation	她		tā	tā	she was	she	she	
+Occupation	你们	你們	nǐ men	nǐ men	you guys	you (plural)	you (plural)	
+Occupation	我们	我們	wǒ men	wǒ men	we	we	we / us / ourselves / our	
+Occupation	他们	他們	tā men	tā men	they	they	they	
+Occupation	们	們	men	men	They	plural marker for pronouns	plural marker for pronouns, and nouns referring to individuals	
+Occupation	老师	老師	lǎo shī	lǎo shī	teacher	teacher	teacher / CL: 個｜个, 位	
+Occupation	医生	醫生	yī shēng	yī shēng	Doctors	doctor	doctor / CL: 個｜个, 位, 名	
+Occupation	她们	她們	tā men	tā men	they	they (females)	they / them (for females)	
+Occupation	老		lǎo	lǎo	old		prefix used before the surname of a person or a numeral indicating the order of birth of the children in a family or to indicate affection or familiarity / old (of people) / venerable (person) / experienced / of long standing / always / all the time / of the past / very / outdated / (of meat etc) tough	Meaning off-topic
+Occupation	师	師	Shī   shī	Shī   shī	division		surname Shi  teacher / master / expert / model / army division / (old) troops / to dispatch troops	Meaning off-topic
+Occupation	医	醫	yī	yī	medical		medical / medicine / doctor / to cure / to treat	Meaning off-topic
+Contact	的		de	de   dī   dí   dì	of	of	of / ~'s (possessive particle) / (used after an attribute) / (used to form a nominal expression) / (used at the end of a declarative sentence for emphasis)  see 的士  really and truly  aim / clear	
+Contact	电话	電話	diàn huà	diàn huà	phone	telephone	telephone / CL: 部 / phone call / CL: 通 / phone number	
+Contact	电	電	diàn	diàn	Electricity	electricity	electric / electricity / electrical	
+Contact	话	話	huà	huà	words	language	dialect / language / spoken words / speech / talk / words / conversation / what sb said / CL: 種｜种, 席, 句, 口, 番	
+Contact	号码	號碼	hào mǎ	hào mǎ	number	number	number / CL: 堆, 個｜个	
+Contact	多少		duō shǎo	duō shǎo   duō shao	How many	how many	number / amount / somewhat  how much / how many / which (number) / as much as	
+Contact	多		duō	duō	many	many	many / much / often / a lot of / numerous / more / in excess / how (to what extent) / multi- / Taiwan pr. [duo2] when it means 'how'	
+Contact	少		shǎo	shǎo   shào	less	few	few / less / to lack / to be missing / to stop (doing sth) / seldom  young	
+Contact	号	號	háo   hào	háo   hào	number		roar / cry / CL: 個｜个  ordinal number / day of a month / mark / sign / business establishment / size / ship suffix / horn (wind instrument) / bugle call / assumed name / to take a pulse / classifier used to indicate number of people	Meaning off-topic
+Contact	码	碼	mǎ	mǎ	code		weight / number / code / to pile / to stack / classifier for length or distance (yard), happenings etc	Meaning off-topic
+Nation	中国	中國	Zhōng guó	Zhōng guó	China	China	China	
+Nation	人		rén	rén	people	person	man / person / people / CL: 個｜个, 位	
+Nation	中		zhōng	Zhōng   zhōng   zhòng	in	middle	China / Chinese / surname Zhong  within / among / in / middle / center / while (doing sth) / during / (dialect) OK / all right  to hit (the mark) / to be hit by / to suffer / to win (a prize, a lottery)	
+Nation	国	國	guó	Guó   guó	country	country	surname Guo  country / nation / state / national / CL: 個｜个	
+Nation	哪		nǎ	nǎ   na   něi	where	how / which	how / which  (particle equivalent to 啊 after noun ending in -n)  which? (interrogative, followed by classifier or numeral-classifier)	
+Nation	英国	英國	Yīng guó	Yīng guó	United Kingdom	United Kingdom	United Kingdom 聯合王國｜联合王国 / United Kingdom of Great Britain and Northern Ireland / abbr. for England 英格蘭｜英格兰	
+Nation	美国	美國	Měi guó	Měi guó	United States	USA	United States / USA / US	
+Nation	英		Yīng   yīng	Yīng   yīng	English	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	
+Nation	美		Měi   měi	Měi   měi	nice	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself	
+Nation	都		Dū   dōu   dū	Dū   dōu   dū	All	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	
+Nation	对	對	duì	duì	Correct	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	
+Nation	加拿大		Jiā ná dà	Jiā ná dà	Canada	Canada / Canadian	Canada / Canadian	
+Nation	加		Jiā   jiā	Jiā   jiā	plus	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	
+Nation	拿		ná	ná	take	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	
+Nation	大		dà   dài	dà   dài	Big	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	
+Greeting 3	忙		máng	máng	busy	busy / hurriedly / to hurry / to rush	busy / hurriedly / to hurry / to rush	
+Greeting 3	早上		zǎo shang	zǎo shang	morning	early morning / CL: 個｜个	early morning / CL: 個｜个	
+Greeting 3	早		zǎo	zǎo	early	early / morning / Good morning! / long ago / prematurely	early / morning / Good morning! / long ago / prematurely	
+Greeting 3	上		shǎng   shàng	shǎng   shàng	on	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	
+Greeting 3	怎么样	怎麼樣	zěn me yàng	zěn me yàng	how about it	how? / how about? / how was it? / how are things?	how? / how about? / how was it? / how are things?	
+Greeting 3	今天		jīn tiān	jīn tiān	Nowadays	today / at the present / now	today / at the present / now	
+Greeting 3	怎		zěn	zěn	How	how	how	
+Greeting 3	样	樣	yàng	yàng	kind	manner / pattern / way / appearance / shape / classifier: kind, type	manner / pattern / way / appearance / shape / classifier: kind, type	
+Greeting 3	今		jīn	jīn	now	today / modern / present / current / this / now	today / modern / present / current / this / now	
+Greeting 3	天		tiān	tiān	day	day / sky / heaven	day / sky / heaven	
+Location 1	家	傢	jiā   Jiā   jiā	jiā   Jiā   jiā	Family	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	
+Location 1	北京		Běi jīng	Běi jīng	Beijing	Beijing, capital of People's Republic of China / Peking / PRC government	Beijing, capital of People's Republic of China / Peking / PRC government	
+Location 1	在		zài	zài	in	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	
+Location 1	北		běi	běi	north	north / to be defeated (classical)	north / to be defeated (classical)	
+Location 1	京		Jīng   jīng	Jīng   jīng	Beijing	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)	
+Location 1	哪儿	哪兒	nǎr	nǎr	where	where? / wherever / anywhere	where? / wherever / anywhere	
+Location 1	纽约	紐約	Niǔ yuē	Niǔ yuē	new York	New York	New York	
+Location 1	香港		Xiāng gǎng	Xiāng gǎng	Hong Kong	Hong Kong	Hong Kong	
+Location 1	儿	兒	ér   r	ér   r	child	child / son  non-syllabic diminutive suffix / retroflex final	child / son  non-syllabic diminutive suffix / retroflex final	
+Location 1	纽	紐	niǔ	niǔ	Button	to turn / to wrench / button / nu (Greek letter Νν)	to turn / to wrench / button / nu (Greek letter Νν)	
+Location 1	约	約	yāo   yuē	yāo   yuē	approximately	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise	
+Location 1	香		xiāng	xiāng	Fragrant	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	
+Location 1	港		Gǎng   gǎng	Gǎng   gǎng	port	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个	
+Location 1	住		zhù	zhù	live	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	
+Location 1	伦敦	倫敦	Lún dūn	Lún dūn	London	London, capital of United Kingdom	London, capital of United Kingdom	
+Location 1	台湾	臺灣	Tái wān	Tái wān	Taiwan	Taiwan	Taiwan	
+Location 1	伦	倫	lún	lún	Lun	human relationship / order / coherence	human relationship / order / coherence	
+Location 1	敦		dūn	dūn	London	kindhearted / place name	kindhearted / place name	
+Location 1	台		Tái   tái   tái   Tái   tái   tái	Tái   tái   tái   Tái   tái   tái	station	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon	
+Location 1	湾	灣	wān	wān	Bay	bay / gulf / to cast anchor / to moor (a boat)	bay / gulf / to cast anchor / to moor (a boat)	
+Phrases 1	谢谢	謝謝	xiè xie	xiè xie	Thank you	to thank / thanks / thank you	to thank / thanks / thank you	
+Phrases 1	不客气	不客氣	bù kè qi	bù kè qi	You're welcome	you're welcome / don't mention it / impolite / rude / blunt	you're welcome / don't mention it / impolite / rude / blunt	
+Phrases 1	谢	謝	Xiè   xiè	Xiè   xiè	thank	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline	
+Phrases 1	客		kè	kè	customer	customer / visitor / guest	customer / visitor / guest	
+Phrases 1	气	氣	qì	qì	gas	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi	
+Phrases 1	对不起	對不起	duì bu qǐ	duì bu qǐ	I am sorry	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	
+Phrases 1	没关系	沒關係	méi guān xi	méi guān xi	It's ok	it doesn't matter	it doesn't matter	
+Phrases 1	起		qǐ	qǐ	Start	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	
+Phrases 1	没	沒	méi   mò	méi   mò	No	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	
+Phrases 1	关	關	Guān   guān	Guān   guān	turn off	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	
+Phrases 1	系	係	xì   xì   jì   xì	xì   xì   jì   xì	system	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry	
+Family 1	爸爸		bà ba	bà ba	father	(informal) father / CL: 個｜个, 位	(informal) father / CL: 個｜个, 位	
+Family 1	妈妈	媽媽	mā ma	mā ma	mom	mama / mommy / mother / CL: 個｜个, 位	mama / mommy / mother / CL: 個｜个, 位	
+Family 1	爱	愛	ài	ài	Love	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)	
+Family 1	家人		jiā rén	jiā rén	family	household / (one's) family	household / (one's) family	
+Family 1	爸		bà	bà	dad	father / dad / pa / papa	father / dad / pa / papa	
+Family 1	妈	媽	mā	mā	mom	ma / mom / mother	ma / mom / mother	
+Family 1	谁	誰	shéi	shéi	Who	who / also pr. [shui2]	who / also pr. [shui2]	
+Family 1	那		Nā   Nuó   nà   nuó	Nā   Nuó   nà   nuó	that	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪	
+Family 1	个	個	gè	gè	More	individual / this / that / size / classifier for people or objects in general	individual / this / that / size / classifier for people or objects in general	
+Family 1	这	這	zhè	zhè	This	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)	
+Family 1	哥哥		gē ge	gē ge	brother	older brother / CL: 個｜个, 位	older brother / CL: 個｜个, 位	
+Family 1	姐姐		jiě jie	jiě jie	sister	older sister / CL: 個｜个	older sister / CL: 個｜个	
+Family 1	有		yǒu	yǒu	Have	to have / there is / there are / to exist / to be	to have / there is / there are / to exist / to be	
+Family 1	哥		gē	gē	brother	elder brother	elder brother	
+Family 1	姐		jiě	jiě	sister	older sister	older sister	
+Family 1	弟弟		dì di	dì di	Little brother	younger brother / CL: 個｜个, 位	younger brother / CL: 個｜个, 位	
+Family 1	和		Hé   hé   hè   hú   huó   huò	Hé   hé   hè   hú   huó   huò	with	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	
+Family 1	妹妹		mèi mei	mèi mei	younger sister	younger sister / young woman / CL: 個｜个	younger sister / young woman / CL: 個｜个	
+Family 1	弟		dì	dì	Younger brother	younger brother / junior male / I (modest word in letter)	younger brother / junior male / I (modest word in letter)	
+Family 1	妹		mèi	mèi	sister	younger sister	younger sister	
+Phrases 2	请问	請問	qǐng wèn	qǐng wèn	Excuse me	Excuse me, may I ask...?	Excuse me, may I ask...?	
+Phrases 2	知道		zhī dào	zhī dào	know	to know / to become aware of / also pr. [zhi1 dao5]	to know / to become aware of / also pr. [zhi1 dao5]	
+Phrases 2	问	問	wèn	wèn	ask	to ask	to ask	
+Phrases 2	请	請	qǐng	qǐng	please	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	
+Phrases 2	知		zhī	zhī	know	to know / to be aware	to know / to be aware	
+Phrases 2	道		dào	dào	Road	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)	
+Phrases 2	说	說	shuì   shuō	shuì   shuō	Say	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)	
+Phrases 2	英语	英語	Yīng yǔ	Yīng yǔ	English	English (language)	English (language)	
+Phrases 2	汉语	漢語	Hàn yǔ	Hàn yǔ	Chinese	Chinese language / CL: 門｜门	Chinese language / CL: 門｜门	
+Phrases 2	汉	漢	Hàn   hàn	Hàn   hàn	Chinese	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man	
+Phrases 2	语	語	yǔ   yù	yǔ   yù	language	dialect / language / speech  to tell to	dialect / language / speech  to tell to	
+Phrases 2	帮助	幫助	bāng zhù	bāng zhù	help	assistance / aid / to help / to assist	assistance / aid / to help / to assist	
+Phrases 2	次		cì	cì	Secondary	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	
+Phrases 2	帮	幫	bāng	bāng	help	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	
+Phrases 2	助		zhù	zhù	help	to help / to assist	to help / to assist	
+Greeting 4	早安		zǎo ān	zǎo ān	good Morning	Good morning!	Good morning!	
+Greeting 4	晚安		wǎn ān	wǎn ān	good night	Good night! / Good evening!	Good night! / Good evening!	
+Greeting 4	一会儿	一會兒	yī huìr	yī huìr	Awhile	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	
+Greeting 4	会	會	huì   kuài	huì   kuài	meeting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	
+Greeting 4	安		Ān   ān	Ān   ān	Secure	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere	
+Greeting 4	最近		zuì jìn	zuì jìn	Recently	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	
+Greeting 4	好久不见	好久不見	hǎo jiǔ bu jiàn	hǎo jiǔ bu jiàn	long time no see	long time no see	long time no see	
+Greeting 4	不错	不錯	bù cuò	bù cuò	Pretty good	correct / right / not bad / pretty good	correct / right / not bad / pretty good	
+Greeting 4	最		zuì	zuì	most	most / the most / -est (superlative suffix)	most / the most / -est (superlative suffix)	
+Greeting 4	近		jìn	jìn	near	near / close to / approximately	near / close to / approximately	
+Greeting 4	久		jiǔ	jiǔ	Long	(long) time / (long) duration of time	(long) time / (long) duration of time	
+Greeting 4	错	錯	Cuò   cuò	Cuò   cuò	wrong	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	
+Drink	要		yāo   yào	yāo   yào	To	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if	
+Drink	热	熱	rè	rè	heat	to warm up / to heat up / hot (of weather) / heat / fervent	to warm up / to heat up / hot (of weather) / heat / fervent	
+Drink	冰		bīng	bīng	ice	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine	
+Drink	牛奶		niú nǎi	niú nǎi	milk	cow's milk / CL: 瓶, 杯	cow's milk / CL: 瓶, 杯	
+Drink	咖啡		kā fēi	kā fēi	coffee	coffee (loanword) / CL: 杯	coffee (loanword) / CL: 杯	
+Drink	牛		Niú   niú	Niú   niú	Cattle	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome	
+Drink	奶		nǎi   nǎi	nǎi   nǎi	milk	breast / milk / to breastfeed  mother / variant of 奶	breast / milk / to breastfeed  mother / variant of 奶	
+Drink	咖		kā	kā	coffee	coffee / class / grade	coffee / class / grade	
+Drink	啡		fēi	fēi	coffee	(phonetic component)	(phonetic component)	
+Location 2	洗手间	洗手間	xǐ shǒu jiān	xǐ shǒu jiān	Toilets	toilet / lavatory / washroom	toilet / lavatory / washroom	
+Location 2	医院	醫院	yī yuàn	yī yuàn	hospital	hospital / CL: 所, 家, 座	hospital / CL: 所, 家, 座	
+Location 2	洗		xǐ	xǐ	wash	to wash / to bathe / to develop (photo)	to wash / to bathe / to develop (photo)	
+Location 2	手		shǒu	shǒu	hand	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	
+Location 2	间	間	jiān   jiàn	jiān   jiàn	between	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	
+Location 2	院		yuàn	yuàn	hospital	courtyard / institution / CL: 個｜个	courtyard / institution / CL: 個｜个	
+Location 2	这儿	這兒	zhèr	zhèr	here	here	here	
+Location 2	那儿	那兒	nàr	nàr	there	there	there	
+Location 2	饭馆	飯館	fàn guǎn	fàn guǎn	restaurant	restaurant / CL: 家	restaurant / CL: 家	
+Location 2	馆	館	guǎn	guǎn	House	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	
+Time 1	年		Nián   nián   nián	Nián   nián   nián	year	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年	
+Time 1	月		yuè	yuè	month	moon / month / monthly / CL: 個｜个, 輪｜轮	moon / month / monthly / CL: 個｜个, 輪｜轮	
+Time 1	几		jī   jī   jǐ	jī   jī   jǐ	a few	small table  almost  how much / how many / several / a few	small table  almost  how much / how many / several / a few	
+Time 1	〇		líng	líng	〇	zero	zero	
+Time 1	星期		xīng qī	xīng qī	week	week / CL: 個｜个 / day of the week / Sunday	week / CL: 個｜个 / day of the week / Sunday	
+Time 1	明天		míng tiān	míng tiān	tomorrow	tomorrow	tomorrow	
+Time 1	日		Rì   rì	Rì   rì	day	abbr. for 日本, Japan  sun / day / date, day of the month	abbr. for 日本, Japan  sun / day / date, day of the month	
+Time 1	星		xīng	xīng	star	star / heavenly body / satellite / small amount	star / heavenly body / satellite / small amount	
+Time 1	期		qī	qī	period	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]	
+Time 1	点	點	diǎn	diǎn	point	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	
+Time 1	现在	現在	xiàn zài	xiàn zài	just now	now / at present / at the moment / modern / current / nowadays	now / at present / at the moment / modern / current / nowadays	
+Time 1	半		bàn	bàn	half	half / semi- / incomplete / (after a number) and a half	half / semi- / incomplete / (after a number) and a half	
+Time 1	现	現	xiàn	xiàn	Present	to appear / present / now / existing / current	to appear / present / now / existing / current	
+Family 2	孩子		hái zi	hái zi	child	child	child	
+Family 2	两	兩	liǎng	liǎng	Two	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	
+Family 2	孩		hái	hái	child	child	child	
+Family 2	子		zǐ   zi	zǐ   zi	child	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)	
+Family 2	女儿	女兒	nǚ ér	nǚ ér	daughter	daughter	daughter	
+Family 2	儿子	兒子	ér zi	ér zi	son	son	son	
+Family 2	岁	歲	suì	suì	year old	classifier for years (of age) / year / year (of crop harvests)	classifier for years (of age) / year / year (of crop harvests)	
+Family 2	女		nǚ	nǚ	Female	female / woman / daughter	female / woman / daughter	
+Family 2	妻子		qī zǐ   qī zi	qī zǐ   qī zi	wife	wife and children  wife / CL: 個｜个	wife and children  wife / CL: 個｜个	
+Family 2	丈夫		zhàng fu	zhàng fu	husband	husband / CL: 個｜个	husband / CL: 個｜个	
+Family 2	妻		qī   qì	qī   qì	wife	wife  to marry off (a daughter)	wife  to marry off (a daughter)	
+Family 2	丈		zhàng	zhàng	length	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male	
+Family 2	夫		fū   fú	fū   fú	husband	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)	
+Family 2	猫	貓	māo	māo	Cat	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem	
+Family 2	它		tā	tā	it	it	it	
+Family 2	狗		gǒu	gǒu	dog	dog / CL: 隻｜只, 條｜条	dog / CL: 隻｜只, 條｜条	
+Telephone	喂		wéi   wèi   wèi	wéi   wèi   wèi	Hey	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	
+Telephone	慢		màn	màn	slow	slow	slow	
+Telephone	一点儿		yī diǎnr	yī diǎnr	a little	erhua variant of 一點｜一点	erhua variant of 一點｜一点	
+Telephone	快		kuài	kuài	fast	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant	
+Telephone	得		dé   de   děi	dé   de   děi	Get	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	
+Telephone	明白		míng bai	míng bai	understand	clear / obvious / unequivocal / to understand / to realize	clear / obvious / unequivocal / to understand / to realize	
+Telephone	白		Bái   bái	Bái   bái	White	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	
+People 1	漂亮		piào liang	piào liang	Pretty	pretty / beautiful	pretty / beautiful	
+People 1	漂		piāo   piǎo   piào	piāo   piǎo   piào	drift	to float / to drift  to bleach  elegant / polished	to float / to drift  to bleach  elegant / polished	
+People 1	亮		liàng	liàng	bright	bright / clear / resonant / to shine / to show / to reveal	bright / clear / resonant / to shine / to show / to reveal	
+People 1	朋友		péng you	péng you	friend	friend / CL: 個｜个, 位	friend / CL: 個｜个, 位	
+People 1	男		nán	nán	male	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个	
+People 1	矮		ǎi	ǎi	short	low / short (in length)	low / short (in length)	
+People 1	朋		péng	péng	Friend	friend	friend	
+People 1	友		yǒu	yǒu	Friendly	friend	friend	
+People 1	可爱	可愛	kě ài	kě ài	lovely	adorable / cute / lovely	adorable / cute / lovely	
+People 1	非常		fēi cháng	fēi cháng	very much	very / very much / unusual / extraordinary	very / very much / unusual / extraordinary	
+People 1	可		kě   kè	kě   kè	can	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗	
+People 1	非		Fēi   fēi	Fēi   fēi	non-	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must	
+People 1	常		Cháng   cháng	Cháng   cháng	often	surname Chang  always / ever / often / frequently / common / general / constant	surname Chang  always / ever / often / frequently / common / general / constant	
+Time 2	上午		shàng wǔ	shàng wǔ	morning	morning / CL: 個｜个	morning / CL: 個｜个	
+Time 2	分		fēn   fèn	fēn   fèn	Minute	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	
+Time 2	下午		xià wǔ	xià wǔ	in the afternoon	afternoon / CL: 個｜个 / p.m.	afternoon / CL: 個｜个 / p.m.	
+Time 2	晚上		wǎn shang	wǎn shang	at night	evening / night / CL: 個｜个 / in the evening	evening / night / CL: 個｜个 / in the evening	
+Time 2	午		wǔ	wǔ	Noon	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)	
+Time 2	晚		wǎn	wǎn	late	evening / night / late	evening / night / late	
+Time 2	下		xià	xià	under	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	
+Time 2	每		měi	měi	each	each / every	each / every	
+Time 2	中午		zhōng wǔ	zhōng wǔ	noon	noon / midday / CL: 個｜个	noon / midday / CL: 個｜个	
+Time 2	周末	週末	zhōu mò	zhōu mò	weekend	weekend	weekend	
+Time 2	周		Zhōu   zhōu   zhōu	Zhōu   zhōu   zhōu	week	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周	
+Time 2	末		mò	mò	end	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man	
+Time 2	昨天		zuó tiān	zuó tiān	yesterday	yesterday	yesterday	
+Time 2	了		le   liǎo   liǎo	le   liǎo   liǎo	The	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	
+Time 2	做		zuò	zuò	do	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	
+Time 2	昨		zuó	zuó	Yesterday	yesterday	yesterday	
+Time 2	今年		jīn nián	jīn nián	this year	this year	this year	
+Time 2	去年		qù nián	qù nián	last year	last year	last year	
+Time 2	明年		míng nián	míng nián	next year	next year	next year	
+Time 2	去		qù	qù	go with	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	
+Location 3	旁边	旁邊	páng biān	páng biān	next to	lateral / side / to the side / beside	lateral / side / to the side / beside	
+Location 3	左边	左邊	zuǒ bian	zuǒ bian	left	left / the left side / to the left of	left / the left side / to the left of	
+Location 3	右边	右邊	yòu bian	yòu bian	right	right side / right, to the right	right side / right, to the right	
+Location 3	旁		páng	páng	Beside	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic	
+Location 3	左		Zuǒ   zuǒ	Zuǒ   zuǒ	left	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	
+Location 3	右		yòu	yòu	right	right (-hand) / the Right (politics) / west (old)	right (-hand) / the Right (politics) / west (old)	
+Location 3	边	邊	biān   bian	biān   bian	side	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality	
+Location 3	前面		qián miàn	qián miàn	front	ahead / in front / preceding / above / also pr. [qian2 mian5]	ahead / in front / preceding / above / also pr. [qian2 mian5]	
+Location 3	后面	後面	hòu miàn	hòu miàn	Behind	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	
+Location 3	学校	學校	xué xiào	xué xiào	school	school / CL: 所	school / CL: 所	
+Location 3	前		qián	qián	before	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	
+Location 3	后		Hòu   hòu   hòu	Hòu   hòu   hòu	Rear	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	
+Location 3	校		jiào   xiào	jiào   xiào	school	to proofread / to check / to compare  school / military officer / CL: 所	to proofread / to check / to compare  school / military officer / CL: 所	
+Location 3	走		zǒu	zǒu	go	to walk / to go / to run / to move (of vehicle) / to visit / to leave / to go away / to die (euph.) / from / through / away (in compound verbs, such as 撤走) / to change (shape, form, meaning)	to walk / to go / to run / to move (of vehicle) / to visit / to leave / to go away / to die (euph.) / from / through / away (in compound verbs, such as 撤走) / to change (shape, form, meaning)	
+Location 3	到		dào	dào	To	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)	
+Location 3	路		Lù   lù	Lù   lù	road	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	
+Location 3	怎么	怎麼	zěn me	zěn me	how	how? / what? / why?	how? / what? / why?	
+Location 3	哪里	哪裏	nǎ lǐ   nǎ lǐ	nǎ lǐ   nǎ lǐ	where	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	
+Location 3	这里	這裡	zhè lǐ	zhè lǐ	Here	here	here	
+Location 3	那里	那裏	nà li   nà li	nà li   nà li	There	there / that place / also written 那裡｜那里  there / that place	there / that place / also written 那裡｜那里  there / that place	
+Location 3	往		wǎng	wǎng	to	to go (in a direction) / to / towards / (of a train) bound for / past / previous	to go (in a direction) / to / towards / (of a train) bound for / past / previous	
+Location 3	里	裡	lǐ   Lǐ   lǐ	lǐ   Lǐ   lǐ	in	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	
+Hobbies 1	喜欢	喜歡	xǐ huan	xǐ huan	like	to like / to be fond of	to like / to be fond of	
+Hobbies 1	看		kān   kàn	kān   kàn	Look	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)	
+Hobbies 1	书	書	Shū   shū	Shū   shū	book	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write	
+Hobbies 1	喜		xǐ	xǐ	like	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad	
+Hobbies 1	欢	歡	huān   huān   huān	huān   huān   huān	Joyous	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢	
+Hobbies 1	玩		wán	wán	play	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	
+Hobbies 1	电脑	電腦	diàn nǎo	diàn nǎo	computer	computer / CL: 臺｜台	computer / CL: 臺｜台	
+Hobbies 1	游戏	遊戲	yóu xì	yóu xì	game	game / CL: 場｜场 / to play	game / CL: 場｜场 / to play	
+Hobbies 1	脑	腦	nǎo	nǎo	brain	brain / mind / head / essence	brain / mind / head / essence	
+Hobbies 1	游		Yóu   yóu   yóu	Yóu   yóu   yóu	tour	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	
+Hobbies 1	戏	戲	xì	xì	play	trick / drama / play / show / CL: 出, 場｜场, 臺｜台	trick / drama / play / show / CL: 出, 場｜场, 臺｜台	
+Hobbies 1	听		yǐn   tīng   tìng	yǐn   tīng   tìng	listen	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	
+Hobbies 1	音乐	音樂	yīn yuè	yīn yuè	music	music / CL: 張｜张, 曲, 段	music / CL: 張｜张, 曲, 段	
+Hobbies 1	歌		gē	gē	song	song / CL: 支, 首 / to sing	song / CL: 支, 首 / to sing	
+Hobbies 1	音		yīn	yīn	sound	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)	
+Hobbies 1	乐	樂	Lè   Yuè   lè   yuè	Lè   Yuè   lè   yuè	fun	surname Le  surname Yue  happy / cheerful / to laugh  music	surname Le  surname Yue  happy / cheerful / to laugh  music	
+Hobbies 1	跳舞		tiào wǔ	tiào wǔ	dancing	to dance	to dance	
+Hobbies 1	唱		chàng	chàng	sing	to sing / to call loudly / to chant	to sing / to call loudly / to chant	
+Hobbies 1	跳		tiào	tiào	jump	to jump / to hop / to skip over / to bounce / to palpitate	to jump / to hop / to skip over / to bounce / to palpitate	
+Hobbies 1	舞		wǔ	wǔ	dance	to dance / to wield / to brandish	to dance / to wield / to brandish	
+Daily Routine 1	起床		qǐ chuáng	qǐ chuáng	get up	to get out of bed / to get up	to get out of bed / to get up	
+Daily Routine 1	上学	上學	shàng xué	shàng xué	go to school	to go to school / to attend school	to go to school / to attend school	
+Daily Routine 1	上班		shàng bān	shàng bān	Go to work	to go to work / to be on duty / to start work / to go to the office	to go to work / to be on duty / to start work / to go to the office	
+Daily Routine 1	早饭	早飯	zǎo fàn	zǎo fàn	breakfast	breakfast / CL: 份, 頓｜顿, 次, 餐	breakfast / CL: 份, 頓｜顿, 次, 餐	
+Daily Routine 1	床		chuáng	chuáng	bed	bed / couch / classifier for beds / CL: 張｜张	bed / couch / classifier for beds / CL: 張｜张	
+Daily Routine 1	班		Bān   bān	Bān   bān	class	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	
+Daily Routine 1	从	從	Cóng   cóng   zòng	Cóng   cóng   zòng	From	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin	
+Daily Routine 1	睡觉	睡覺	shuì jiào	shuì jiào	go to bed	to go to bed / to sleep	to go to bed / to sleep	
+Daily Routine 1	午饭	午飯	wǔ fàn	wǔ fàn	lunch	lunch / CL: 份, 頓｜顿, 次, 餐	lunch / CL: 份, 頓｜顿, 次, 餐	
+Daily Routine 1	睡		shuì	shuì	sleep	to sleep / to lie down	to sleep / to lie down	
+Daily Routine 1	觉	覺	jiào   jué	jiào   jué	feel	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	
+Daily Routine 1	放学	放學	fàng xué	fàng xué	School	to dismiss students at the end of the school day	to dismiss students at the end of the school day	
+Daily Routine 1	下班		xià bān	xià bān	Commute	to finish work / to get off work	to finish work / to get off work	
+Daily Routine 1	回		huí   huí	huí   huí	Times	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	
+Daily Routine 1	晚饭	晚飯	wǎn fàn	wǎn fàn	dinner	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	
+Daily Routine 1	放		fàng	fàng	put	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	
+Payment	钱	錢	Qián   qián	Qián   qián	money	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两	
+Payment	块	塊	kuài	kuài	Piece	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	
+Payment	只		zhǐ   zhǐ   zhī	zhǐ   zhǐ   zhī	only	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	
+Payment	买	買	mǎi	mǎi	buy	to buy / to purchase	to buy / to purchase	
+Payment	一共		yī gòng	yī gòng	Altogether	altogether	altogether	
+Payment	毛		Máo   máo	Máo   máo	hair	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	
+Payment	共		gòng	gòng	Altogether	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party	
+Payment	信用卡		xìn yòng kǎ	xìn yòng kǎ	credit card	credit card	credit card	
+Payment	收		shōu	shōu	Receive	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)	
+Payment	千		qiān   qiān	qiān   qiān	thousand	thousand  see 鞦韆｜秋千	thousand  see 鞦韆｜秋千	
+Payment	信		xìn	xìn	letter	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	
+Payment	用		yòng	yòng	use	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	
+Payment	卡		kǎ   qiǎ	kǎ   qiǎ	card	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]	
+Payment	贵	貴	guì	guì	expensive	expensive / noble / precious / (honorific) your	expensive / noble / precious / (honorific) your	
+Payment	便宜		biàn yí   pián yi	biàn yí   pián yi	Inexpensive	convenient  cheap / inexpensive / small advantages / to let sb off lightly	convenient  cheap / inexpensive / small advantages / to let sb off lightly	
+Payment	现金	現金	xiàn jīn	xiàn jīn	cash	cash	cash	
+Payment	便		biàn   pián	biàn   pián	Then	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	
+Payment	宜		Yí   yí	Yí   yí	should	surname Yi  proper / should / suitable / appropriate	surname Yi  proper / should / suitable / appropriate	
+Payment	金		Jīn   jīn	Jīn   jīn	gold	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音	
+Payment	太		tài	tài	too	highest / greatest / too (much) / very / extremely	highest / greatest / too (much) / very / extremely	
+Payment	万		Mò   Wàn   wàn	Mò   Wàn   wàn	Ten thousand	see 万俟  surname Wan  ten thousand / a great number	see 万俟  surname Wan  ten thousand / a great number	
+Payment	行		háng   xíng	háng   xíng	Row	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	
+Entertainment	想		xiǎng	xiǎng	miss you	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	
+Entertainment	干	乾	Gān   gān   gān   gàn	Gān   gān   gān   gàn	dry	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	
+Entertainment	影		yǐng	yǐng	Shadow	picture / image / film / movie / photograph / reflection / shadow / trace	picture / image / film / movie / photograph / reflection / shadow / trace	
+Entertainment	视	視	shì	shì	Regard	to look at / to regard / to inspect	to look at / to regard / to inspect	
+Entertainment	电视	電視	diàn shì	diàn shì	TV	television / TV / CL: 臺｜台, 個｜个	television / TV / CL: 臺｜台, 個｜个	
+Entertainment	电影	電影	diàn yǐng	diàn yǐng	the film	movie / film / CL: 部, 片, 幕, 場｜场	movie / film / CL: 部, 片, 幕, 場｜场	
+Entertainment	报纸	報紙	bào zhǐ	bào zhǐ	newspaper	newspaper / newsprint / CL: 份, 期, 張｜张	newspaper / newsprint / CL: 份, 期, 張｜张	
+Entertainment	上网	上網	shàng wǎng	shàng wǎng	Internet	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	
+Entertainment	报	報	bào	bào	Report	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张	
+Entertainment	纸	紙	zhǐ	zhǐ	paper	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	
+Entertainment	网	網	wǎng	wǎng	network	net / network	net / network	
+Entertainment	手机	手機	shǒu jī	shǒu jī	Cellular phone	cell phone / mobile phone / CL: 部, 支	cell phone / mobile phone / CL: 部, 支	
+Entertainment	新闻	新聞	xīn wén	xīn wén	news	news / CL: 條｜条, 個｜个	news / CL: 條｜条, 個｜个	
+Entertainment	机	機	Jī   jī	Jī   jī	machine	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台	
+Entertainment	新		Xīn   xīn	Xīn   xīn	new	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	
+Entertainment	闻	聞	Wén   wén	Wén   wén	smell	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at	
+Entertainment	明星		míng xīng	míng xīng	Celebrity	star / celebrity	star / celebrity	
+Entertainment	体育	體育	tǐ yù	tǐ yù	physical education	sports / physical education	sports / physical education	
+Entertainment	节目	節目	jié mù	jié mù	program	program / item (on a program) / CL: 臺｜台, 個｜个, 套	program / item (on a program) / CL: 臺｜台, 個｜个, 套	
+Entertainment	韩国	韓國	Hán guó	Hán guó	Korea	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	
+Entertainment	体	體	tǐ	tǐ	body	body / form / style / system / substance / to experience / aspect (linguistics)	body / form / style / system / substance / to experience / aspect (linguistics)	
+Entertainment	节	節	jiē   jié	jiē   jié	Festival	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个	
+Entertainment	韩	韓	Hán	Hán	Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han	
+Entertainment	育		yù	yù	Educate	to have children / to raise or bring up / to educate	to have children / to raise or bring up / to educate	
+Entertainment	目		mù	mù	Eye	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title	
+Location 4	桌		zhuō	zhuō	table	table / desk / classifier for tables of guests at a banquet etc	table / desk / classifier for tables of guests at a banquet etc	
+Location 4	找		zhǎo	zhǎo	Find	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	
+Location 4	桌子		zhuō zi	zhuō zi	table	table / desk / CL: 張｜张, 套	table / desk / CL: 張｜张, 套	
+Location 4	椅子		yǐ zi	yǐ zi	chair	chair / CL: 把, 套	chair / CL: 把, 套	
+Location 4	椅		yǐ	yǐ	chair	chair	chair	
+Location 4	房间	房間	fáng jiān	fáng jiān	room	room / CL: 間｜间, 個｜个	room / CL: 間｜间, 個｜个	
+Location 4	冰箱		bīng xiāng	bīng xiāng	refrigerator	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	
+Location 4	外		wài	wài	outer	outside / in addition / foreign / external	outside / in addition / foreign / external	
+Location 4	房		Fáng   fáng	Fáng   fáng	room	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)	
+Location 4	箱		xiāng	xiāng	box	box / trunk / chest	box / trunk / chest	
+Restaurant	位		wèi	wèi	Place	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential	
+Restaurant	等		děng	děng	Wait	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	
+Restaurant	一下		yī xià	yī xià	a bit	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	
+Restaurant	进	進	jìn	jìn	Enter	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	
+Restaurant	坐		Zuò   zuò	Zuò   zuò	sit	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	
+Restaurant	菜单	菜單	cài dān	cài dān	menu	menu / CL: 份, 張｜张	menu / CL: 份, 張｜张	
+Restaurant	英文		Yīng wén	Yīng wén	English	English (language)	English (language)	
+Restaurant	菜		cài	cài	dish	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	
+Restaurant	单	單	Shàn   dān	Shàn   dān	single	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	
+Restaurant	文		Wén   wén	Wén   wén	Culture	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	
+Restaurant	服务员	服務員	fú wù yuán	fú wù yuán	Waiter	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	
+Restaurant	点菜	點菜	diǎn cài	diǎn cài	A la carte	to order dishes (in a restaurant)	to order dishes (in a restaurant)	
+Restaurant	买单	買單	mǎi dān	mǎi dān	Pay	to pay the restaurant bill	to pay the restaurant bill	
+Restaurant	订位	訂位	dìng wèi	dìng wèi	booking	to reserve a seat / to book a table / reservation	to reserve a seat / to book a table / reservation	
+Restaurant	服		fú   fù	fú   fù	clothes	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]	
+Restaurant	务	務	wù	wù	Business	affair / business / matter / to be engaged in / to attend to / by all means	affair / business / matter / to be engaged in / to attend to / by all means	
+Restaurant	员	員	yuán	yuán	member	person / employee / member	person / employee / member	
+Restaurant	订	訂	dìng	dìng	Order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	
+Supermarket	些		xiē	xiē	some	some / few / several / measure word indicating a small amount or small number (greater than 1)	some / few / several / measure word indicating a small amount or small number (greater than 1)	
+Supermarket	西		Xī   xī	Xī   xī	WEAT	the West / abbr. for Spain 西班牙 / Spanish  west	the West / abbr. for Spain 西班牙 / Spanish  west	
+Supermarket	东	東	Dōng   dōng	Dōng   dōng	east	surname Dong  east / host (i.e. sitting on east side of guest) / landlord	surname Dong  east / host (i.e. sitting on east side of guest) / landlord	
+Supermarket	东西	東西	dōng xī   dōng xi	dōng xī   dōng xi	thing	east and west  thing / stuff / person / CL: 個｜个, 件	east and west  thing / stuff / person / CL: 個｜个, 件	
+Supermarket	超市		chāo shì	chāo shì	Supermarket	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	
+Supermarket	水果		shuǐ guǒ	shuǐ guǒ	fruit	fruit / CL: 個｜个	fruit / CL: 個｜个	
+Supermarket	超		chāo	chāo	super	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-	
+Supermarket	市		shì	shì	city	market / city / CL: 個｜个	market / city / CL: 個｜个	
+Supermarket	果		guǒ	guǒ	fruit	fruit / result / resolute / indeed / if really	fruit / result / resolute / indeed / if really	
+Supermarket	给	給	gěi   jǐ	gěi   jǐ	give	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	
+Supermarket	苹果	蘋果	píng guǒ	píng guǒ	apple	apple / CL: 個｜个, 顆｜颗	apple / CL: 個｜个, 顆｜颗	
+Supermarket	西瓜		xī guā	xī guā	watermelon	watermelon / CL: 顆｜颗, 粒, 個｜个	watermelon / CL: 顆｜颗, 粒, 個｜个	
+Supermarket	苹		píng   pín   píng	píng   pín   píng	apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple	
+Supermarket	瓜		guā	guā	melon	melon / gourd / squash	melon / gourd / squash	
+Supermarket	鸡蛋	雞蛋	jī dàn	jī dàn	egg	(chicken) egg / hen's egg / CL: 個｜个, 打	(chicken) egg / hen's egg / CL: 個｜个, 打	
+Supermarket	新鲜	新鮮	xīn xiān	xīn xiān	fresh	fresh (experience, food etc) / freshness / novel / uncommon	fresh (experience, food etc) / freshness / novel / uncommon	
+Supermarket	鸡	雞	jī	jī	Chicken	fowl / chicken / CL: 隻｜只 / (slang) prostitute	fowl / chicken / CL: 隻｜只 / (slang) prostitute	
+Supermarket	蛋		dàn	dàn	egg	egg / CL: 個｜个, 打 / oval-shaped thing	egg / CL: 個｜个, 打 / oval-shaped thing	
+Supermarket	鲜	鮮	xiān   xiǎn   xiān	xiān   xiǎn   xiān	fresh	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜	
+Supermarket	蔬菜		shū cài	shū cài	vegetables	vegetables / produce / CL: 種｜种	vegetables / produce / CL: 種｜种	
+Supermarket	蔬		shū	shū	vegetable	vegetables	vegetables	
+Supermarket	包		Bāo   bāo	Bāo   bāo	package	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只	
+Supermarket	米		Mǐ   mǐ	Mǐ   mǐ	Meter	surname Mi  rice / CL: 粒 / meter (classifier)	surname Mi  rice / CL: 粒 / meter (classifier)	
+Supermarket	面包	麵包	miàn bāo	miàn bāo	bread	bread / CL: 片, 袋, 塊｜块	bread / CL: 片, 袋, 塊｜块	
+Supermarket	袋		dài	dài	bag	pouch / bag / sack / pocket	pouch / bag / sack / pocket	
+Supermarket	糖		táng	táng	sugar	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	
+Hobbies 2	为	為	wéi   wèi	wéi   wèi	for	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	
+Hobbies 2	习	習	Xí   xí	Xí   xí	Study	surname Xi  to practice / to study / habit	surname Xi  to practice / to study / habit	
+Hobbies 2	学习	學習	xué xí	xué xí	Learn	to learn / to study	to learn / to study	
+Hobbies 2	中文		Zhōng wén	Zhōng wén	Chinese	Chinese language	Chinese language	
+Hobbies 2	为什么	為什麼	wèi shén me	wèi shén me	why	why? / for what reason?	why? / for what reason?	
+Hobbies 2	因为	因為	yīn wèi	yīn wèi	because	because / owing to / on account of	because / owing to / on account of	
+Hobbies 2	所以		suǒ yǐ	suǒ yǐ	and so	therefore / as a result / so / the reason why	therefore / as a result / so / the reason why	
+Hobbies 2	西班牙		Xī bān yá	Xī bān yá	Spain	Spain	Spain	
+Hobbies 2	因		yīn	yīn	because	cause / reason / because	cause / reason / because	
+Hobbies 2	所		suǒ	suǒ	The	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个	
+Hobbies 2	以		Yǐ   yǐ	Yǐ   yǐ	With	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)	
+Hobbies 2	牙		yá	yá	tooth	tooth / ivory / CL: 顆｜颗	tooth / ivory / CL: 顆｜颗	
+Hobbies 2	旅游	旅遊	lǚ yóu	lǚ yóu	tourism	trip / journey / tourism / travel / tour / to travel	trip / journey / tourism / travel / tour / to travel	
+Hobbies 2	爱好	愛好	ài hào	ài hào	Hobby	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	
+Hobbies 2	西班牙语	西班牙語	Xī bān yá yǔ	Xī bān yá yǔ	Spanish	Spanish language	Spanish language	
+Hobbies 2	轻松	輕鬆	qīng sōng	qīng sōng	Relaxed	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	
+Hobbies 2	旅		lǚ	lǚ	trip	trip / travel / to travel / brigade (army)	trip / travel / to travel / brigade (army)	
+Hobbies 2	轻	輕	qīng	qīng	light	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	
+Hobbies 2	松		Sōng   sōng   sōng	Sōng   sōng   sōng	loose	surname Song  pine / CL: 棵  loose / to loosen / to relax	surname Song  pine / CL: 棵  loose / to loosen / to relax	
+Hobbies 2	照相机	照相機	zhào xiàng jī	zhào xiàng jī	camera	camera / CL: 個｜个, 架, 部, 台, 隻｜只	camera / CL: 個｜个, 架, 部, 台, 隻｜只	
+Hobbies 2	印度		Yìn dù	Yìn dù	India	India	India	
+Hobbies 2	拍照		pāi zhào	pāi zhào	Photograph	to take a picture	to take a picture	
+Hobbies 2	拍		pāi	pāi	beat	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)	
+Hobbies 2	照		zhào	zhào	Photo	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	
+Hobbies 2	印		Yìn   yìn	Yìn   yìn	Print	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image	
+Hobbies 2	相		Xiāng   xiāng   xiàng	Xiāng   xiāng   xiàng	phase	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	
+Hobbies 2	度		dù   duó	dù   duó	degree	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	
+Dining 1	海		Hǎi   hǎi	Hǎi   hǎi	sea	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous	
+Dining 1	本		běn	běn	this	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	
+Dining 1	还	還	Huán   hái   huán	Huán   hái   huán	also	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	
+Dining 1	上海		Shàng hǎi	Shàng hǎi	Shanghai	Shanghai municipality, central east China, abbr. to 滬｜沪	Shanghai municipality, central east China, abbr. to 滬｜沪	
+Dining 1	还是	還是	hái shi	hái shi	still is	or / still / nevertheless / had better	or / still / nevertheless / had better	
+Dining 1	日本		Rì běn	Rì běn	Japan	Japan / Japanese	Japan / Japanese	
+Dining 1	肉		ròu	ròu	meat	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute	
+Dining 1	米饭	米飯	mǐ fàn	mǐ fàn	rice	(cooked) rice	(cooked) rice	
+Dining 1	面条	麵條	miàn tiáo	miàn tiáo	noodles	noodles	noodles	
+Dining 1	鸡肉	雞肉	jī ròu	jī ròu	chicken	chicken meat	chicken meat	
+Dining 1	牛肉		niú ròu	niú ròu	beef	beef	beef	
+Dining 1	猪肉	豬肉	zhū ròu	zhū ròu	pork	pork	pork	
+Dining 1	羊肉		yáng ròu	yáng ròu	Lamb	mutton / goat meat	mutton / goat meat	
+Dining 1	饮料	飲料	yǐn liào	yǐn liào	Drink	drink / beverage	drink / beverage	
+Dining 1	猪	豬	zhū	zhū	pig	hog / pig / swine / CL: 口, 頭｜头	hog / pig / swine / CL: 口, 頭｜头	
+Dining 1	羊		Yáng   yáng	Yáng   yáng	sheep	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只	
+Dining 1	饮	飲	yǐn   yìn	yǐn   yìn	drink	to drink  to give (animals) water to drink	to drink  to give (animals) water to drink	
+Dining 1	料		liào	liào	Fee	material / stuff / grain / feed / to expect / to anticipate / to guess	material / stuff / grain / feed / to expect / to anticipate / to guess	
+Health 1	作		zuō   zuò	zuō   zuò	Make	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works	
+Health 1	工		gōng	gōng	work	work / worker / skill / profession / trade / craft / labor	work / worker / skill / profession / trade / craft / labor	
+Health 1	累		lěi   lèi   Léi   léi	lěi   lèi   Léi   léi	tired	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	
+Health 1	工作		gōng zuò	gōng zuò	jobs	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	
+Health 1	觉得	覺得	jué de	jué de	feel	to think / to feel	to think / to feel	
+Health 1	有点儿	有點兒	yǒu diǎnr	yǒu diǎnr	kind of	slightly / a little / somewhat	slightly / a little / somewhat	
+Health 1	胖		pán   pàng	pán   pàng	fat	healthy / at ease  fat / plump	healthy / at ease  fat / plump	
+Health 1	健康		jiàn kāng	jiàn kāng	health	health / healthy	health / healthy	
+Health 1	不要		bù yào	bù yào	Do not	don't! / must not	don't! / must not	
+Health 1	健		jiàn	jiàn	Healthy	healthy / to invigorate / to strengthen / to be good at / to be strong in	healthy / to invigorate / to strengthen / to be good at / to be strong in	
+Health 1	康		Kāng   kāng	Kāng   kāng	Kang	surname Kang  healthy / peaceful / abundant	surname Kang  healthy / peaceful / abundant	
+Health 1	身体	身體	shēn tǐ	shēn tǐ	body	the body / one's health / CL: 具, 個｜个 / in person	the body / one's health / CL: 具, 個｜个 / in person	
+Health 1	注意		zhù yì	zhù yì	note	to take note of / to pay attention to	to take note of / to pay attention to	
+Health 1	身		shēn	shēn	body	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158	
+Health 1	注		zhù   zhù	zhù   zhù	Note	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment	
+Health 1	意		Yì   yì	Yì   yì	meaning	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate	
+Health 1	开始	開始	kāi shǐ	kāi shǐ	Start	to begin / beginning / to start / initial / CL: 個｜个	to begin / beginning / to start / initial / CL: 個｜个	
+Health 1	锻炼	鍛鍊	duàn liàn	duàn liàn	work out	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	
+Health 1	开	開	kāi	kāi	open	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	
+Health 1	锻	鍛	duàn	duàn	Wrought	to forge / to discipline / wrought	to forge / to discipline / wrought	
+Health 1	始		shǐ	shǐ	beginning	to begin / to start / then / only then	to begin / to start / then / only then	
+Health 1	炼	煉	liàn	liàn	Refine	to refine / to smelt	to refine / to smelt	
+Transportation	铁	鐵	Tiě   tiě	Tiě   tiě	iron	surname Tie  iron (metal) / arms / weapons / hard / strong / violent / unshakeable / determined / close / tight (slang)	surname Tie  iron (metal) / arms / weapons / hard / strong / violent / unshakeable / determined / close / tight (slang)	
+Transportation	店		diàn	diàn	shop	inn / shop / store / CL: 家	inn / shop / store / CL: 家	
+Transportation	地		de   dì	de   dì	Ground	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	
+Transportation	酒		jiǔ	jiǔ	liqueur	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	
+Transportation	酒店		jiǔ diàn	jiǔ diàn	Hotels	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	
+Transportation	地铁	地鐵	dì tiě	dì tiě	subway	subway / metro	subway / metro	
+Transportation	不准		bù zhǔn	bù zhǔn	Forbid	not to allow / to forbid / to prohibit	not to allow / to forbid / to prohibit	
+Transportation	准		zhǔn   zhǔn	zhǔn   zhǔn	quasi-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	
+Transportation	出租车	出租車	chū zū chē	chū zū chē	taxi	taxi / (Taiwan) rental car	taxi / (Taiwan) rental car	
+Transportation	站		zhàn	zhàn	station	station / to stand / to halt / to stop / branch of a company or organization / website	station / to stand / to halt / to stop / branch of a company or organization / website	
+Transportation	车	車	Chē   chē   jū	Chē   chē   jū	car	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)	
+Transportation	出		chū	chū	Out	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	
+Transportation	租		zū	zū	rent	to hire / to rent / to charter / to rent out / to lease out / rent / land tax	to hire / to rent / to charter / to rent out / to lease out / rent / land tax	
+Transportation	可以		kě yǐ	kě yǐ	can	can / may / possible / able to / not bad / pretty good	can / may / possible / able to / not bad / pretty good	
+Transportation	汽车	汽車	qì chē	qì chē	car	car / automobile / bus / CL: 輛｜辆	car / automobile / bus / CL: 輛｜辆	
+Transportation	公共		gōng gòng	gōng gòng	public	public / common / communal	public / common / communal	
+Transportation	船		chuán	chuán	ferry	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	
+Transportation	公		gōng	gōng	public	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)	
+Transportation	汽		qì	qì	vapor	steam / vapor	steam / vapor	
+Shopping 1	件		jiàn	jiàn	Matter	item / component / classifier for events, things, clothes etc	item / component / classifier for events, things, clothes etc	
+Shopping 1	衣		yī   yì	yī   yì	clothes	clothes / CL: 件  to dress / to wear / to put on (clothes)	clothes / CL: 件  to dress / to wear / to put on (clothes)	
+Shopping 1	商		Shāng   shāng	Shāng   shāng	Business	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)	
+Shopping 1	商店		shāng diàn	shāng diàn	store	store / shop / CL: 家, 個｜个	store / shop / CL: 家, 個｜个	
+Shopping 1	衣服		yī fu	yī fu	clothes	clothes / CL: 件, 套	clothes / CL: 件, 套	
+Shopping 1	门	門	Mén   mén	Mén   mén	door	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	
+Shopping 1	欢迎	歡迎	huān yíng	huān yíng	welcome	to welcome / welcome	to welcome / welcome	
+Shopping 1	迎		yíng	yíng	welcome	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)	
+Shopping 1	您		nín	nín	you	you (courteous, as opposed to informal 你)	you (courteous, as opposed to informal 你)	
+Shopping 1	帮忙	幫忙	bāng máng	bāng máng	help	to help / to lend a hand / to do a favor / to do a good turn	to help / to lend a hand / to do a favor / to do a good turn	
+Shopping 1	需要		xū yào	xū yào	need	to need / to want / to demand / to require / requirement / need	to need / to want / to demand / to require / requirement / need	
+Shopping 1	需		xū	xū	need	to require / to need / to want / necessity / need	to require / to need / to want / necessity / need	
+Shopping 1	随便	隨便	suí biàn	suí biàn	casual	as one wishes / as one pleases / at random / negligent / casual / wanton	as one wishes / as one pleases / at random / negligent / casual / wanton	
+Shopping 1	随	隨	Suí   suí	Suí   suí	Follow	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently	
+Languages	读	讀	dòu   dú	dòu   dú	read	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	
+Languages	意思		yì si	yì si	meaning	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc	
+Languages	写	寫	xiě	xiě	write	to write	to write	
+Languages	难	難	nán   nàn	nán   nàn	difficult	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold	
+Languages	思		sī	sī	think	to think / to consider	to think / to consider	
+Time 3	秒		miǎo	miǎo	second	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	
+Time 3	刻		kè	kè	engraved	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	
+Time 3	差		chā   chà   chāi	chā   chà   chāi	difference	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	
+Time 3	小时	小時	xiǎo shí	xiǎo shí	hour	hour / CL: 個｜个	hour / CL: 個｜个	
+Time 3	分钟	分鐘	fēn zhōng	fēn zhōng	minute	minute	minute	
+Time 3	小		xiǎo	xiǎo	small	small / tiny / few / young	small / tiny / few / young	
+Time 3	时	時	Shí   shí	Shí   shí	Time	surname Shi  o'clock / time / when / hour / season / period	surname Shi  o'clock / time / when / hour / season / period	
+Time 3	钟	鍾	Zhōng   zhōng   zhōng	Zhōng   zhōng   zhōng	bell	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座	
+Time 3	整		zhěng	zhěng	whole	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	
+Dining 2	杯		bēi	bēi	cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup	
+Dining 2	啤		pí	pí	beer	beer	beer	
+Dining 2	德		Dé   dé	Dé   dé	Morality	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind	
+Dining 2	德国	德國	Dé guó	Dé guó	Germany	Germany / German	Germany / German	
+Dining 2	啤酒		pí jiǔ	pí jiǔ	beer	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	
+Dining 2	果汁		guǒ zhī	guǒ zhī	fruit juice	fruit juice	fruit juice	
+Dining 2	汁		zhī	zhī	juice	juice	juice	
+Dining 2	香蕉		xiāng jiāo	xiāng jiāo	banana	banana / CL: 枝, 根, 個｜个, 把	banana / CL: 枝, 根, 個｜个, 把	
+Dining 2	蛋糕		dàn gāo	dàn gāo	cake	cake / CL: 塊｜块, 個｜个	cake / CL: 塊｜块, 個｜个	
+Dining 2	蕉		jiāo   qiáo	jiāo   qiáo	banana	banana  see 蕉萃	banana  see 蕉萃	
+Dining 2	糕		gāo	gāo	cake	cake	cake	
+Dining 2	碗		wǎn	wǎn	bowl	bowl / cup / CL: 隻｜只, 個｜个	bowl / cup / CL: 隻｜只, 個｜个	
+Dining 2	杯子		bēi zi	bēi zi	cup	cup / glass / CL: 個｜个, 隻｜只	cup / glass / CL: 個｜个, 隻｜只	
+Dining 2	盘子	盤子	pán zi	pán zi	plate	tray / plate / dish / CL: 個｜个	tray / plate / dish / CL: 個｜个	
+Dining 2	盘	盤	pán	pán	plate	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess	
+Dining 2	筷子		kuài zi	kuài zi	chopsticks	chopsticks / CL: 對｜对, 根, 把, 雙｜双	chopsticks / CL: 對｜对, 根, 把, 雙｜双	
+Dining 2	刀		Dāo   dāo	Dāo   dāo	Knife	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	
+Dining 2	叉		chā   chá   chǎ	chā   chá   chǎ	cross	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	
+Dining 2	筷		kuài	kuài	chopsticks	chopstick	chopstick	
+Dining 2	勺子		sháo zi	sháo zi	Spoon	scoop / ladle / CL: 把	scoop / ladle / CL: 把	
+Dining 2	勺		sháo	sháo	Spoon	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)	
+Existence	室		Shì   shì	Shì   shì	room	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	
+Existence	办	辦	bàn	bàn	do	to do / to manage / to handle / to go about / to run / to set up / to deal with	to do / to manage / to handle / to go about / to run / to set up / to deal with	
+Existence	辆	輛	liàng	liàng	Vehicles	classifier for vehicles	classifier for vehicles	
+Existence	办公室	辦公室	bàn gōng shì	bàn gōng shì	office	office / business premises / bureau / CL: 間｜间	office / business premises / bureau / CL: 間｜间	
+Existence	瓶子		píng zi	píng zi	bottle	bottle / CL: 個｜个	bottle / CL: 個｜个	
+Existence	照片		zhào piàn	zhào piàn	photo	photograph / picture / CL: 張｜张, 套, 幅	photograph / picture / CL: 張｜张, 套, 幅	
+Existence	瓶		píng	píng	bottle	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	
+Existence	片		piān   piàn	piān   piàn	sheet	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc	
+Existence	鸟	鳥	niǎo	niǎo	bird	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam	
+Existence	树	樹	shù	shù	tree	tree / CL: 棵 / to cultivate / to set up	tree / CL: 棵 / to cultivate / to set up	
+Sports 1	步		Bù   bù	Bù   bù	step	surname Bu  a step / a pace / walk / march / stages in a process / situation	surname Bu  a step / a pace / walk / march / stages in a process / situation	
+Sports 1	跑		páo   pǎo	páo   pǎo	run	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off	
+Sports 1	泳		yǒng	yǒng	swimming	swimming / to swim	swimming / to swim	
+Sports 1	游泳		yóu yǒng	yóu yǒng	Swim	swimming / to swim	swimming / to swim	
+Sports 1	跑步		pǎo bù	pǎo bù	Run	to run / to jog / (military) to march at the double	to run / to jog / (military) to march at the double	
+Sports 1	踢		tī	tī	kick	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	
+Sports 1	足球		zú qiú	zú qiú	football	soccer ball / a football / CL: 個｜个 / soccer / football	soccer ball / a football / CL: 個｜个 / soccer / football	
+Sports 1	打		dá   dǎ	dá   dǎ	hit	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from	
+Sports 1	篮球	籃球	lán qiú	lán qiú	basketball	basketball / CL: 個｜个, 隻｜只	basketball / CL: 個｜个, 隻｜只	
+Sports 1	足		jù   zú	jù   zú	leg	excessive  foot / to be sufficient / ample	excessive  foot / to be sufficient / ample	
+Sports 1	篮	籃	lán	lán	basket	basket (receptacle) / basket (in basketball)	basket (receptacle) / basket (in basketball)	
+Sports 1	球		qiú	qiú	ball	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场	
+Sports 1	运动	運動	yùn dòng	yùn dòng	motion	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	
+Sports 1	马	馬	Mǎ   mǎ	Mǎ   mǎ	horse	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess	
+Sports 1	骑	騎	jì   qí	jì   qí	ride	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	
+Sports 1	运	運	yùn	yùn	Transport	to move / to transport / to use / to apply / fortune / luck / fate	to move / to transport / to use / to apply / fortune / luck / fate	
+Sports 1	动	動	dòng	dòng	move	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb	
+Invitiation 1	吧		bā   ba	bā   ba	It	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	
+Invitiation 1	出去		chū qù	chū qù	Out	to go out	to go out	
+Invitiation 1	时间	時間	shí jiān	shí jiān	time	time / period / CL: 段	time / period / CL: 段	
+Invitiation 1	时候	時候	shí hou	shí hou	time	time / length of time / moment / period	time / length of time / moment / period	
+Invitiation 1	空		kōng   kòng	kōng   kòng	air	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	
+Invitiation 1	来	來	lái	lái	Come	to come / to arrive / to come round / ever since / next	to come / to arrive / to come round / ever since / next	
+Invitiation 1	候		hòu	hòu	Wait	to wait / to inquire after / to watch / season / climate / (old) period of five days	to wait / to inquire after / to watch / season / climate / (old) period of five days	
+Invitiation 1	过	過	Guò   guò   guo	Guò   guò   guo	Live	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	
+Invitiation 1	一起		yī qǐ	yī qǐ	together	in the same place / together / with / altogether (in total)	in the same place / together / with / altogether (in total)	
+Invitiation 1	不好意思		bù hǎo yì si	bù hǎo yì si	Feel embarrassed	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	
+Invitiation 1	告诉	告訴	gào sù   gào su	gào sù   gào su	tell	to press charges / to file a complaint  to tell / to inform / to let know	to press charges / to file a complaint  to tell / to inform / to let know	
+Invitiation 1	告		gào	gào	Tell	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue	
+Invitiation 1	诉	訴	sù	sù	Complaint	to complain / to sue / to tell	to complain / to sue / to tell	
+Invitiation 1	约会	約會	yuē huì	yuē huì	appointment	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	
+Invitiation 1	浪漫		làng màn	làng màn	romantic	romantic	romantic	
+Invitiation 1	浪		làng	làng	wave	wave / breaker / unrestrained / dissipated	wave / breaker / unrestrained / dissipated	
+Invitiation 1	漫		màn	màn	Overflow	free / unrestrained / to inundate	free / unrestrained / to inundate	
+Health 2	该	該	gāi	gāi	That	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned	
+Health 2	病		bìng	bìng	disease	illness / CL: 場｜场 / disease / to fall ill / defect	illness / CL: 場｜场 / disease / to fall ill / defect	
+Health 2	舒		Shū   shū	Shū   shū	Shu	surname Shu  to stretch / to unfold / to relax / leisurely	surname Shu  to stretch / to unfold / to relax / leisurely	
+Health 2	应	應	Yìng   yīng   yìng	Yìng   yīng   yìng	should	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	
+Health 2	生病		shēng bìng	shēng bìng	sick	to fall ill	to fall ill	
+Health 2	应该	應該	yīng gāi	yīng gāi	should	ought to / should / must	ought to / should / must	
+Health 2	舒服		shū fu	shū fu	Comfortably	comfortable / feeling well	comfortable / feeling well	
+Health 2	疼		téng	téng	pain	(it) hurts / sore / to love dearly	(it) hurts / sore / to love dearly	
+Health 2	头	頭	tóu   tou	tóu   tou	head	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns	
+Health 2	休息		xiū xi	xiū xi	rest	rest / to rest	rest / to rest	
+Health 2	休		Xiū   xiū	Xiū   xiū	Rest	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't	
+Health 2	息		xī	xī	interest	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]	
+Health 2	肚子		dù zi	dù zi	belly	belly / abdomen / stomach / CL: 個｜个	belly / abdomen / stomach / CL: 個｜个	
+Health 2	肚		dǔ   dù	dǔ   dù	tripe	tripe  belly	tripe  belly	
+Health 2	药	葯	yào   yào	yào   yào	medicine	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	
+Health 2	一定		yī dìng	yī dìng	for sure	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	
+Health 2	感冒		gǎn mào	gǎn mào	cold	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	
+Health 2	感		gǎn	gǎn	sense	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~	
+Health 2	定		dìng	dìng	set	to set / to fix / to determine / to decide / to order	to set / to fix / to determine / to decide / to order	
+Health 2	冒		Mào   mào	Mào   mào	Risk	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover	
+Health 2	留		liú	liú	stay	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve	
+Health 2	请假	請假	qǐng jià	qǐng jià	Ask for leave	to request leave of absence	to request leave of absence	
+Health 2	发烧	發燒	fā shāo	fā shāo	fever	to have a high temperature (from illness) / to have a fever	to have a high temperature (from illness) / to have a fever	
+Health 2	别	別	Bié   bié   biè	Bié   bié   biè	do not	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc	
+Health 2	发	發	fā   fà	fā   fà	hair	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	
+Health 2	假		jiǎ   jià	jiǎ   jià	false	fake / false / artificial / to borrow / if / suppose  vacation	fake / false / artificial / to borrow / if / suppose  vacation	
+Health 2	烧	燒	shāo	shāo	burn	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head	
+Invitation 2	派		pài	pài	send	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie	
+Invitation 2	能		Néng   néng	Néng   néng	can	surname Neng  can / to be able to / might possibly / ability / (physics) energy	surname Neng  can / to be able to / might possibly / ability / (physics) energy	
+Invitation 2	生日		shēng rì	shēng rì	birthday	birthday / CL: 個｜个	birthday / CL: 個｜个	
+Invitation 2	派对	派對	pài duì	pài duì	Party	party (loanword)	party (loanword)	
+Invitation 2	打扮		dǎ ban	dǎ ban	dress up	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	
+Invitation 2	扮		bàn	bàn	Play	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)	
+Invitation 2	希望		xī wàng	xī wàng	hope	to wish for / to desire / hope / CL: 個｜个	to wish for / to desire / hope / CL: 個｜个	
+Invitation 2	跟		gēn	gēn	with	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	
+Invitation 2	希		xī	xī	hope	to hope / to admire / variant of 稀	to hope / to admire / variant of 稀	
+Invitation 2	望		wàng   wàng	wàng   wàng	hope	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望	
+Invitation 2	大家		dà jiā	dà jiā	everyone	everyone / influential family / great expert	everyone / influential family / great expert	
+Invitation 2	公司		gōng sī	gōng sī	the company	(business) company / company / firm / corporation / incorporated / CL: 家	(business) company / company / firm / corporation / incorporated / CL: 家	
+Invitation 2	正在		zhèng zài	zhèng zài	Seizai	just at (that time) / right in (that place) / right in the middle of (doing sth)	just at (that time) / right in (that place) / right in the middle of (doing sth)	
+Invitation 2	正		zhēng   zhèng	zhēng   zhèng	positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive	
+Invitation 2	司		Sī   sī	Sī   sī	Department	surname Si  to take charge of / to manage / department (under a ministry)	surname Si  to take charge of / to manage / department (under a ministry)	
+Invitation 2	事情		shì qing	shì qing	thing	affair / matter / thing / business / CL: 件, 樁｜桩	affair / matter / thing / business / CL: 件, 樁｜桩	
+Invitation 2	才		cái   cái	cái   cái	only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only	
+Invitation 2	事		shì	shì	Thing	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	
+Invitation 2	情		qíng	qíng	situation	feeling / emotion / passion / situation	feeling / emotion / passion / situation	
+Dining 3	费	費	Fèi   fèi	Fèi   fèi	fee	surname Fei  to cost / to spend / fee / wasteful / expenses	surname Fei  to cost / to spend / fee / wasteful / expenses	
+Dining 3	完		wán	wán	Finish	to finish / to be over / whole / complete / entire	to finish / to be over / whole / complete / entire	
+Dining 3	经	經	Jīng   jīng	Jīng   jīng	through	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	
+Dining 3	已		yǐ	yǐ	Already	already / to stop / then / afterwards	already / to stop / then / afterwards	
+Dining 3	已经	已經	yǐ jīng	yǐ jīng	already	already	already	
+Dining 3	小费	小費	xiǎo fèi	xiǎo fèi	tip	tip / gratuity	tip / gratuity	
+Dining 3	饱	飽	bǎo	bǎo	full	to eat till full / satisfied	to eat till full / satisfied	
+Dining 3	好吃		hǎo chī   hào chī	hǎo chī   hào chī	good to eat	tasty / delicious  to be fond of eating / to be gluttonous	tasty / delicious  to be fond of eating / to be gluttonous	
+Dining 3	真		zhēn	zhēn	true	really / truly / indeed / real / true / genuine	really / truly / indeed / real / true / genuine	
+Dining 3	饿	餓	è	è	hungry	to be hungry / hungry / to starve (sb)	to be hungry / hungry / to starve (sb)	
+Dining 3	好喝		hǎo hē	hǎo hē	Tasty	tasty (drinks)	tasty (drinks)	
+Dining 3	渴		kě	kě	thirsty	thirsty	thirsty	
+Dining 3	巧克力		qiǎo kè lì	qiǎo kè lì	chocolate	chocolate (loanword) / CL: 塊｜块	chocolate (loanword) / CL: 塊｜块	
+Dining 3	味道		wèi dao	wèi dao	taste	flavor / smell / hint of	flavor / smell / hint of	
+Dining 3	甜点	甜點	tián diǎn	tián diǎn	dessert	dessert	dessert	
+Dining 3	甜		tián	tián	sweet	sweet	sweet	
+Dining 3	巧		qiǎo	qiǎo	Opportunely	opportunely / coincidentally / as it happens / skillful / timely	opportunely / coincidentally / as it happens / skillful / timely	
+Dining 3	克		kè   Kè   kēi	kè   Kè   kēi	Gram	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat	
+Dining 3	力		Lì   lì	Lì   lì	force	surname Li  power / force / strength / ability / strenuously	surname Li  power / force / strength / ability / strenuously	
+Shopping 2	试	試	shì	shì	test	to test / to try / experiment / examination / test	to test / to try / experiment / examination / test	
+Shopping 2	蓝	藍	Lán   lán	Lán   lán	blue	surname Lan  blue / indigo plant	surname Lan  blue / indigo plant	
+Shopping 2	条	條	tiáo	tiáo	article	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)	
+Shopping 2	裙		qún	qún	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条	
+Shopping 2	裙子		qún zi	qún zi	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条	
+Shopping 2	双	雙	Shuāng   shuāng	Shuāng   shuāng	double	surname Shuang  two / double / pair / both / even (number)	surname Shuang  two / double / pair / both / even (number)	
+Shopping 2	鞋子		xié zi	xié zi	Shoe	shoe	shoe	
+Shopping 2	意大利		Yì dà lì	Yì dà lì	Italy	Italy / Italian	Italy / Italian	
+Shopping 2	色		sè   shǎi	sè   shǎi	color	color / CL: 種｜种 / look / appearance / sex  color / dice	color / CL: 種｜种 / look / appearance / sex  color / dice	
+Shopping 2	鞋		xié	xié	shoe	shoe / CL: 雙｜双, 隻｜只	shoe / CL: 雙｜双, 隻｜只	
+Shopping 2	利		Lì   lì	Lì   lì	Profit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	
+Shopping 2	比		Bǐ   bǐ   bì	Bǐ   bǐ   bì	ratio	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near	
+Shopping 2	衬衫	襯衫	chèn shān	chèn shān	shirt	shirt / blouse / CL: 件	shirt / blouse / CL: 件	
+Shopping 2	衬	襯	chèn	chèn	lining	(of garments) against the skin / to line / lining / to contrast with / to assist financially	(of garments) against the skin / to line / lining / to contrast with / to assist financially	
+Shopping 2	衫		shān	shān	Shirt	garment / jacket with open slits in place of sleeves	garment / jacket with open slits in place of sleeves	
+Shopping 2	裤子	褲子	kù zi	kù zi	pants	trousers / pants / CL: 條｜条	trousers / pants / CL: 條｜条	
+Shopping 2	好看		hǎo kàn	hǎo kàn	good looking	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	
+Shopping 2	裤	褲	kù	kù	pants	underpants / trousers / pants	underpants / trousers / pants	
+Shopping 2	质	質	zhì	zhì	quality	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]	
+Shopping 2	量		liáng   liàng	liáng   liàng	the amount	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word	
+Shopping 2	质量	質量	zhì liàng	zhì liàng	quality	quality / (physics) mass / CL: 個｜个	quality / (physics) mass / CL: 個｜个	
+Body Parts	朵		duǒ	duǒ	Flowers	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc	
+Body Parts	睛		jīng	jīng	eye	eye / eyeball	eye / eyeball	
+Body Parts	绿	綠	lǜ	lǜ	green	green	green	
+Body Parts	耳		ěr	ěr	ear	ear / handle (archaeology) / and that is all (classical Chinese)	ear / handle (archaeology) / and that is all (classical Chinese)	
+Body Parts	眼		yǎn	yǎn	eye	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)	
+Body Parts	耳朵		ěr duo	ěr duo	ear	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	
+Body Parts	眼睛		yǎn jing	yǎn jing	eye	eye / CL: 隻｜只, 雙｜双	eye / CL: 隻｜只, 雙｜双	
+Body Parts	头发	頭髮	tóu fa	tóu fa	hair	hair (on the head)	hair (on the head)	
+Body Parts	脸	臉	liǎn	liǎn	face	face / CL: 張｜张, 個｜个	face / CL: 張｜张, 個｜个	
+Body Parts	又		yòu	yòu	also	(once) again / also / both... and... / and yet / (used for emphasis) anyway	(once) again / also / both... and... / and yet / (used for emphasis) anyway	
+Body Parts	黑		Hēi   hēi	Hēi   hēi	black	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)	
+Body Parts	嘴巴		zuǐ ba	zuǐ ba	mouth	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	
+Body Parts	鼻子		bí zi	bí zi	nose	nose / CL: 個｜个, 隻｜只	nose / CL: 個｜个, 隻｜只	
+Body Parts	脚	腳	jiǎo	jiǎo	foot	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	
+Body Parts	嘴		zuǐ	zuǐ	mouth	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个	
+Body Parts	鼻		bí	bí	nose	nose	nose	
+Body Parts	巴		Bā   bā	Bā   bā	-bar	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail	
+Travel	远	遠	yuǎn   yuàn	yuǎn   yuàn	far	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	
+Travel	离		chī   Lí   lí	chī   Lí   lí	from	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲	
+Travel	走路		zǒu lù	zǒu lù	walk	to walk / to go on foot	to walk / to go on foot	
+Travel	开车	開車	kāi chē	kāi chē	Drive a car	to drive a car	to drive a car	
+Travel	飞机	飛機	fēi jī	fēi jī	aircraft	airplane / CL: 架	airplane / CL: 架	
+Travel	机场	機場	jī chǎng	jī chǎng	airport	airport / airfield / CL: 家, 處｜处	airport / airfield / CL: 家, 處｜处	
+Travel	飞	飛	fēi	fēi	fly	to fly	to fly	
+Travel	场	場	cháng   chǎng	cháng   chǎng	field	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams	
+Travel	靠		kào	kào	by	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	
+Travel	停		tíng	tíng	stop	to stop / to halt / to park (a car)	to stop / to halt / to park (a car)	
+Travel	火车	火車	huǒ chē	huǒ chē	train	train / CL: 列, 節｜节, 班, 趟	train / CL: 列, 節｜节, 班, 趟	
+Travel	票		piào	piào	ticket	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions	
+Travel	机票	機票	jī piào	jī piào	Air tickets	air ticket / passenger ticket / CL: 張｜张	air ticket / passenger ticket / CL: 張｜张	
+Travel	火		Huǒ   huǒ	Huǒ   huǒ	fire	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)	
+Travel	迟到	遲到	chí dào	chí dào	be late	to arrive late	to arrive late	
+Travel	让	讓	ràng	ràng	Let	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	
+Travel	怎么办	怎麼辦	zěn me bàn	zěn me bàn	How to do	what's to be done	what's to be done	
+Travel	迟	遲	Chí   chí	Chí   chí	late	surname Chi  late / delayed / slow	surname Chi  late / delayed / slow	
+Weather	冷		Lěng   lěng	Lěng   lěng	cold	surname Leng  cold	surname Leng  cold	
+Weather	晴		qíng	qíng	clear	clear / fine (weather)	clear / fine (weather)	
+Weather	天气	天氣	tiān qì	tiān qì	the weather	weather	weather	
+Weather	雨		yǔ   yù	yǔ   yù	rain	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	
+Weather	雪		Xuě   xuě	Xuě   xuě	snow	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	
+Weather	阴	陰	Yīn   yīn	Yīn   yīn	Yin	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	
+Weather	着	著	zhāo   zháo   zhe   zhuó	zhāo   zháo   zhe   zhuó	The	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	
+Weather	伞	傘	sǎn   sǎn	sǎn   sǎn	umbrella	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	
+Weather	带	帶	dài	dài	band	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	
+Weather	外面		wài miàn	wài miàn	outside	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	
+Weather	可能		kě néng	kě néng	may	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	
+Weather	刮		guā   guā	guā   guā	scratch	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	
+Weather	风	風	fēng	fēng	wind	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝	
+Weather	如果		rú guǒ	rú guǒ	in case	if / in case / in the event that	if / in case / in the event that	
+Weather	就		jiù	jiù	on	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	
+Weather	从来	從來	cóng lái	cóng lái	Never	always / at all times / never (if used in negative sentence)	always / at all times / never (if used in negative sentence)	
+Weather	如		rú	rú	Such as	as / as if / such as	as / as if / such as	
+Weather	里面	裡面	lǐ miàn	lǐ miàn	inside	inside / interior / also pr. [li3 mian5]	inside / interior / also pr. [li3 mian5]	
+Shopping 3	然		rán	rán	However	correct / right / so / thus / like this / -ly	correct / right / so / thus / like this / -ly	
+Shopping 3	但		dàn	dàn	but	but / yet / however / only / merely / still	but / yet / however / only / merely / still	
+Shopping 3	虽	雖	suī	suī	although	although / even though	although / even though	
+Shopping 3	短		duǎn	duǎn	short	short / brief / to lack / weak point / fault	short / brief / to lack / weak point / fault	
+Shopping 3	长	長	cháng   zhǎng	cháng   zhǎng	long	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	
+Shopping 3	虽然	雖然	suī rán	suī rán	although	although / even though / even if	although / even though / even if	
+Shopping 3	但是		dàn shì	dàn shì	but	but / however	but / however	
+Shopping 3	红	紅	Hóng   hóng	Hóng   hóng	red	surname Hong  red / popular / revolutionary / bonus	surname Hong  red / popular / revolutionary / bonus	
+Shopping 3	颜色	顏色	yán sè	yán sè	colour	color / countenance / appearance / facial expression / pigment / dyestuff	color / countenance / appearance / facial expression / pigment / dyestuff	
+Shopping 3	穿		chuān	chuān	wear	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	
+Shopping 3	颜	顏	Yán   yán	Yán   yán	Color	surname Yan  color / face / countenance	surname Yan  color / face / countenance	
+Shopping 3	黄	黃	Huáng   huáng	Huáng   huáng	yellow	surname Huang or Hwang  yellow / pornographic / to fall through	surname Huang or Hwang  yellow / pornographic / to fall through	
+Shopping 3	手表	手錶	shǒu biǎo	shǒu biǎo	Watch	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	
+Shopping 3	卖	賣	mài	mài	Sell	to sell / to betray / to spare no effort / to show off or flaunt	to sell / to betray / to spare no effort / to show off or flaunt	
+Shopping 3	帽子		mào zi	mào zi	hat	hat / cap / (fig.) label / bad name / CL: 頂｜顶	hat / cap / (fig.) label / bad name / CL: 頂｜顶	
+Shopping 3	帽		mào	mào	cap	hat / cap	hat / cap	
+Shopping 3	表		biǎo   biǎo	biǎo   biǎo	table	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch	
+Shopping 3	紫		zǐ	zǐ	purple	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	
+People 2	绍	紹	Shào   shào	Shào   shào	Introduce	surname Shao  to continue / to carry on	surname Shao  to continue / to carry on	
+People 2	介		jiè	jiè	Introduction	to introduce / to lie between / between / shell / armor	to introduce / to lie between / between / shell / armor	
+People 2	介绍	介紹	jiè shào	jiè shào	Introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	
+People 2	帅	帥	Shuài   shuài	Shuài   shuài	Shuai	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!	
+People 2	笑		xiào	xiào	Lol	laugh / smile / CL: 個｜个	laugh / smile / CL: 個｜个	
+People 2	说话	說話	shuō huà	shuō huà	speak	to speak / to say / to talk / to gossip / to tell stories / talk / word	to speak / to say / to talk / to gossip / to tell stories / talk / word	
+People 2	聪明	聰明	cōng ming	cōng ming	clever	intelligent / clever / bright / smart / acute (of sight and hearing)	intelligent / clever / bright / smart / acute (of sight and hearing)	
+People 2	别人	別人	bié ren	bié ren	other people	other people / others / other person	other people / others / other person	
+People 2	不但		bù dàn	bù dàn	Not only	not only (... but also...)	not only (... but also...)	
+People 2	而且		ér qiě	ér qiě	and	(not only ...) but also / moreover / in addition / furthermore	(not only ...) but also / moreover / in addition / furthermore	
+People 2	聪	聰	cōng	cōng	Clever	quick at hearing / wise / clever / sharp-witted / intelligent / acute	quick at hearing / wise / clever / sharp-witted / intelligent / acute	
+People 2	而		ér	ér	and	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)	
+People 2	且		qiě	qiě	And	and / moreover / yet / for the time being / to be about to / both (... and...)	and / moreover / yet / for the time being / to be about to / both (... and...)	
+Celebration	春		Chūn   chūn	Chūn   chūn	spring	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	
+Celebration	快乐	快樂	kuài lè	kuài lè	happy	happy / merry	happy / merry	
+Celebration	节日	節日	jié rì	jié rì	festival	holiday / festival / CL: 個｜个	holiday / festival / CL: 個｜个	
+Celebration	春节	春節	Chūn jié	Chūn jié	Spring Festival	Spring Festival (Chinese New Year)	Spring Festival (Chinese New Year)	
+Celebration	礼物	禮物	lǐ wù	lǐ wù	gift	gift / present / CL: 件, 個｜个, 份	gift / present / CL: 件, 個｜个, 份	
+Celebration	送		sòng	sòng	give away	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	
+Celebration	新年		xīn nián	xīn nián	new Year	New Year / CL: 個｜个	New Year / CL: 個｜个	
+Celebration	白酒		bái jiǔ	bái jiǔ	Spirit	baijiu, a spirit usually distilled from sorghum	baijiu, a spirit usually distilled from sorghum	
+Celebration	礼	禮	Lǐ   lǐ	Lǐ   lǐ	ceremony	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy	
+Celebration	物		wù	wù	object	thing / object / matter / abbr. for physics 物理	thing / object / matter / abbr. for physics 物理	
+Celebration	干杯	乾杯	gān bēi	gān bēi	Cheers	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	
+Celebration	祝		Zhù   zhù	Zhù   zhù	wish	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	
+Celebration	法国	法國	Fǎ guó	Fǎ guó	France	France / French	France / French	
+Celebration	红酒		hóng jiǔ	hóng jiǔ	Red wine	Red wine	Red wine	
+Celebration	法		Fǎ   fǎ	Fǎ   fǎ	law	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	
+Sports 2	赛	賽	sài	sài	Competition	to compete / competition / match / to surpass / better than / superior to / to excel	to compete / competition / match / to surpass / better than / superior to / to excel	
+Sports 2	练	練	liàn	liàn	practice	to practice / to train / to drill / to perfect (one's skill) / exercise	to practice / to train / to drill / to perfect (one's skill) / exercise	
+Sports 2	练习	練習	liàn xí	liàn xí	Exercise	to practice / exercise / drill / practice / CL: 個｜个	to practice / exercise / drill / practice / CL: 個｜个	
+Sports 2	比赛	比賽	bǐ sài	bǐ sài	game	competition (sports etc) / match / CL: 場｜场, 次 / to compete	competition (sports etc) / match / CL: 場｜场, 次 / to compete	
+Sports 2	好在		hǎo zài	hǎo zài	Fortunately	luckily / fortunately	luckily / fortunately	
+Sports 2	乒乓球		pīng pāng qiú	pīng pāng qiú	pingpong	table tennis / ping-pong / table tennis ball / CL: 個｜个	table tennis / ping-pong / table tennis ball / CL: 個｜个	
+Sports 2	乒		pīng	pīng	Table tennis	(onom.) ping / bing	(onom.) ping / bing	
+Sports 2	乓		pāng	pāng	Bang	(onom.) bang	(onom.) bang	
+Sports 2	参加	參加	cān jiā	cān jiā	participate	to participate / to take part / to join	to participate / to take part / to join	
+Sports 2	第		dì	dì	The first	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	
+Sports 2	参	參	cān   shēn	cān   shēn	Ginseng	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations	
+Sports 2	网球	網球	wǎng qiú	wǎng qiú	tennis	tennis / tennis ball / CL: 個｜个	tennis / tennis ball / CL: 個｜个	
+Sports 2	排球		pái qiú	pái qiú	volleyball	volleyball / CL: 個｜个	volleyball / CL: 個｜个	
+Sports 2	加油		jiā yóu	jiā yóu	Refuel	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	
+Sports 2	排		pái	pái	row	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	
+Sports 2	油		yóu	yóu	oil	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	
+Sports 2	输	輸	shū	shū	lose	to lose / to transport / to donate / to enter (a password)	to lose / to transport / to donate / to enter (a password)	
+Sports 2	赢	贏	yíng	yíng	win	to beat / to win / to profit	to beat / to win / to profit	
+Sports 2	失望		shī wàng	shī wàng	Disappointed	disappointed / to lose hope / to despair	disappointed / to lose hope / to despair	
+Sports 2	信心		xìn xīn	xìn xīn	confidence	confidence / faith (in sb or sth) / CL: 個｜个	confidence / faith (in sb or sth) / CL: 個｜个	
+Sports 2	失		shī	shī	Lose	to lose / to miss / to fail	to lose / to miss / to fail	
+Sports 2	心		xīn	xīn	heart	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个	
+School	同	仝	tóng   tóng   tòng	tóng   tóng   tòng	with	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同	
+School	课	課	kè	kè	class	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination	
+School	教		Jiào   jiāo   jiào	Jiào   jiāo   jiào	teach	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	
+School	教室		jiào shì	jiào shì	Classroom	classroom / CL: 間｜间	classroom / CL: 間｜间	
+School	同学	同學	tóng xué	tóng xué	Classmate	to study at the same school / fellow student / classmate / CL: 位, 個｜个	to study at the same school / fellow student / classmate / CL: 位, 個｜个	
+School	地理		dì lǐ	dì lǐ	Geography	geography	geography	
+School	理		lǐ	lǐ	Reason	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up	
+School	懂		dǒng	dǒng	understand	to understand / to comprehend	to understand / to comprehend	
+School	问题	問題	wèn tí	wèn tí	problem	question / problem / issue / topic / CL: 個｜个	question / problem / issue / topic / CL: 個｜个	
+School	笔	筆	bǐ	bǐ	pen	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝	
+School	题	題	Tí   tí	Tí   tí	question	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道	
+School	美术	美術	měi shù	měi shù	art	art / fine arts / painting / CL: 種｜种	art / fine arts / painting / CL: 種｜种	
+School	术	術	shù   zhú	shù   zhú	Technique	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea	
+School	考试	考試	kǎo shì	kǎo shì	examination	to take an exam / exam / CL: 次	to take an exam / exam / CL: 次	
+School	准备	準備	zhǔn bèi	zhǔn bèi	ready	preparation / to prepare / to intend / to be about to / reserve (fund)	preparation / to prepare / to intend / to be about to / reserve (fund)	
+School	考	攷	kǎo   kǎo	kǎo   kǎo	test	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	
+School	备	備	bèi	bèi	Equipment	to prepare / get ready / to provide or equip	to prepare / get ready / to provide or equip	
+School	科学	科學	kē xué	kē xué	science	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	
+School	科		kē	kē	Family	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个	
+School	下课	下課	xià kè	xià kè	Finish class	to finish class / to get out of class	to finish class / to get out of class	
+Family 3	爷爷	爺爺	yé ye	yé ye	grandfather	(coll.) father's father / paternal grandfather / CL: 個｜个	(coll.) father's father / paternal grandfather / CL: 個｜个	
+Family 3	奶奶		nǎi nai	nǎi nai	grandmother	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	
+Family 3	阿姨		ā yí	ā yí	Auntie	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	
+Family 3	爷	爺	yé	yé	Father	grandpa / old gentleman	grandpa / old gentleman	
+Family 3	阿		Ā   ā   ē	Ā   ā   ē	A	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter	
+Family 3	姨		yí	yí	aunt	mother's sister / aunt	mother's sister / aunt	
+Family 3	兄弟姐妹		xiōng dì jiě mèi	xiōng dì jiě mèi	brothers and sisters	Brothers and Sisters	Brothers and Sisters	
+Family 3	关系	關係	guān xi	guān xi	relationship	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个	
+Family 3	叔叔		shū shu	shū shu	uncle	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	
+Family 3	父母		fù mǔ	fù mǔ	parents	father and mother / parents	father and mother / parents	
+Family 3	兄		xiōng	xiōng	Brother	elder brother	elder brother	
+Family 3	叔		shū	shū	uncle	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]	
+Family 3	父		fù	fù	father	father	father	
+Family 3	母		mǔ	mǔ	mother	mother / elderly female relative / origin / source / (of animals) female	mother / elderly female relative / origin / source / (of animals) female	
+Family 3	像		xiàng	xiàng	image	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	
+Family 3	一样	一樣	yī yàng	yī yàng	same	same / like / equal to / the same as / just like	same / like / equal to / the same as / just like	
+Family 3	亲戚	親戚	qīn qi	qīn qi	relative	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	
+Family 3	戚		Qī   qī	Qī   qī	Qi	surname Qi  relative / parent / grief / sorrow / battle-axe	surname Qi  relative / parent / grief / sorrow / battle-axe	
+Family 3	亲	親	qīn   qìng	qīn   qìng	Dear	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring	
+Gourmet 1	拉面	拉麵	lā miàn	lā miàn	Hand-Pulled Noodle	pulled noodles / ramen	pulled noodles / ramen	
+Gourmet 1	点心	點心	diǎn xin	diǎn xin	dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	
+Gourmet 1	小笼包	小籠包	xiǎo lóng bāo	xiǎo lóng bāo	Dumplings	steamed dumpling	steamed dumpling	
+Gourmet 1	拉		lā	lā	Pull	to pull / to play (a bowed instrument) / to drag / to draw / to chat	to pull / to play (a bowed instrument) / to drag / to draw / to chat	
+Gourmet 1	笼	籠	lóng   lǒng	lóng   lǒng	cage	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]	
+Gourmet 1	粥		yù   zhōu	yù   zhōu	Gruel	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	
+Gourmet 1	油条	油條	yóu tiáo	yóu tiáo	Fritters	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	
+Gourmet 1	豆浆	豆漿	dòu jiāng	dòu jiāng	Milk	soy milk	soy milk	
+Gourmet 1	豆		dòu	dòu	beans	bean / pea / CL: 棵, 粒 / sacrificial vessel	bean / pea / CL: 棵, 粒 / sacrificial vessel	
+Gourmet 1	浆	漿	jiāng   jiàng	jiāng   jiàng	Pulp	broth / serum / to starch  starch paste	broth / serum / to starch  starch paste	
+Gourmet 1	火锅	火鍋	huǒ guō	huǒ guō	Hot Pot	hotpot	hotpot	
+Gourmet 1	包子		bāo zi	bāo zi	bun	steamed stuffed bun / CL: 個｜个	steamed stuffed bun / CL: 個｜个	
+Gourmet 1	炒饭	炒飯	chǎo fàn	chǎo fàn	Fried rice	fried rice / (slang) (Tw) to have sex	fried rice / (slang) (Tw) to have sex	
+Gourmet 1	锅	鍋	guō	guō	pot	pot / pan / boiler / CL: 口, 隻｜只	pot / pan / boiler / CL: 口, 隻｜只	
+Gourmet 1	炒		chǎo	chǎo	fry	to sauté / to stir-fry / to speculate / to hype / to fire (sb)	to sauté / to stir-fry / to speculate / to hype / to fire (sb)	
+Time 4	夏		Xià   xià	Xià   xià	summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	
+Time 4	冬		dōng   Dōng   dōng	dōng   Dōng   dōng	winter	winter  surname Dong  (onom.) beating a drum / rat-a-tat	winter  surname Dong  (onom.) beating a drum / rat-a-tat	
+Time 4	秋		Qiū   qiū   qiū	Qiū   qiū   qiū	autumn	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千	
+Time 4	季		Jì   jì	Jì   jì	season	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields	
+Time 4	澳		Ào   ào	Ào   ào	Australia	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor	
+Time 4	亚	亞	yà	yà	Asia	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]	
+Time 4	季节	季節	jì jié	jì jié	season	time / season / period / CL: 個｜个	time / season / period / CL: 個｜个	
+Time 4	澳大利亚	澳大利亞	Ào dà lì yà	Ào dà lì yà	Australia	Australia	Australia	
+Time 4	越来越	越來越	yuè lái yuè	yuè lái yuè	More	more and more	more and more	
+Time 4	前天		qián tiān	qián tiān	The day before yesterday	the day before yesterday	the day before yesterday	
+Time 4	后天	後天	hòu tiān	hòu tiān	acquired	the day after tomorrow / acquired (not innate) / a posteriori	the day after tomorrow / acquired (not innate) / a posteriori	
+Time 4	堵车	堵車	dǔ chē	dǔ chē	Traffic jam	traffic jam / choking	traffic jam / choking	
+Time 4	大概		dà gài	dà gài	probably	roughly / probably / rough / approximate / about / general idea	roughly / probably / rough / approximate / about / general idea	
+Time 4	准时	準時	zhǔn shí	zhǔn shí	on time	on time / punctual / on schedule	on time / punctual / on schedule	
+Time 4	刚	剛	gāng	gāng	just	hard / firm / strong / just / barely / exactly	hard / firm / strong / just / barely / exactly	
+Time 4	堵		dǔ	dǔ	Blocking	to stop up / (to feel) stifled or suffocated / wall / classifier for walls	to stop up / (to feel) stifled or suffocated / wall / classifier for walls	
+Time 4	概		gài	gài	General	general / approximate	general / approximate	
+Location 5	城		chéng	chéng	city	city walls / city / town / CL: 座, 道, 個｜个	city walls / city / town / CL: 座, 道, 個｜个	
+Location 5	附		fù	fù	Attached	to add / to attach / to be close to / to be attached	to add / to attach / to be close to / to be attached	
+Location 5	园	園	Yuán   yuán	Yuán   yuán	garden	surname Yuan  land used for growing plants / site used for public recreation	surname Yuan  land used for growing plants / site used for public recreation	
+Location 5	城市		chéng shì	chéng shì	city	city / town / CL: 座	city / town / CL: 座	
+Location 5	附近		fù jìn	fù jìn	nearby	(in the) vicinity / nearby / neighboring / next to	(in the) vicinity / nearby / neighboring / next to	
+Location 5	公园	公園	gōng yuán	gōng yuán	park	park (for public recreation) / CL: 個｜个, 座	park (for public recreation) / CL: 個｜个, 座	
+Location 5	图	圖	tú	tú	Map	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek	
+Location 5	方		Fāng   fāng	Fāng   fāng	How to	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter	
+Location 5	中间	中間	zhōng jiān	zhōng jiān	intermediate	between / intermediate / mid / middle	between / intermediate / mid / middle	
+Location 5	图书馆	圖書館	tú shū guǎn	tú shū guǎn	library	library / CL: 家, 個｜个	library / CL: 家, 個｜个	
+Location 5	地方		dì fāng   dì fang	dì fāng   dì fang	local	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	
+Location 5	上面		shàng miàn	shàng miàn	On	on top of / above-mentioned / also pr. [shang4 mian5]	on top of / above-mentioned / also pr. [shang4 mian5]	
+Location 5	下面		xià miàn   xià miàn	xià miàn   xià miàn	below	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	
+Location 5	咖啡馆	咖啡館	kā fēi guǎn	kā fēi guǎn	coffee shop	café / coffee shop / CL: 家	café / coffee shop / CL: 家	
+Shopping 4	折		shé   zhē   zhé	shé   zhē   zhé	fold	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book	
+Shopping 4	角		Jué   jiǎo   jué	Jué   jiǎo   jué	angle	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	
+Shopping 4	花		Huā   huā	Huā   huā	flower	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	
+Shopping 4	打折		dǎ zhé	dǎ zhé	Discount	to give a discount	to give a discount	
+Shopping 4	旧	舊	jiù	jiù	old	old / opposite: new 新 / former / worn (with age)	old / opposite: new 新 / former / worn (with age)	
+Shopping 4	皮		Pí   pí	Pí   pí	skin	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty	
+Shopping 4	换	換	huàn	huàn	change	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)	
+Shopping 4	皮鞋		pí xié	pí xié	leather shoes	leather shoes	leather shoes	
+Shopping 4	经过	經過	jīng guò	jīng guò	through	to pass / to go through / process / course / CL: 個｜个	to pass / to go through / process / course / CL: 個｜个	
+Shopping 4	退货	退貨	tuì huò	tuì huò	Returns	to return merchandise / to withdraw a product	to return merchandise / to withdraw a product	
+Shopping 4	退款		tuì kuǎn	tuì kuǎn	Refund	to refund / refund	to refund / refund	
+Shopping 4	退		tuì	tuì	Retreat	to retreat / to decline / to move back / to withdraw	to retreat / to decline / to move back / to withdraw	
+Shopping 4	货	貨	huò	huò	goods	goods / money / commodity / CL: 個｜个	goods / money / commodity / CL: 個｜个	
+Shopping 4	款		kuǎn	kuǎn	paragraph	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)	
+Shopping 4	袋子		dài zi	dài zi	bag	bag	bag	
+Daily Routine 2	惯	慣	guàn	guàn	used	accustomed to / used to / indulge / to spoil (a child)	accustomed to / used to / indulge / to spoil (a child)	
+Daily Routine 2	刷		shuā   shuà	shuā   shuà	brush	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	
+Daily Routine 2	习惯	習慣	xí guàn	xí guàn	habit	habit / custom / usual practice / to be used to / CL: 個｜个	habit / custom / usual practice / to be used to / CL: 個｜个	
+Daily Routine 2	刷牙		shuā yá	shuā yá	Brush teeth	to brush one's teeth	to brush one's teeth	
+Daily Routine 2	马上	馬上	mǎ shàng	mǎ shàng	immediately	at once / right away / immediately / on horseback (i.e. by military force)	at once / right away / immediately / on horseback (i.e. by military force)	
+Daily Routine 2	以后	以後	yǐ hòu	yǐ hòu	after	after / later / afterwards / following / later on / in the future	after / later / afterwards / following / later on / in the future	
+Daily Routine 2	澡		zǎo	zǎo	bath	bath	bath	
+Daily Routine 2	总	總	zǒng	zǒng	total	always / to assemble / gather / total / overall / head / chief / general / in every case	always / to assemble / gather / total / overall / head / chief / general / in every case	
+Daily Routine 2	洗澡		xǐ zǎo	xǐ zǎo	Bathe	to bathe / to take a shower	to bathe / to take a shower	
+Daily Routine 2	一边	一邊	yī biān	yī biān	One side	one side / either side / on the one hand / on the other hand / doing while	one side / either side / on the one hand / on the other hand / doing while	
+Daily Routine 2	总是	總是	zǒng shì	zǒng shì	always	always	always	
+Daily Routine 2	讲	講	jiǎng	jiǎng	speak	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	
+Daily Routine 2	故		gù	gù	Therefore	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead	
+Daily Routine 2	故事		gù shì   gù shi	gù shì   gù shi	story	old practice / CL: 個｜个  narrative / story / tale	old practice / CL: 個｜个  narrative / story / tale	
+Daily Routine 2	以前		yǐ qián	yǐ qián	before	before / formerly / previous / ago	before / formerly / previous / ago	
+Daily Routine 2	做梦	做夢	zuò mèng	zuò mèng	dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream	
+Daily Routine 2	梦	夢	mèng	mèng	dream	dream / CL: 場｜场, 個｜个	dream / CL: 場｜场, 個｜个	
+Food 3	除		chú	chú	except	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including	
+Food 3	其		qí	qí	its	his / her / its / their / that / such / it (refers to sth preceding it)	his / her / its / their / that / such / it (refers to sth preceding it)	
+Food 3	饺	餃	jiǎo	jiǎo	dumpling	dumplings with meat filling	dumplings with meat filling	
+Food 3	北方		běi fāng	běi fāng	north	north / the northern part a country / China north of the Yellow River	north / the northern part a country / China north of the Yellow River	
+Food 3	除了		chú le	chú le	apart from	besides / apart from (... also...) / in addition to / except (for)	besides / apart from (... also...) / in addition to / except (for)	
+Food 3	其他		qí tā	qí tā	other	other / (sth or sb) else / the rest	other / (sth or sb) else / the rest	
+Food 3	饺子	餃子	jiǎo zi	jiǎo zi	Dumplings	dumpling / pot-sticker / CL: 個｜个, 隻｜只	dumpling / pot-sticker / CL: 個｜个, 隻｜只	
+Food 3	辣		là	là	hot	hot (spicy) / pungent	hot (spicy) / pungent	
+Food 3	极	極	jí	jí	pole	extremely / pole (geography, physics) / utmost / top	extremely / pole (geography, physics) / utmost / top	
+Food 3	苦		kǔ	kǔ	bitter	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly	
+Food 3	盐	鹽	yán	yán	salt	salt / CL: 粒	salt / CL: 粒	
+Food 3	咸		Xián   xián   xián	Xián   xián   xián	salty	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	
+Food 3	南		Nán   nán	Nán   nán	south	surname Nan  south	surname Nan  south	
+Food 3	南方		nán fāng	nán fāng	south	south / the southern part of the country / the South	south / the southern part of the country / the South	
+Food 3	难吃	難吃	nán chī	nán chī	Unpalatable	unpalatable	unpalatable	
+People 3	级	級	jí	jí	level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level	
+People 3	个子	個子	gè zi	gè zi	Stature	height / stature / build / size	height / stature / build / size	
+People 3	年级	年級	nián jí	nián jí	grade	grade / year (in school, college etc) / CL: 個｜个	grade / year (in school, college etc) / CL: 個｜个	
+People 3	小学	小學	xiǎo xué	xiǎo xué	primary school	elementary school / primary school / CL: 個｜个	elementary school / primary school / CL: 個｜个	
+People 3	初中		chū zhōng	chū zhōng	junior high school	junior high school / abbr. for 初級中學｜初级中学	junior high school / abbr. for 初級中學｜初级中学	
+People 3	初		chū	chū	First	at first / (at the) beginning / first / junior / basic	at first / (at the) beginning / first / junior / basic	
+People 3	较	較	jiào	jiào	Relatively	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]	
+People 3	年轻	年輕	nián qīng	nián qīng	young	young	young	
+People 3	比较	比較	bǐ jiào	bǐ jiào	Compare	to compare / to contrast / comparatively / relatively / quite / comparison	to compare / to contrast / comparatively / relatively / quite / comparison	
+People 3	眼镜	眼鏡	yǎn jìng	yǎn jìng	glasses	spectacles / eyeglasses / CL: 副	spectacles / eyeglasses / CL: 副	
+People 3	戴		Dài   dài	Dài   dài	wore	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	
+People 3	镜	鏡	jìng	jìng	mirror	mirror / lens	mirror / lens	
+Location 6	先		xiān	xiān	first	early / prior / former / in advance / first	early / prior / former / in advance / first	
+Location 6	然后	然後	rán hòu	rán hòu	then	after / then (afterwards) / after that / afterwards	after / then (afterwards) / after that / afterwards	
+Location 6	西边	西邊	xī biān	xī biān	The west	west / west side / western part / to the west of	west / west side / western part / to the west of	
+Location 6	东边	東邊	dōng bian	dōng bian	The east	east / east side / eastern part / to the east of	east / east side / eastern part / to the east of	
+Location 6	北边	北邊	běi biān	běi biān	North	north / north side / northern part / to the north of	north / north side / northern part / to the north of	
+Location 6	一直		yī zhí	yī zhí	Up	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	
+Location 6	最后	最後	zuì hòu	zuì hòu	At last	final / last / finally / ultimate	final / last / finally / ultimate	
+Location 6	南边	南邊	nán bian	nán bian	South	south / south side / southern part / to the south of	south / south side / southern part / to the south of	
+Location 6	直		Zhí   zhí	Zhí   zhí	straight	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters	
+Location 6	迷路		mí lù	mí lù	get lost	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	
+Location 6	地址		dì zhǐ	dì zhǐ	address	address / CL: 個｜个	address / CL: 個｜个	
+Location 6	周围	周圍	zhōu wéi	zhōu wéi	around	surroundings / environment / to encompass	surroundings / environment / to encompass	
+Location 6	迷		mí	mí	fan	to bewilder / crazy about / fan / enthusiast / lost / confused	to bewilder / crazy about / fan / enthusiast / lost / confused	
+Location 6	址		zhǐ	zhǐ	site	location / site	location / site	
+Location 6	围	圍	Wéi   wéi	Wéi   wéi	Enclose	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)	
+Daily Routine 3	般		bān   pán	bān   pán	Sort	sort / kind / class / way / manner  see 般樂｜般乐	sort / kind / class / way / manner  see 般樂｜般乐	
+Daily Routine 3	聊		liáo	liáo	chat	to chat / to depend upon (literary) / temporarily / just / slightly	to chat / to depend upon (literary) / temporarily / just / slightly	
+Daily Routine 3	聊天		liáo tiān	liáo tiān	to chat with	to chat / to gossip	to chat / to gossip	
+Daily Routine 3	一般		yī bān	yī bān	general	same / ordinary / so-so / common / general / generally / in general	same / ordinary / so-so / common / general / generally / in general	
+Daily Routine 3	见面	見面	jiàn miàn	jiàn miàn	meet	to meet / to see each other / CL: 次	to meet / to see each other / CL: 次	
+Daily Routine 3	自己		zì jǐ	zì jǐ	Own	oneself / one's own	oneself / one's own	
+Daily Routine 3	一个人	一個人	yī gè rén	yī gè rén	A person	by oneself (without assistance) / alone (without company)	by oneself (without assistance) / alone (without company)	
+Daily Routine 3	自		zì	zì	from	self / oneself / from / since / naturally / surely	self / oneself / from / since / naturally / surely	
+Daily Routine 3	己		jǐ	jǐ	already	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa	
+Travel 2	证	証	zhèng   zhèng	zhèng   zhèng	certificate	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症	
+Travel 2	签	簽	qiān   qiān	qiān   qiān	sign	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag	
+Travel 2	护	護	hù	hù	Protect	to protect	to protect	
+Travel 2	护照	護照	hù zhào	hù zhào	passport	passport / CL: 本, 個｜个	passport / CL: 本, 個｜个	
+Travel 2	签证	簽證	qiān zhèng	qiān zhèng	visa	visa / certificate / to certify / CL: 個｜个	visa / certificate / to certify / CL: 個｜个	
+Travel 2	发现	發現	fā xiàn	fā xiàn	Find	to find / to discover	to find / to discover	
+Travel 2	起飞	起飛	qǐ fēi	qǐ fēi	take off	(of an aircraft) to take off	(of an aircraft) to take off	
+Travel 2	离开	離開	lí kāi	lí kāi	go away	to depart / to leave	to depart / to leave	
+Travel 2	检查	檢查	jiǎn chá	jiǎn chá	an examination	inspection / to examine / to inspect / CL: 次	inspection / to examine / to inspect / CL: 次	
+Travel 2	行李		xíng li	xíng li	Baggage	luggage / CL: 件	luggage / CL: 件	
+Travel 2	安全		ān quán	ān quán	Safety	safe / secure / safety / security	safe / secure / safety / security	
+Travel 2	检	檢	jiǎn	jiǎn	Check	to check / to examine / to inspect / to exercise restraint	to check / to examine / to inspect / to exercise restraint	
+Travel 2	查		Zhā   chá   zhā	Zhā   chá   zhā	check	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查	
+Travel 2	几乎	幾乎	jī hū	jī hū	almost	almost / nearly / practically	almost / nearly / practically	
+Travel 2	忘记	忘記	wàng jì	wàng jì	forget	to forget	to forget	
+Travel 2	海关	海關	hǎi guān	hǎi guān	Customs	customs (i.e. border crossing inspection) / CL: 個｜个	customs (i.e. border crossing inspection) / CL: 個｜个	
+Travel 2	忘		wàng	wàng	forget	to forget / to overlook / to neglect	to forget / to overlook / to neglect	
+Travel 2	记	記	jì	jì	Remember	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots	
+Travel 2	乎		hū	hū	Down	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)	
+Languages 2	言		yán	yán	Speech	words / speech / to say / to talk	words / speech / to say / to talk	
+Languages 2	易		Yì   yì	Yì   yì	easy	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange	
+Languages 2	容		Róng   róng	Róng   róng	Allow	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance	
+Languages 2	种	種	zhǒng   zhòng	zhǒng   zhòng	Kind	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	
+Languages 2	容易		róng yì	róng yì	easily	easy / likely / liable (to)	easy / likely / liable (to)	
+Languages 2	语言	語言	yǔ yán	yǔ yán	Language	language / CL: 門｜门, 種｜种	language / CL: 門｜门, 種｜种	
+Languages 2	更		gēng   gèng	gēng   gèng	more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	
+Languages 2	努力		nǔ lì	nǔ lì	Strive	great effort / to strive / to try hard	great effort / to strive / to try hard	
+Languages 2	汉字	漢字	hàn zì	hàn zì	Chinese character	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	
+Languages 2	努		nǔ	nǔ	Strive	to exert / to strive	to exert / to strive	
+Languages 2	提高		tí gāo	tí gāo	improve	to raise / to increase / to improve	to raise / to increase / to improve	
+Languages 2	水平		shuǐ píng	shuǐ píng	Level	level (of achievement etc) / standard / horizontal	level (of achievement etc) / standard / horizontal	
+Languages 2	后来	後來	hòu lái	hòu lái	later	afterwards / later	afterwards / later	
+Languages 2	提		tí	tí	mention	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid	
+Languages 2	平		Píng   píng	Píng   píng	level	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声	
+Personality and Feelings	看起来	看起來	kàn qǐ lai	kàn qǐ lai	Looks	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	
+Personality and Feelings	奇怪		qí guài	qí guài	strange	strange / odd / to marvel / to be baffled	strange / odd / to marvel / to be baffled	
+Personality and Feelings	生气	生氣	shēng qì	shēng qì	pissed off	to get angry / to take offense / angry / vitality / liveliness	to get angry / to take offense / angry / vitality / liveliness	
+Personality and Feelings	紧张	緊張	jǐn zhāng	jǐn zhāng	tension	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	
+Personality and Feelings	奇		jī   qí	jī   qí	odd	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually	
+Personality and Feelings	怪		guài	guài	strange	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather	
+Personality and Feelings	紧	緊	jǐn	jǐn	tight	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten	
+Personality and Feelings	难过	難過	nán guò	nán guò	Sorry	to feel sad / to feel unwell / (of life) to be difficult	to feel sad / to feel unwell / (of life) to be difficult	
+Personality and Feelings	哭		kū	kū	cry	to cry / to weep	to cry / to weep	
+Personality and Feelings	可怕		kě pà	kě pà	terrible	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	
+Personality and Feelings	热情	熱情	rè qíng	rè qíng	enthusiasm	cordial / enthusiastic / passion / passionate / passionately	cordial / enthusiastic / passion / passionate / passionately	
+Personality and Feelings	关心	關心	guān xīn	guān xīn	care	to be concerned about / to care about	to be concerned about / to care about	
+Personality and Feelings	经常	經常	jīng cháng	jīng cháng	often	frequently / constantly / regularly / often / day-to-day / everyday / daily	frequently / constantly / regularly / often / day-to-day / everyday / daily	
+Personality and Feelings	遇到		yù dào	yù dào	Experience	to meet / to run into / to come across	to meet / to run into / to come across	
+Personality and Feelings	好笑		hǎo xiào	hǎo xiào	funny	laughable / funny / ridiculous	laughable / funny / ridiculous	
+Personality and Feelings	遇		Yù   yù	Yù   yù	Encounter	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance	
+School 2	求		qiú	qiú	begging	to seek / to look for / to request / to demand / to beseech	to seek / to look for / to request / to demand / to beseech	
+School 2	校长	校長	xiào zhǎng	xiào zhǎng	principal	(college, university) president / headmaster / CL: 個｜个, 位, 名	(college, university) president / headmaster / CL: 個｜个, 位, 名	
+School 2	要求		yāo qiú	yāo qiú	Claim	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	
+School 2	食堂		shí táng	shí táng	Cafeteria	dining hall / CL: 個｜个, 間｜间	dining hall / CL: 個｜个, 間｜间	
+School 2	食		shí   sì	shí   sì	food	to eat / food / animal feed / eclipse  to feed	to eat / food / animal feed / eclipse  to feed	
+School 2	堂		táng	táng	Hall	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture	
+School 2	必须	必須	bì xū	bì xū	have to	to have to / must / compulsory / necessarily	to have to / must / compulsory / necessarily	
+School 2	完成		wán chéng	wán chéng	carry out	to complete / to accomplish	to complete / to accomplish	
+School 2	作业	作業	zuò yè	zuò yè	operation	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	
+School 2	高中		gāo zhōng   gāo zhòng	gāo zhōng   gāo zhòng	Senior middle school	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	
+School 2	必		bì	bì	must	certainly / must / will / necessarily	certainly / must / will / necessarily	
+School 2	成		Chéng   chéng	Chéng   chéng	to make	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	
+School 2	须	須	xū   xū	xū   xū	must	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel	
+School 2	业	業	Yè   yè	Yè   yè	industry	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already	
+School 2	向		Xiàng   xiàng   xiàng	Xiàng   xiàng   xiàng	to	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	
+School 2	借		jiè	jiè	borrow	to lend / to borrow / by means of / to take (an opportunity)	to lend / to borrow / by means of / to take (an opportunity)	
+School 2	笔记	筆記	bǐ jì	bǐ jì	notes	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本	
+School 2	铅笔	鉛筆	qiān bǐ	qiān bǐ	pencil	(lead) pencil / CL: 支, 枝, 桿｜杆	(lead) pencil / CL: 支, 枝, 桿｜杆	
+School 2	铅	鉛	qiān	qiān	lead	lead (chemistry)	lead (chemistry)	
+School 2	清楚		qīng chu	qīng chu	clear	clear / distinct / to understand thoroughly / to be clear about	clear / distinct / to understand thoroughly / to be clear about	
+School 2	黑板		hēi bǎn	hēi bǎn	blackboard	blackboard / CL: 塊｜块, 個｜个	blackboard / CL: 塊｜块, 個｜个	
+School 2	笔记本	筆記本	bǐ jì běn	bǐ jì běn	notebook	notebook (stationery) / CL: 本 / notebook (computing)	notebook (stationery) / CL: 本 / notebook (computing)	
+School 2	清		Qīng   qīng	Qīng   qīng	clear	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge	
+School 2	楚		Chǔ   chǔ	Chǔ   chǔ	Chu	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)	
+School 2	板		bǎn   bǎn   pàn	bǎn   bǎn   pàn	board	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	
+School 2	体育馆	體育館	tǐ yù guǎn	tǐ yù guǎn	stadium	gym / gymnasium / stadium / CL: 個｜个	gym / gymnasium / stadium / CL: 個｜个	
+Future	化		huà	huà	Of	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学	
+Future	算		suàn	suàn	Count	to regard as / to figure / to calculate / to compute	to regard as / to figure / to calculate / to compute	
+Future	搬		bān	bān	move	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	
+Future	变	變	biàn	biàn	change	to change / to become different / to transform / to vary / rebellion	to change / to become different / to transform / to vary / rebellion	
+Future	打算		dǎ suàn	dǎ suàn	intend	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	
+Future	变化	變化	biàn huà	biàn huà	Variety	change / variation / to change / to vary / CL: 個｜个	change / variation / to change / to vary / CL: 個｜个	
+Future	机会	機會	jī huì	jī huì	opportunity	opportunity / chance / occasion / CL: 個｜个	opportunity / chance / occasion / CL: 個｜个	
+Future	留学	留學	liú xué	liú xué	Study abroad	to study abroad	to study abroad	
+Future	国家	國家	guó jiā	guó jiā	country	country / nation / state / CL: 個｜个	country / nation / state / CL: 個｜个	
+Future	选择	選擇	xuǎn zé	xuǎn zé	select	to select / to pick / choice / option / alternative	to select / to pick / choice / option / alternative	
+Future	选	選	xuǎn	xuǎn	selected	to choose / to pick / to select / to elect	to choose / to pick / to select / to elect	
+Future	择	擇	zé	zé	Choose	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]	
+Future	结婚	結婚	jié hūn	jié hūn	marry	to marry / to get married / CL: 次	to marry / to get married / CL: 次	
+Future	愿意	願意	yuàn yì	yuàn yì	willing	to wish / to want / ready / willing (to do sth)	to wish / to want / ready / willing (to do sth)	
+Future	认真	認真	rèn zhēn	rèn zhēn	serious	conscientious / earnest / serious / to take seriously / to take to heart	conscientious / earnest / serious / to take seriously / to take to heart	
+Future	结	結	jiē   jié	jiē   jié	Knot	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	
+Future	愿		yuàn   yuàn	yuàn   yuàn	willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing	
+Future	婚		hūn	hūn	marriage	to marry / marriage / wedding / to take a wife	to marry / marriage / wedding / to take a wife	
+Future	当然	當然	dāng rán	dāng rán	of course	only natural / as it should be / certainly / of course / without doubt	only natural / as it should be / certainly / of course / without doubt	
+Future	放心		fàng xīn	fàng xīn	rest assured	to feel relieved / to feel reassured / to be at ease	to feel relieved / to feel reassured / to be at ease	
+Future	害怕		hài pà	hài pà	Afraid	to be afraid / to be scared	to be afraid / to be scared	
+Future	当	噹	dāng   dāng   dàng	dāng   dāng   dàng	when	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)	
+Future	害		hài	hài	harm	to do harm to / to cause trouble to / harm / evil / calamity	to do harm to / to cause trouble to / harm / evil / calamity	
+Future	怕		Pà   pà	Pà   pà	afraid	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps	
+Future	分手		fēn shǒu	fēn shǒu	Breaking up	to part company / to split up / to break up	to part company / to split up / to break up	
+Environment	境		jìng	jìng	territory	border / place / condition / boundary / circumstances / territory	border / place / condition / boundary / circumstances / territory	
+Environment	环	環	Huán   huán	Huán   huán	ring	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in	
+Environment	层	層	céng	céng	Floor	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	
+Environment	方便		fāng biàn	fāng biàn	Convenience	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	
+Environment	环境	環境	huán jìng	huán jìng	surroundings	environment / circumstances / surroundings / CL: 個｜个 / ambient	environment / circumstances / surroundings / CL: 個｜个 / ambient	
+Environment	草		cǎo	cǎo	grass	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	
+Environment	太阳	太陽	tài yang	tài yang	sun	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	
+Environment	星星		xīng xing	xīng xing	star	star in the sky	star in the sky	
+Environment	阳	陽	yáng	yáng	Positive	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯	
+Environment	安静	安靜	ān jìng	ān jìng	be quiet	quiet / peaceful / calm	quiet / peaceful / calm	
+Environment	楼	樓	Lóu   lóu	Lóu   lóu	floor	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	
+Environment	静	靜	jìng	jìng	Quiet	still / calm / quiet / not moving	still / calm / quiet / not moving	
+Environment	声音	聲音	shēng yīn	shēng yīn	sound	voice / sound / CL: 個｜个	voice / sound / CL: 個｜个	
+Environment	影响	影響	yǐng xiǎng	yǐng xiǎng	influences	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	
+Environment	邻居	鄰居	lín jū	lín jū	neighbor	neighbor / next door / CL: 個｜个	neighbor / next door / CL: 個｜个	
+Environment	声	聲	shēng	shēng	sound	sound / voice / tone / noise / classifier for sounds	sound / voice / tone / noise / classifier for sounds	
+Environment	邻	鄰	lín	lín	adjacent	neighbor / adjacent / close to	neighbor / adjacent / close to	
+Environment	响	響	xiǎng	xiǎng	ring	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises	
+Environment	居		Jū   jī   jū	Jū   jī   jū	House	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms	
+Environment	垃圾		lā jī	lā jī	Rubbish	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	
+Environment	桶		tǒng	tǒng	barrel	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	
+Environment	丢	丟	diū	diū	throw	to lose / to put aside / to throw	to lose / to put aside / to throw	
+Environment	脏	臟	zàng   zāng	zàng   zāng	dirty	viscera / (anatomy) organ  dirty / filthy	viscera / (anatomy) organ  dirty / filthy	
+Environment	垃		lā	lā	garbage	see 垃圾 / Taiwan pr. [le4]	see 垃圾 / Taiwan pr. [le4]	
+Environment	圾		jī	jī	Rubbish	see 垃圾 / Taiwan pr. [se4]	see 垃圾 / Taiwan pr. [se4]	
+Work	先生		Xiān sheng   xiān sheng	Xiān sheng   xiān sheng	Mr	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	
+Work	小姐		xiǎo jie	xiǎo jie	Young lady	young lady / miss / (slang) prostitute / CL: 個｜个, 位	young lady / miss / (slang) prostitute / CL: 個｜个, 位	
+Work	经理	經理	jīng lǐ	jīng lǐ	manager	manager / director / CL: 個｜个, 位, 名	manager / director / CL: 個｜个, 位, 名	
+Work	同事		tóng shì	tóng shì	colleague	colleague / co-worker / CL: 個｜个, 位	colleague / co-worker / CL: 個｜个, 位	
+Work	突然		tū rán	tū rán	suddenly	sudden / abrupt / unexpected	sudden / abrupt / unexpected	
+Work	重要		zhòng yào	zhòng yào	important	important / significant / major	important / significant / major	
+Work	会议	會議	huì yì	huì yì	meeting	meeting / conference / CL: 場｜场, 屆｜届	meeting / conference / CL: 場｜场, 屆｜届	
+Work	突		tū	tū	Sudden	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]	
+Work	重		chóng   zhòng	chóng   zhòng	weight	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to	
+Work	议	議	yì	yì	Discuss	to comment on / to discuss / to suggest	to comment on / to discuss / to suggest	
+Work	解决	解決	jiě jué	jiě jué	solve	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	
+Work	办法	辦法	bàn fǎ	bàn fǎ	Method	means / method / way (of doing sth) / CL: 條｜条, 個｜个	means / method / way (of doing sth) / CL: 條｜条, 個｜个	
+Work	相信		xiāng xìn	xiāng xìn	Believe	to be convinced (that sth is true) / to believe / to accept sth as true	to be convinced (that sth is true) / to believe / to accept sth as true	
+Work	决	決	jué	jué	Decide	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly	
+Work	解		Xiè   jiě   jiè   xiè	Xiè   jiě   jiè   xiè	solution	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)	
+Culture	界		jiè	jiè	boundary	boundary / scope / extent / circles / group / kingdom (taxonomy)	boundary / scope / extent / circles / group / kingdom (taxonomy)	
+Culture	河		hé	hé	River	river / CL: 條｜条, 道	river / CL: 條｜条, 道	
+Culture	世		Shì   shì	Shì   shì	world	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble	
+Culture	黄河	黃河	Huáng Hé	Huáng Hé	Yellow River	Yellow River or Huang He	Yellow River or Huang He	
+Culture	动物	動物	dòng wù	dòng wù	animal	animal / CL: 隻｜只, 群, 個｜个	animal / CL: 隻｜只, 群, 個｜个	
+Culture	有名		yǒu míng	yǒu míng	Famous	famous / well-known	famous / well-known	
+Culture	世界		shì jiè	shì jiè	world	world / CL: 個｜个	world / CL: 個｜个	
+Culture	长江	長江	Cháng Jiāng	Cháng Jiāng	Yangtze	Yangtze River, or Chang Jiang	Yangtze River, or Chang Jiang	
+Culture	江		Jiāng   jiāng	Jiāng   jiāng	River	surname Jiang  river / CL: 條｜条, 道	surname Jiang  river / CL: 條｜条, 道	
+Culture	多么	多麼	duō me	duō me	how	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	
+Culture	熊猫	熊貓	xióng māo	xióng māo	panda	panda / CL: 隻｜只	panda / CL: 隻｜只	
+Culture	西安		Xī ān	Xī ān	Xi'an	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	
+Culture	啊		ā   á   ǎ   à   a	ā   á   ǎ   à   a	what	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	
+Culture	熊		Xióng   xióng	Xióng   xióng	Bear	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly	
+Culture	长城	長城	Cháng chéng	Cháng chéng	Great Wall	the Great Wall	the Great Wall	
+Culture	故宫	故宮	Gù gōng   gù gōng	Gù gōng   gù gōng	Forbidden City	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	
+Culture	宫	宮	Gōng   gōng	Gōng   gōng	palace	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale	
+Hobbies 3	山		Shān   shān	Shān   shān	mountain	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable	
+Hobbies 3	者		zhě	zhě	Person	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this	
+Hobbies 3	爬		pá	pá	climb	to crawl / to climb / to get up or sit up	to crawl / to climb / to get up or sit up	
+Hobbies 3	或		huò	huò	or	maybe / perhaps / might / possibly / or	maybe / perhaps / might / possibly / or	
+Hobbies 3	自行车	自行車	zì xíng chē	zì xíng chē	bicycle	bicycle / bike / CL: 輛｜辆	bicycle / bike / CL: 輛｜辆	
+Hobbies 3	或者		huò zhě	huò zhě	or	or / possibly / maybe / perhaps	or / possibly / maybe / perhaps	
+Hobbies 3	爬山		pá shān	pá shān	Climb	to climb a mountain / to mountaineer / hiking / mountaineering	to climb a mountain / to mountaineer / hiking / mountaineering	
+Hobbies 3	功夫		gōng fu	gōng fu	effort	skill / art / kung fu / labor / effort	skill / art / kung fu / labor / effort	
+Hobbies 3	功		gōng	gōng	Gong	meritorious deed or service / achievement / result / service / accomplishment / work (physics)	meritorious deed or service / achievement / result / service / accomplishment / work (physics)	
+Hobbies 3	文化		wén huà	wén huà	culture	culture / civilization / cultural / CL: 個｜个, 種｜种	culture / civilization / cultural / CL: 個｜个, 種｜种	
+Hobbies 3	历史	歷史	lì shǐ	lì shǐ	history	history / CL: 門｜门, 段	history / CL: 門｜门, 段	
+Hobbies 3	兴趣	興趣	xìng qù	xìng qù	interest	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个	
+Hobbies 3	感兴趣	感興趣	gǎn xìng qù	gǎn xìng qù	Interested	to be interested	to be interested	
+Hobbies 3	历	曆	lì   lì	lì   lì	calendar	calendar  to experience / to undergo / to pass through / all / each / every / history	calendar  to experience / to undergo / to pass through / all / each / every / history	
+Hobbies 3	趣		qù	qù	interest	interesting / to interest	interesting / to interest	
+Hobbies 3	史		Shǐ   shǐ	Shǐ   shǐ	history	surname Shi  history / annals / title of an official historian in ancient China	surname Shi  history / annals / title of an official historian in ancient China	
+Hobbies 3	为了	為了	wèi le	wèi le	in order to	in order to / for the purpose of / so as to	in order to / for the purpose of / so as to	
+Hobbies 3	特别	特別	tè bié	tè bié	particular	especially / special / particular / unusual	especially / special / particular / unusual	
+Hobbies 3	了解		liǎo jiě   liǎo jiě	liǎo jiě   liǎo jiě	To understanding	to understand / to realize / to find out  to understand / to realize / to find out	to understand / to realize / to find out  to understand / to realize / to find out	
+Hobbies 3	麻将	麻將	má jiàng	má jiàng	Mahjong	mahjong / CL: 副	mahjong / CL: 副	
+Hobbies 3	特		tè	tè	special	special / unique / distinguished / especially / unusual / very	special / unique / distinguished / especially / unusual / very	
+Hobbies 3	麻		Má   má	Má   má	hemp	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb	
+Hobbies 3	将	將	jiāng   jiàng   qiāng	jiāng   jiàng   qiāng	will	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request	
+Health 3	顾	顧	Gù   gù	Gù   gù	Attend	surname Gu  to look after / to take into consideration / to attend to	surname Gu  to look after / to take into consideration / to attend to	
+Health 3	死		sǐ	sǐ	dead	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	
+Health 3	闷	悶	mēn   mèn	mēn   mèn	stuffy	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	
+Health 3	腿		tuǐ   tuǐ	tuǐ   tuǐ	leg	leg / CL: 條｜条  hip bone / old variant of 腿	leg / CL: 條｜条  hip bone / old variant of 腿	
+Health 3	照顾	照顧	zhào gu	zhào gu	Look after	to take care of / to show consideration / to attend to / to look after	to take care of / to show consideration / to attend to / to look after	
+Health 3	公斤		gōng jīn	gōng jīn	kg	kilogram (kg)	kilogram (kg)	
+Health 3	着急	著急	zháo jí	zháo jí	Worry	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	
+Health 3	瘦		shòu	shòu	thin	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	
+Health 3	斤		jīn	jīn	jin	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g	
+Health 3	急		jí	jí	anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious	
+Health 3	咳嗽		ké sou	ké sou	cough	to cough / CL: 陣｜阵	to cough / CL: 陣｜阵	
+Health 3	抽烟	抽煙	chōu yān	chōu yān	smokes	to smoke (a cigarette, tobacco)	to smoke (a cigarette, tobacco)	
+Health 3	咳		hāi   ké	hāi   ké	cough	sound of sighing  cough	sound of sighing  cough	
+Health 3	嗽		sòu	sòu	cough	cough	cough	
+Health 3	抽		chōu	chōu	Draw	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash	
+Health 3	烟	煙	yān	yān	smoke	cigarette or pipe tobacco / CL: 根 / smoke / mist / vapour / CL: 縷｜缕 / tobacco plant / (of the eyes) to be irritated by smoke	cigarette or pipe tobacco / CL: 根 / smoke / mist / vapour / CL: 縷｜缕 / tobacco plant / (of the eyes) to be irritated by smoke	
+Travel 3	际	際	jì	jì	The occasion	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)	
+Travel 3	柜		jǔ   guì	jǔ   guì	cabinet	Salix multinervis  cupboard / cabinet / wardrobe	Salix multinervis  cupboard / cabinet / wardrobe	
+Travel 3	转	轉	zhuǎi   zhuǎn   zhuàn	zhuǎi   zhuǎn   zhuàn	turn	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions	
+Travel 3	转机	轉機	zhuǎn jī	zhuǎn jī	Connection	(to take) a turn for the better / to change planes	(to take) a turn for the better / to change planes	
+Travel 3	柜台	櫃檯	guì tái	guì tái	counter	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	
+Travel 3	国际	國際	guó jì	guó jì	International	international	international	
+Travel 3	换钱	換錢	huàn qián	huàn qián	Change money	to change money / to sell	to change money / to sell	
+Travel 3	银行	銀行	yín háng	yín háng	bank	bank / CL: 家, 個｜个	bank / CL: 家, 個｜个	
+Travel 3	充电	充電	chōng diàn	chōng diàn	Charging	to recharge batteries / fig. to rest and recuperate	to recharge batteries / fig. to rest and recuperate	
+Travel 3	国内	國內	guó nèi	guó nèi	domestic	domestic / internal (to a country) / civil	domestic / internal (to a country) / civil	
+Travel 3	银	銀	yín	yín	silver	silver / silver-colored / relating to money or currency	silver / silver-colored / relating to money or currency	
+Travel 3	充		chōng	chōng	Charge	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full	
+Travel 3	内	內	nèi	nèi	Inside	inside / inner / internal / within / interior	inside / inner / internal / within / interior	
+Travel 3	充值		chōng zhí	chōng zhí	Recharge	to recharge (money onto a card)	to recharge (money onto a card)	
+Travel 3	漫游	漫遊	màn yóu	màn yóu	roaming	to travel around / to roam / (mobile telephony) roaming	to travel around / to roam / (mobile telephony) roaming	
+Travel 3	电话卡	電話卡	diàn huà kǎ	diàn huà kǎ	phone card	telephone card	telephone card	
+Travel 3	值		zhí	zhí	value	value / (to be) worth / to happen to / to be on duty	value / (to be) worth / to happen to / to be on duty	
+Travel 3	订房	訂房	dìng fáng	dìng fáng	Booking	to reserve a room	to reserve a room	
+Travel 3	退房		tuì fáng	tuì fáng	check out	to check out of a hotel room	to check out of a hotel room	
+Travel 3	取消		qǔ xiāo	qǔ xiāo	cancel	to cancel / cancellation	to cancel / cancellation	
+Travel 3	导游	導遊	dǎo yóu	dǎo yóu	Tourist guide	tour guide / guidebook / to conduct a tour	tour guide / guidebook / to conduct a tour	
+Travel 3	取		qǔ	qǔ	take	to take / to get / to choose / to fetch	to take / to get / to choose / to fetch	
+Travel 3	导	導	dǎo	dǎo	guide	to transmit / to lead / to guide / to conduct / to direct	to transmit / to lead / to guide / to conduct / to direct	
+Travel 3	消		xiāo	xiāo	Eliminate	to disappear / to vanish / to eliminate / to spend (time) / have to / need	to disappear / to vanish / to eliminate / to spend (time) / have to / need	
+Languages 3	答		dā   dá	dā   dá	answer	to answer / to agree  reply / answer / return / respond / echo	to answer / to agree  reply / answer / return / respond / echo	
+Languages 3	句		jù	jù	sentence	sentence / clause / phrase / classifier for phrases or lines of verse	sentence / clause / phrase / classifier for phrases or lines of verse	
+Languages 3	简	簡	jiǎn	jiǎn	simple	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)	
+Languages 3	简单	簡單	jiǎn dān	jiǎn dān	simple	simple / not complicated	simple / not complicated	
+Languages 3	句子		jù zi	jù zi	sentence	sentence / CL: 個｜个	sentence / CL: 個｜个	
+Languages 3	回答		huí dá	huí dá	Reply	to reply / to answer / the answer / CL: 個｜个	to reply / to answer / the answer / CL: 個｜个	
+Languages 3	词典	詞典	cí diǎn	cí diǎn	dictionary	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	
+Languages 3	应用	應用	yìng yòng	yìng yòng	application	to use / to apply / application / applicable	to use / to apply / application / applicable	
+Languages 3	语法	語法	yǔ fǎ	yǔ fǎ	grammar	grammar	grammar	
+Languages 3	流利		liú lì	liú lì	fluent	fluent	fluent	
+Languages 3	词	詞	cí	cí	word	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首	
+Languages 3	流		liú	liú	flow	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade	
+Languages 3	典		diǎn	diǎn	Code	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn	
+Languages 3	下载	下載	xià zǎi	xià zǎi	download	to download / also pr. [xia4 zai4]	to download / also pr. [xia4 zai4]	
+Languages 3	多邻国		duō lín guó	duō lín guó	Duolingo	duolingo	duolingo	
+Languages 3	翻译	翻譯	fān yì	fān yì	translation	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	
+Languages 3	翻		fān	fān	turn	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross	
+Languages 3	载	載	zǎi   zài	zǎi   zài	Load	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously	
+Languages 3	译	譯	yì	yì	Translate	to translate / to interpret	to translate / to interpret	
+House	把		bǎ   bà	bǎ   bà	The	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	
+House	灯	燈	dēng	dēng	light	lamp / light / lantern / CL: 盞｜盏	lamp / light / lantern / CL: 盞｜盏	
+House	空调	空調	kōng tiáo	kōng tiáo	air conditioning	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	
+House	画	畫	huà	huà	painting	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	
+House	厨房	廚房	chú fáng	chú fáng	kitchen	kitchen / CL: 間｜间	kitchen / CL: 間｜间	
+House	客厅	客廳	kè tīng	kè tīng	living room	drawing room (room for arriving guests) / living room / CL: 間｜间	drawing room (room for arriving guests) / living room / CL: 間｜间	
+House	厨	廚	chú	chú	Kitchen	kitchen	kitchen	
+House	厅	廳	tīng	tīng	hall	(reception) hall / living room / office / provincial government department	(reception) hall / living room / office / provincial government department	
+House	客人		kè rén	kè rén	The guests	visitor / guest / customer / client / CL: 位	visitor / guest / customer / client / CL: 位	
+House	打扫	打掃	dǎ sǎo	dǎ sǎo	clean	to clean / to sweep	to clean / to sweep	
+House	干净	乾淨	gān jìng	gān jìng	clean	clean / neat	clean / neat	
+House	扫	掃	sǎo   sào	sǎo   sào	sweep	to sweep  broom	to sweep  broom	
+House	净	淨	jìng	jìng	net	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role	
+House	电梯	電梯	diàn tī	diàn tī	elevator	elevator / escalator / CL: 臺｜台, 部	elevator / escalator / CL: 臺｜台, 部	
+House	坏	壞	huài	huài	Bad	bad / spoiled / broken / to break down / (suffix) to the utmost	bad / spoiled / broken / to break down / (suffix) to the utmost	
+House	被		bèi	bèi	Is	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	
+House	厕所	廁所	cè suǒ	cè suǒ	WC	toilet / lavatory / CL: 間｜间, 處｜处	toilet / lavatory / CL: 間｜间, 處｜处	
+House	厕	廁	cè   sì	cè   sì	toilet	restroom / toilet / lavatory  see 茅廁｜茅厕	restroom / toilet / lavatory  see 茅廁｜茅厕	
+House	梯		tī	tī	ladder	ladder / stairs	ladder / stairs	
+Exam	寒		hán	hán	cold	cold / poor / to tremble	cold / poor / to tremble	
+Exam	暑		shǔ	shǔ	Heat	heat / hot weather / summer heat	heat / hot weather / summer heat	
+Exam	复	復	fù   fù	fù   fù	complex	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate	
+Exam	记得	記得	jì de	jì de	remember	to remember	to remember	
+Exam	复习	復習	fù xí	fù xí	review	to review / revision / CL: 次	to review / revision / CL: 次	
+Exam	数学	數學	shù xué	shù xué	mathematics	mathematics / mathematical	mathematics / mathematical	
+Exam	放假		fàng jià	fàng jià	holiday	to have a holiday or vacation	to have a holiday or vacation	
+Exam	暑假		shǔ jià	shǔ jià	summer vacation	summer vacation / CL: 個｜个	summer vacation / CL: 個｜个	
+Exam	寒假		hán jià	hán jià	winter vacation	winter vacation	winter vacation	
+Exam	终于	終於	zhōng yú	zhōng yú	at last	at last / in the end / finally / eventually	at last / in the end / finally / eventually	
+Exam	结束	結束	jié shù	jié shù	End	termination / to finish / to end / to conclude / to close	termination / to finish / to end / to conclude / to close	
+Exam	放松	放鬆	fàng sōng	fàng sōng	Relax	to loosen / to relax	to loosen / to relax	
+Exam	大学	大學	Dà xué   dà xué	Dà xué   dà xué	the University	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	
+Exam	终	終	zhōng	zhōng	end	end / finish	end / finish	
+Exam	于		Yú   yú   yú	Yú   yú   yú	to	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of	
+Exam	束		Shù   shù	Shù   shù	bundle	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control	
+Exam	成绩	成績	chéng jì	chéng jì	Achievement	achievement / performance records / grades / CL: 項｜项, 個｜个	achievement / performance records / grades / CL: 項｜项, 個｜个	
+Exam	担心	擔心	dān xīn	dān xīn	worry	anxious / worried / uneasy / to worry / to be anxious	anxious / worried / uneasy / to worry / to be anxious	
+Exam	专业	專業	zhuān yè	zhuān yè	profession	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	
+Exam	担	擔	dān   dàn	dān   dàn	Dan	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole	
+Exam	专	專	zhuān	zhuān	Special	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized	
+Exam	绩	績	jì	jì	Merit	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]	
+Travel 4	景		Jǐng   jǐng	Jǐng   jǐng	view	surname Jing  bright / circumstance / scenery	surname Jing  bright / circumstance / scenery	
+Travel 4	街		jiē	jiē	street	street / CL: 條｜条	street / CL: 條｜条	
+Travel 4	地图	地圖	dì tú	dì tú	map	map / CL: 張｜张, 本	map / CL: 張｜张, 本	
+Travel 4	街道		jiē dào	jiē dào	street	street / CL: 條｜条 / subdistrict / residential district	street / CL: 條｜条 / subdistrict / residential district	
+Travel 4	红绿灯	紅綠燈	hóng lǜ dēng	hóng lǜ dēng	traffic light	traffic light / traffic signal	traffic light / traffic signal	
+Travel 4	风景	風景	fēng jǐng	fēng jǐng	landscape	scenery / landscape / CL: 個｜个	scenery / landscape / CL: 個｜个	
+Travel 4	司机	司機	sī jī	sī jī	driver	chauffeur / driver / CL: 個｜个	chauffeur / driver / CL: 個｜个	
+Travel 4	接		jiē	jiē	Meet	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	
+Travel 4	免费	免費	miǎn fèi	miǎn fèi	free	free (of charge)	free (of charge)	
+Travel 4	打车	打車	dǎ chē	dǎ chē	A taxi	to take a taxi (in town) / to hitch a lift	to take a taxi (in town) / to hitch a lift	
+Travel 4	观光	觀光	guān guāng	guān guāng	go sightseeing	to tour / sightseeing / tourism	to tour / sightseeing / tourism	
+Travel 4	免		miǎn	miǎn	Avoid	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	
+Travel 4	观	觀	Guàn   guān   guàn	Guàn   guān   guàn	Watch	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform	
+Travel 4	光		guāng	guāng	Light	light / ray / CL: 道 / bright / only / merely / to use up	light / ray / CL: 道 / bright / only / merely / to use up	
+Travel 4	小心		xiǎo xīn	xiǎo xīn	Be careful	to be careful / to take care	to be careful / to take care	
+Travel 4	时差	時差	shí chā	shí chā	jet lag	time difference / time lag / jet lag	time difference / time lag / jet lag	
+Travel 4	马路	馬路	mǎ lù	mǎ lù	road	street / road / CL: 條｜条	street / road / CL: 條｜条	
+Travel 4	参观	參觀	cān guān	cān guān	Visit	to look around / to tour / to visit	to look around / to tour / to visit	
+Travel 4	博物馆	博物館	bó wù guǎn	bó wù guǎn	museum	museum	museum	
+Travel 4	博		bó	bó	Rich	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble	
+Travel 4	安排		ān pái	ān pái	arrangement	to arrange / to plan / to set up / arrangements / plans	to arrange / to plan / to set up / arrangements / plans	
+Travel 4	活动	活動	huó dòng	huó dòng	activity	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	
+Travel 4	表演		biǎo yǎn	biǎo yǎn	Performance	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	
+Travel 4	海边	海邊	hǎi biān	hǎi biān	seaside	coast / seaside / seashore / beach	coast / seaside / seashore / beach	
+Travel 4	活		huó	huó	live	to live / alive / living / work / workmanship	to live / alive / living / work / workmanship	
+Travel 4	演		yǎn	yǎn	play	to develop / to evolve / to practice / to perform / to play / to act	to develop / to evolve / to practice / to perform / to play / to act	
+Communication 2	邮	郵	yóu	yóu	mail	post (office) / mail	post (office) / mail	
+Communication 2	刚才	剛才	gāng cái   gāng cái	gāng cái   gāng cái	Just now	just now / a moment ago  (just) a moment ago	just now / a moment ago  (just) a moment ago	
+Communication 2	电子邮件	電子郵件	diàn zǐ yóu jiàn	diàn zǐ yóu jiàn	e-mail	email / CL: 封, 份	email / CL: 封, 份	
+Communication 2	主要		zhǔ yào	zhǔ yào	main	main / principal / major / primary	main / principal / major / primary	
+Communication 2	短信		duǎn xìn	duǎn xìn	SMS	text message / SMS	text message / SMS	
+Communication 2	关于	關於	guān yú	guān yú	on	pertaining to / concerning / with regard to / about / a matter of	pertaining to / concerning / with regard to / about / a matter of	
+Communication 2	主		zhǔ	zhǔ	the Lord	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)	
+Communication 2	登录	登錄	dēng lù	dēng lù	log in	to register / to log in	to register / to log in	
+Communication 2	密码	密碼	mì mǎ	mì mǎ	password	secret code / ciphertext / password / PIN	secret code / ciphertext / password / PIN	
+Communication 2	信号	信號	xìn hào	xìn hào	signal	signal	signal	
+Communication 2	登		dēng	dēng	Ascend	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)	
+Communication 2	密		Mì   mì	Mì   mì	dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense	
+Communication 2	录	錄	Lù   lù	Lù   lù	record	surname Lu  diary / record / to hit / to copy	surname Lu  diary / record / to hit / to copy	
+Communication 2	段		Duàn   duàn	Duàn   duàn	segment	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	
+Communication 2	其实	其實	qí shí	qí shí	in fact	actually / in fact / really	actually / in fact / really	
+Communication 2	过去	過去	guò qù   guò qu	guò qù   guò qu	past	(in the) past / former / previous / to go over / to pass by  (verb suffix)	(in the) past / former / previous / to go over / to pass by  (verb suffix)	
+Communication 2	谈	談	Tán   tán	Tán   tán	talk	surname Tan  to speak / to talk / to converse / to chat / to discuss	surname Tan  to speak / to talk / to converse / to chat / to discuss	
+Communication 2	实	實	shí	shí	real	real / true / honest / really / solid / fruit / seed / definitely	real / true / honest / really / solid / fruit / seed / definitely	
+Work 2	同意		tóng yì	tóng yì	agree	to agree / to consent / to approve	to agree / to consent / to approve	
+Work 2	决定	決定	jué dìng	jué dìng	Decide	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	
+Work 2	根据	根據	gēn jù	gēn jù	according to	according to / based on / basis / foundation / CL: 個｜个	according to / based on / basis / foundation / CL: 個｜个	
+Work 2	升职	升職	shēng zhí	shēng zhí	Promotion	to get promoted (at work etc) / promotion	to get promoted (at work etc) / promotion	
+Work 2	根		gēn	gēn	root	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)	
+Work 2	据		jū   jù	jū   jù	according to	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	
+Work 2	升		shēng	shēng	Rise	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗	
+Work 2	职	職	zhí	zhí	Office	office / duty	office / duty	
+Work 2	满意	滿意	mǎn yì	mǎn yì	satisfaction	satisfied / pleased / to one's satisfaction	satisfied / pleased / to one's satisfaction	
+Work 2	认为	認為	rèn wéi	rèn wéi	think	to believe / to think / to consider / to feel	to believe / to think / to consider / to feel	
+Work 2	出差		chū chāi	chū chāi	On a business trip	to go on an official or business trip	to go on an official or business trip	
+Work 2	表现	表現	biǎo xiàn	biǎo xiàn	which performed	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	
+Work 2	满	滿	Mǎn   mǎn	Mǎn   mǎn	full	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented	
+Work 2	老板	老闆	Lǎo bǎn   lǎo bǎn	Lǎo bǎn   lǎo bǎn	boss	Robam (brand)  boss / business proprietor / CL: 個｜个	Robam (brand)  boss / business proprietor / CL: 個｜个	
+Work 2	麻烦	麻煩	má fan	má fan	trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	
+Work 2	开会	開會	kāi huì	kāi huì	Meetings	to hold a meeting / to attend a meeting	to hold a meeting / to attend a meeting	
+Work 2	面试	面試	miàn shì	miàn shì	Interview	to be interviewed (as a candidate) / interview	to be interviewed (as a candidate) / interview	
+Work 2	烦	煩	fán	fán	bother	to feel vexed / to bother / to trouble / superfluous and confusing / edgy	to feel vexed / to bother / to trouble / superfluous and confusing / edgy	
+Festivals	饼	餅	bǐng	bǐng	cake	round flat cake / cookie / cake / pastry / CL: 張｜张	round flat cake / cookie / cake / pastry / CL: 張｜张	
+Festivals	月亮		yuè liang	yuè liang	moon	the moon	the moon	
+Festivals	月饼	月餅	yuè bǐng	yuè bǐng	moon cake	mooncake (esp. for the Mid-Autumn Festival)	mooncake (esp. for the Mid-Autumn Festival)	
+Festivals	中秋节	中秋節	Zhōng qiū jié	Zhōng qiū jié	Mid-Autumn Festival	the Mid-Autumn Festival on 15th of 8th lunar month	the Mid-Autumn Festival on 15th of 8th lunar month	
+Festivals	圆	圓	yuán	yuán	circle	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify	
+Festivals	恭喜		gōng xǐ	gōng xǐ	Congratulation	congratulations / greetings	congratulations / greetings	
+Festivals	红包	紅包	hóng bāo	hóng bāo	Red envelope	money wrapped in red as a gift / bonus payment / kickback / bribe	money wrapped in red as a gift / bonus payment / kickback / bribe	
+Festivals	汤圆	湯圓	tāng yuán	tāng yuán	Dumpling	boiled balls of glutinous rice flour, eaten during the Lantern Festival	boiled balls of glutinous rice flour, eaten during the Lantern Festival	
+Festivals	聚会	聚會	jù huì	jù huì	get together	party / gathering / to meet / to get together	party / gathering / to meet / to get together	
+Festivals	发财	發財	fā cái	fā cái	Make a fortune	to get rich	to get rich	
+Festivals	恭		gōng	gōng	Respectful	respectful	respectful	
+Festivals	聚		jù	jù	Gather	to congregate / to assemble / to mass / to gather together / to amass / to polymerize	to congregate / to assemble / to mass / to gather together / to amass / to polymerize	
+Festivals	财	財	cái	cái	fiscal	money / wealth / riches / property / valuables	money / wealth / riches / property / valuables	
+Festivals	端午节	端午節	Duān wǔ jié	Duān wǔ jié	Dragon boat festival	Dragon Boat Festival (5th day of the 5th lunar month)	Dragon Boat Festival (5th day of the 5th lunar month)	
+Festivals	粽子		zòng zi	zòng zi	Zongzi	glutinous rice and choice of filling wrapped in leaves and boiled	glutinous rice and choice of filling wrapped in leaves and boiled	
+Festivals	划		huá   huá   huà	huá   huá   huà	Draw	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	
+Festivals	龙舟	龍舟	lóng zhōu	lóng zhōu	Dragon Boat	dragon boat / imperial boat	dragon boat / imperial boat	
+Festivals	端		duān	duān	end	end / extremity / item / port / to hold sth level with both hands / to carry / regular	end / extremity / item / port / to hold sth level with both hands / to carry / regular	
+Festivals	粽		zòng	zòng	Dumplings	rice dumplings wrapped in leaves	rice dumplings wrapped in leaves	
+Festivals	龙	龍	Lóng   lóng	Lóng   lóng	Dragon	surname Long  dragon / CL: 條｜条 / imperial	surname Long  dragon / CL: 條｜条 / imperial	
+Festivals	舟		zhōu	zhōu	boat	boat	boat	
+Gourmet 2	珠		zhū	zhū	Pearl	bead / pearl / CL: 粒, 顆｜颗	bead / pearl / CL: 粒, 顆｜颗	
+Gourmet 2	汤	湯	Tāng   shāng   tāng	Tāng   shāng   tāng	soup	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled	
+Gourmet 2	酸		suān	suān	acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid	
+Gourmet 2	珍		zhēn	zhēn	Treasure	precious thing / treasure / culinary delicacy / rare / valuable / to value highly	precious thing / treasure / culinary delicacy / rare / valuable / to value highly	
+Gourmet 2	珍珠奶茶		zhēn zhū nǎi chá	zhēn zhū nǎi chá	Pearl milk tea	pearl milk tea / tapioca milk tea / bubble milk tea	pearl milk tea / tapioca milk tea / bubble milk tea	
+Gourmet 2	酸辣汤	酸辣湯	suān là tāng	suān là tāng	Hot and sour soup	hot and sour soup / sour and spicy soup	hot and sour soup / sour and spicy soup	
+Gourmet 2	北京烤鸭	北京烤鴨	Běi jīng kǎo yā	Běi jīng kǎo yā	Peking duck	Peking Duck	Peking Duck	
+Gourmet 2	春卷	春捲	chūn juǎn	chūn juǎn	Spring Rolls	egg roll / spring roll	egg roll / spring roll	
+Gourmet 2	豆花		dòu huā	dòu huā	Curd	jellied tofu / soft bean curd	jellied tofu / soft bean curd	
+Gourmet 2	烤		kǎo	kǎo	grilled	to roast / to bake / to broil	to roast / to bake / to broil	
+Gourmet 2	鸭	鴨	yā	yā	duck	duck / CL: 隻｜只 / (slang) male prostitute	duck / CL: 隻｜只 / (slang) male prostitute	
+Gourmet 2	卷		juǎn   juàn   juǎn	juǎn   juàn   juǎn	volume	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll	
+Gourmet 2	宫保鸡丁	宮保雞丁	gōng bǎo jī dīng	gōng bǎo jī dīng	Kung Pao Chicken	Kung Pao Chicken / spicy diced chicken	Kung Pao Chicken / spicy diced chicken	
+Gourmet 2	卤肉饭		lǔ ròu fàn	lǔ ròu fàn	Braised pork on rice	Braised pork on rice	Braised pork on rice	
+Gourmet 2	馒头	饅頭	mán tou	mán tou	steamed bread	steamed roll / steamed bun / steamed bread / CL: 個｜个	steamed roll / steamed bun / steamed bread / CL: 個｜个	
+Gourmet 2	保		Bǎo   bǎo	Bǎo   bǎo	Insurance	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure	
+Gourmet 2	卤	滷	lǔ   lǔ	lǔ   lǔ	halogen	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid	
+Gourmet 2	馒	饅	mán	mán	steamed bread	steamed bread	steamed bread	
+Gourmet 2	丁		Dīng   dīng	Dīng   dīng	Ding	surname Ding  fourth of the ten Heavenly Stems 十天干 / fourth in order / letter 'D' or roman 'IV' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 195° / butyl / cubes (of food)	surname Ding  fourth of the ten Heavenly Stems 十天干 / fourth in order / letter 'D' or roman 'IV' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 195° / butyl / cubes (of food)	
+Internet Slang	豪		háo	háo	Howe	grand / heroic	grand / heroic	
+Internet Slang	宅		zhái	zhái	House	residence / (coll.) to stay in at home / to hang around at home	residence / (coll.) to stay in at home / to hang around at home	
+Internet Slang	土		Tǔ   tǔ	Tǔ   tǔ	soil	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音	
+Internet Slang	土豪		tǔ háo	tǔ háo	Local tycoon	local tyrant / local strong man / (slang) nouveau riche	local tyrant / local strong man / (slang) nouveau riche	
+Internet Slang	吃货	吃貨	chī huò	chī huò	Food goods	chowhound / foodie / a good-for-nothing	chowhound / foodie / a good-for-nothing	
+Internet Slang	宅男		zhái nán	zhái nán	Takuotoko	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	
+Internet Slang	菜鸟	菜鳥	cài niǎo	cài niǎo	Rookie	(coll.) sb new to a particular subject / rookie / beginner / newbie	(coll.) sb new to a particular subject / rookie / beginner / newbie	
+Internet Slang	美图		měi tú	měi tú	Mito			
+Internet Slang	萌		méng	méng	Sprout	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	
+Internet Slang	自拍		zì pāi	zì pāi	Selfie	to take a picture or video of oneself	to take a picture or video of oneself	
+Internet Slang	囧		jiǒng	jiǒng	Oops	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	
+Internet Slang	美眉		měi méi	měi méi	Meimei	(coll.) pretty girl	(coll.) pretty girl	
+Internet Slang	高富帅	高富帥	gāo fù shuài	gāo fù shuài	Tall, rich and handsome	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	
+Internet Slang	眉		méi	méi	eyebrow	eyebrow / upper margin	eyebrow / upper margin	
+Internet Slang	富		Fù   fù	Fù   fù	rich	surname Fu  rich / abundant / wealthy	surname Fu  rich / abundant / wealthy	
+Internet Slang	微博		wēi bó	wēi bó	BiHiroshi	micro-blogging / microblog	micro-blogging / microblog	
+Internet Slang	微信		Wēi xìn	Wēi xìn	Micro letter	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	
+Internet Slang	朋友圈		Péng you quān	Péng you quān	Circle of friends	Moments (social networking function of smartphone app WeChat 微信)	Moments (social networking function of smartphone app WeChat 微信)	
+Internet Slang	微		Wēi   wēi	Wēi   wēi	micro-	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]	
+Internet Slang	圈		juān   juàn   quān	juān   juàn   quān	ring	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle	
+Internet Slang	关注	關注	guān zhù	guān zhù	attention	to pay attention to / to follow sth closely / concern / interest / attention	to pay attention to / to follow sth closely / concern / interest / attention	
+Internet Slang	赞	贊	zàn	zàn	awesome	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	
+Internet Slang	转发	轉發	zhuǎn fā	zhuǎn fā	Forwarded	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	
+Internet Slang	好友		hǎo yǒu	hǎo yǒu	Friends	close friend / pal / (social networking website) friend / CL: 個｜个	close friend / pal / (social networking website) friend / CL: 個｜个	
+Internet Slang	粉丝	粉絲	fěn sī	fěn sī	Fans	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	
+Internet Slang	分享		fēn xiǎng	fēn xiǎng	share it	to share (let others have some of sth good)	to share (let others have some of sth good)	
+Internet Slang	评论	評論	píng lùn	píng lùn	comment	to comment on / to discuss / comment / commentary / CL: 篇	to comment on / to discuss / comment / commentary / CL: 篇	
+Internet Slang	粉		fěn	fěn	powder	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink	
+Internet Slang	丝	絲	sī	sī	wire	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc	
+Internet Slang	享		xiǎng	xiǎng	enjoy	to enjoy / to benefit / to have the use of	to enjoy / to benefit / to have the use of	
+Internet Slang	评	評	píng	píng	Review	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)	
+Internet Slang	论	論	Lún   lùn	Lún   lùn	s	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)	
+Business 1	销	銷	xiāo	xiāo	pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin	
+Business 1	收据	收據	shōu jù	shōu jù	receipt	receipt / CL: 張｜张	receipt / CL: 張｜张	
+Business 1	报销	報銷	bào xiāo	bào xiāo	Submit an expense account	to submit an expense account / to apply for reimbursement / to write off / to wipe out	to submit an expense account / to apply for reimbursement / to write off / to wipe out	
+Business 1	费用	費用	fèi yòng	fèi yòng	cost	cost / expenditure / expense / CL: 筆｜笔, 個｜个	cost / expenditure / expense / CL: 筆｜笔, 個｜个	
+Business 1	尽快	儘快	jǐn kuài   jìn kuài	jǐn kuài   jìn kuài	ASAP	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	
+Business 1	回复	回復	huí fù	huí fù	Reply	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	
+Business 1	报告	報告	bào gào	bào gào	report	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	
+Business 1	协议	協議	xié yì	xié yì	protocol	agreement / pact / protocol / CL: 項｜项	agreement / pact / protocol / CL: 項｜项	
+Business 1	尽	儘	jǐn   jìn	jǐn   jìn	Exhausted	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely	
+Business 1	协	協	xié	xié	Assist	to cooperate / to harmonize / to help / to assist / to join	to cooperate / to harmonize / to help / to assist / to join	
+Business 1	合同		hé tong	hé tong	contract	(business) contract / CL: 個｜个	(business) contract / CL: 個｜个	
+Business 1	项目	項目	xiàng mù	xiàng mù	project	item / project / (sports) event / CL: 個｜个	item / project / (sports) event / CL: 個｜个	
+Business 1	签名	簽名	qiān míng	qiān míng	signature	to sign (one's name with a pen etc) / to autograph / signature	to sign (one's name with a pen etc) / to autograph / signature	
+Business 1	汇报	匯報	huì bào   huì bào	huì bào   huì bào	report	to report / to give an account of / to collect information and report back  to report / to give an account of / report	to report / to give an account of / to collect information and report back  to report / to give an account of / report	
+Business 1	合		gě   hé	gě   hé	Close	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒	
+Business 1	项	項	Xiàng   xiàng	Xiàng   xiàng	item	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc	
+Business 1	汇	匯	huì   huì	huì   huì	exchange	to remit / to converge (of rivers) / to exchange  class / collection	to remit / to converge (of rivers) / to exchange  class / collection	
+Business 1	广告	廣告	guǎng gào	guǎng gào	ad	to advertise / a commercial / advertisement / CL: 項｜项	to advertise / a commercial / advertisement / CL: 項｜项	
+Business 1	预算	預算	yù suàn	yù suàn	budget	budget	budget	
+Business 1	资本	資本	zī běn	zī běn	capital	capital (economics)	capital (economics)	
+Business 1	低		dī	dī	low	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	
+Business 1	广	廣	Guǎng   guǎng	Guǎng   guǎng	wide	surname Guang  wide / numerous / to spread	surname Guang  wide / numerous / to spread	
+Business 1	资	資	zī	zī	Capital	resources / capital / to provide / to supply / to support / money / expense	resources / capital / to provide / to supply / to support / money / expense	
+Business 2	险	險	xiǎn	xiǎn	risk	danger / dangerous / rugged	danger / dangerous / rugged	
+Business 2	投		tóu	tóu	cast	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of	
+Business 2	保险	保險	bǎo xiǎn	bǎo xiǎn	Insurance	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	
+Business 2	风险	風險	fēng xiǎn	fēng xiǎn	risk	risk / hazard	risk / hazard	
+Business 2	投资	投資	tóu zī	tóu zī	investment	investment / to invest	investment / to invest	
+Business 2	律师	律師	lǜ shī	lǜ shī	lawyer	lawyer	lawyer	
+Business 2	版权	版權	bǎn quán	bǎn quán	copyright	copyright	copyright	
+Business 2	咨询	咨詢	zī xún	zī xún	advisory	to consult / to seek advice / consultation / (sales) inquiry (formal)	to consult / to seek advice / consultation / (sales) inquiry (formal)	
+Business 2	律		Lǜ   lǜ	Lǜ   lǜ	law	surname Lü  law	surname Lü  law	
+Business 2	版		bǎn	bǎn	Version	a register / block of printing / edition / version / page	a register / block of printing / edition / version / page	
+Business 2	咨		zī	zī	Advisory	to consult	to consult	
+Business 2	权	權	Quán   quán	Quán   quán	right	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary	
+Business 2	询	詢	xún	xún	Query	to ask about / to inquire about	to ask about / to inquire about	
+Business 2	保持		bǎo chí	bǎo chí	maintain	to keep / to maintain / to hold / to preserve	to keep / to maintain / to hold / to preserve	
+Business 2	联系	聯繫	lián xì	lián xì	contact	connection / contact / relation / to get in touch with / to integrate / to link / to touch	connection / contact / relation / to get in touch with / to integrate / to link / to touch	
+Business 2	联	聯	lián	lián	United	to ally / to unite / to join / (poetry) antithetical couplet	to ally / to unite / to join / (poetry) antithetical couplet	
+Business 2	持		chí	chí	hold	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control	
+Business 2	合作		hé zuò	hé zuò	Cooperation	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	
+Business 2	愉快		yú kuài	yú kuài	happy	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	
+Business 2	辛苦		xīn kǔ	xīn kǔ	hard	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	
+Business 2	感谢	感謝	gǎn xiè	gǎn xiè	thank	(express) thanks / gratitude / grateful / thankful / thanks	(express) thanks / gratitude / grateful / thankful / thanks	
+Business 2	愉		yú	yú	Discovery	pleased	pleased	
+Business 2	辛		Xīn   xīn	Xīn   xīn	Xin	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa	
+Emergency	伤	傷	shāng	shāng	hurt	to injure / injury / wound	to injure / injury / wound	
+Emergency	受		shòu	shòu	Suffer	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)	
+Emergency	救		jiù	jiù	save	to save / to assist / to rescue	to save / to assist / to rescue	
+Emergency	警		jǐng	jǐng	police	to alert / to warn / police	to alert / to warn / police	
+Emergency	报警	報警	bào jǐng	bào jǐng	Call the police	to sound an alarm / to report sth to the police	to sound an alarm / to report sth to the police	
+Emergency	救护车	救護車	jiù hù chē	jiù hù chē	ambulance	ambulance / CL: 輛｜辆	ambulance / CL: 輛｜辆	
+Emergency	受伤	受傷	shòu shāng	shòu shāng	Injured	to sustain injuries / wounded (in an accident etc) / harmed	to sustain injuries / wounded (in an accident etc) / harmed	
+Emergency	救命		jiù mìng	jiù mìng	Help	to save sb's life / (interj.) Help! / Save me!	to save sb's life / (interj.) Help! / Save me!	
+Emergency	发生	發生	fā shēng	fā shēng	occur	to happen / to occur / to take place / to break out	to happen / to occur / to take place / to break out	
+Emergency	意外		yì wài	yì wài	accident	unexpected / accident / mishap / CL: 個｜个	unexpected / accident / mishap / CL: 個｜个	
+Emergency	严重	嚴重	yán zhòng	yán zhòng	serious	grave / serious / severe / critical	grave / serious / severe / critical	
+Emergency	严	嚴	Yán   yán	Yán   yán	strict	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father	
+Emergency	命		mìng	mìng	Life	life / fate / order or command / to assign a name, title etc	life / fate / order or command / to assign a name, title etc	
+Emergency	偷		tōu	tōu	steal	to steal / to pilfer / to snatch / thief / stealthily	to steal / to pilfer / to snatch / thief / stealthily	
+Emergency	警察		jǐng chá	jǐng chá	Policemen	police / police officer / CL: 個｜个	police / police officer / CL: 個｜个	
+Emergency	察		Chá   chá	Chá   chá	Observe	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident	
+Work 3	奖	獎	jiǎng	jiǎng	prize	prize / award / encouragement / CL: 個｜个	prize / award / encouragement / CL: 個｜个	
+Work 3	工资	工資	gōng zī	gōng zī	wage	wages / pay / CL: 個｜个, 份, 月	wages / pay / CL: 個｜个, 份, 月	
+Work 3	加班		jiā bān	jiā bān	Overtime	to work overtime	to work overtime	
+Work 3	奖金	獎金	jiǎng jīn	jiǎng jīn	bonus	premium / award money / bonus	premium / award money / bonus	
+Work 3	生意		shēng yì   shēng yi	shēng yì   shēng yi	business	life force / vitality  business / CL: 筆｜笔	life force / vitality  business / CL: 筆｜笔	
+Work 3	压力	壓力	yā lì	yā lì	pressure	pressure	pressure	
+Work 3	责任	責任	zé rèn	zé rèn	responsibility	responsibility / blame / duty / CL: 個｜个	responsibility / blame / duty / CL: 個｜个	
+Work 3	商量		shāng liang	shāng liang	discuss	to consult / to talk over / to discuss	to consult / to talk over / to discuss	
+Work 3	意见	意見	yì jiàn	yì jiàn	opinion	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	
+Work 3	压	壓	yā   yà	yā   yà	Press	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿	
+Work 3	责	責	zé	zé	responsibility	duty / responsibility / to reproach / to blame	duty / responsibility / to reproach / to blame	
+Work 3	任		Rén   rèn	Rén   rèn	Any	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)	
+Work 3	误会	誤會	wù huì	wù huì	misunderstanding	to misunderstand / to mistake / misunderstanding / CL: 個｜个	to misunderstand / to mistake / misunderstanding / CL: 個｜个	
+Work 3	抱歉		bào qiàn	bào qiàn	Sorry	to be sorry / to feel apologetic / sorry!	to be sorry / to feel apologetic / sorry!	
+Work 3	原谅	原諒	yuán liàng	yuán liàng	forgive	to excuse / to forgive / to pardon	to excuse / to forgive / to pardon	
+Work 3	误	誤	wù	wù	error	mistake / error / to miss / to harm / to delay / to neglect / mistakenly	mistake / error / to miss / to harm / to delay / to neglect / mistakenly	
+Work 3	抱		bào	bào	hold	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish	
+Work 3	原		Yuán   yuán	Yuán   yuán	original	Hara (Japanese surname)  former / original / primary / raw / level / cause / source	Hara (Japanese surname)  former / original / primary / raw / level / cause / source	
+Work 3	歉		qiàn	qiàn	apologize	to apologize / to regret / deficient	to apologize / to regret / deficient	
+Work 3	谅	諒	liàng	liàng	Forgive	to show understanding / to excuse / to presume / to expect	to show understanding / to excuse / to presume / to expect	
+Weather 2	干燥	乾燥	gān zào	gān zào	dry	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	
+Weather 2	暖和		nuǎn huo	nuǎn huo	warm	warm / nice and warm	warm / nice and warm	
+Weather 2	凉快	涼快	liáng kuai	liáng kuai	Cool off	nice and cold / pleasantly cool	nice and cold / pleasantly cool	
+Weather 2	燥		zào	zào	dry	dry / parched / impatient	dry / parched / impatient	
+Weather 2	暖		nuǎn	nuǎn	warm	warm / to warm	warm / to warm	
+Weather 2	凉	涼	Liáng   liáng   liàng	Liáng   liáng   liàng	cool	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down	
+Weather 2	温度	溫度	wēn dù	wēn dù	temperature	temperature / CL: 個｜个	temperature / CL: 個｜个	
+Weather 2	大约	大約	dà yuē	dà yuē	about	approximately / probably	approximately / probably	
+Weather 2	温	溫	Wēn   wēn	Wēn   wēn	temperature	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟	
+Duo	鹰	鷹	yīng	yīng	eagle	eagle / falcon / hawk	eagle / falcon / hawk	
+Duo	羽		yǔ	yǔ	feather	feather / 5th note in pentatonic scale	feather / 5th note in pentatonic scale	
+Duo	橙		chéng	chéng	Orange	orange tree / orange (color)	orange tree / orange (color)	
+Duo	猫头鹰	貓頭鷹	māo tóu yīng	māo tóu yīng	owl	owl	owl	
+Duo	羽毛		yǔ máo	yǔ máo	feather	feather / plumage / plume	feather / plumage / plume	
+Duo	多儿		duō er	duō er	And more children			
+Duo	鼓励	鼓勵	gǔ lì	gǔ lì	encourage	to encourage	to encourage	
+Duo	提醒		tí xǐng	tí xǐng	remind	to remind / to call attention to / to warn of	to remind / to call attention to / to warn of	
+Duo	懒	懶	lǎn	lǎn	lazy	lazy	lazy	
+Duo	放弃	放棄	fàng qì	fàng qì	give up	to renounce / to abandon / to give up	to renounce / to abandon / to give up	
+Duo	鼓		gǔ	gǔ	drum	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell	
+Duo	励	勵	Lì   lì	Lì   lì	Encourage	surname Li  to encourage / to urge	surname Li  to encourage / to urge	
+Duo	醒		xǐng	xǐng	wake	to wake up / to be awake / to become aware / to sober up / to come to	to wake up / to be awake / to become aware / to sober up / to come to	
+Duo	弃	棄	qì	qì	abandoned	to abandon / to relinquish / to discard / to throw away	to abandon / to relinquish / to discard / to throw away	


### PR DESCRIPTION
I removed duplicate characters from the file reducing the row count from 1666 to 1501, including the header row.  Before doing so, I sorted the file and confirmed that the definitions for these 165 deleted rows were an exact match to the original row.  

I am pretty excited about the Google Translate definition.  It is not perfect, but at a glance I would guess it gets us a clean, usable definition for probably 70% of the words.  Take a look and give me your thoughts.

After deleting the duplicates yesterday, I realized there may be some value in keeping a list of the words that each character appears in.  As an example, the character "们" appears in 你们, 我们, 他们, and 她们.  Or another example, “学" appears in 学生,上学,放学, 学习, 同学, 科学, 小学, 留学, 数学, and 大学.  These vocabulary words appear across many lessons throughout Duolingo, and this is related to the reason there were so many duplicates in the file.  I would like to note the vocabulary words and lessons where each character appears, and I began working on that yesterday.  Admittedly I am uncertain whether we will print these on an Anki card, which means I might be going down a bit of a rabbit hole, but since I am also doing this for my own benefit, I see personal value in it and I think I can finish it pretty quickly.