### PR TITLE
Added Alternate Occurrences Column

### DIFF
--- a/words.tsv
+++ b/words.tsv
@@ -1,1501 +1,1501 @@
-Lesson	Simplified Chinese	Traditional Chinese	Primary pinyin	CC-CEDICT pinyin	Google_Translate_Definition	Primary English definition	CC-CEDICT English definition	Labels
-Greeting 1	你		nǐ		you	you		
-Greeting 1	好		hǎo   hào		it is good	good		
-Greeting 1	再见	再見	zài jiàn		Goodbye	see you again later		
-Greeting 1	再		zài		again	again		
-Greeting 1	见	見	jiàn		see	to see		
-Numbers	三		sān		three	3		
-Numbers	一		yī		One	1		
-Numbers	七		qī		Seven	7		
-Numbers	八		bā		Eight	8		
-Numbers	十		shí		ten	10		
-Numbers	零		líng		zero	zero		
-Numbers	元		Yuán		yuan	Chinese yuan currency unit		
-Numbers	五		wǔ		Fives	5		
-Numbers	九		jiǔ		nine	9		
-Numbers	百		bǎi		hundred	100		
-Numbers	二		èr		two	2		
-Numbers	四		sì		four	4		
-Numbers	六		liù		six	6		
-Name	叫		jiào		call	to be called		
-Name	我		wǒ		I	I		
-Name	张	張	Zhāng		Zhang	surname Zhang		
-Name	李		Lǐ		Plum	surname Li		
-Name	华	華	Huá		China	given name Huá		
-Name	明		míng		Bright			Meaning off-topic
-Name	名字		míng zi		first name	name		
-Name	什么	什麼	shén me		what	what?		
-Name	名		míng		name			Meaning off-topic
-Name	字		zì		word	letter		
-Name	什		shén   shí		Assorted			Meaning off-topic
-Name	么	麼	má   ma   me		What			Meaning off-topic
-Name	姓		xìng		surname	Family name		
-Name	王		Wáng		king	surname Wang		
-Name	呢		ne		It	question particle		
-Greeting 2	很		hěn		very	very		
-Greeting 2	高兴	高興	gāo xìng		happy	happy		
-Greeting 2	高		gāo		high	tall		
-Greeting 2	兴	興	xìng		Interest			Meaning off-topic
-Greeting 2	认识	認識	rèn shi		understanding	to know		
-Greeting 2	也		yě		and also	too		
-Greeting 2	认	認	rèn		recognize			Meaning off-topic
-Greeting 2	识	識	shí   zhì		knowledge			Meaning off-topic
-Food 1	吃		chī	chī	eat	to eat	to eat / to consume / to eat at (a cafeteria etc) / to eradicate / to destroy / to absorb / to suffer / to stammer (Taiwan pr. for this sense is [ji2])	
-Food 1	饭	飯	fàn	fàn	rice	food	food / cuisine / cooked rice / meal / CL: 碗, 頓｜顿	
-Food 1	鱼	魚	yú	Yú   yú	fish	fish	surname Yu  fish / CL: 條｜条, 尾	
-Food 1	面		miàn	miàn   miàn	surface	noodles	face / side / surface / aspect / top / classifier for flat surfaces such as drums, mirrors, flags etc  flour / noodles / (of food) soft (not crunchy) / (slang) (of a person) ineffectual / spineless	
-Food 1	喝		hē	hē   hè	drink	to drink	to drink / My goodness!  to shout loudly	
-Food 1	水		shuǐ	Shuǐ   shuǐ	water	water	surname Shui  water / river / liquid / beverage / additional charges or income / (of clothes) classifier for number of washes	
-Food 1	茶		chá	chá	tea	tea	tea / tea plant / CL: 杯, 壺｜壶	
-Food 1	不		bù	bù	Do not	not	(negative prefix) / not / no	
-Occupation	是		shì	shì	Yes	to be	is / are / am / yes / to be	
-Occupation	他		tā	tā	he	he	he or him / (used for either sex when the sex is unknown or unimportant) / (used before sb's name for emphasis) / (used as a meaningless mock object) / other / another	
-Occupation	学生	學生	xué sheng	xué sheng	student	student	student / schoolchild	
-Occupation	学	學	xué	xué	learn	to learn	to learn / to study / to imitate / science / -ology	
-Occupation	生		shēng	shēng	Raw		to be born / to give birth / life / to grow / raw / uncooked / student	Meaning off-topic
-Occupation	吗	嗎	mǎ	mǎ   ma	It	question particle for 'yes-no' questions	see 嗎啡｜吗啡, morphine  (question particle for 'yes-no' questions)	
-Occupation	她		tā	tā	she was	she	she	
-Occupation	你们	你們	nǐ men	nǐ men	you guys	you (plural)	you (plural)	
-Occupation	我们	我們	wǒ men	wǒ men	we	we	we / us / ourselves / our	
-Occupation	他们	他們	tā men	tā men	they	they	they	
-Occupation	们	們	men	men	They	plural marker for pronouns	plural marker for pronouns, and nouns referring to individuals	
-Occupation	老师	老師	lǎo shī	lǎo shī	teacher	teacher	teacher / CL: 個｜个, 位	
-Occupation	医生	醫生	yī shēng	yī shēng	Doctors	doctor	doctor / CL: 個｜个, 位, 名	
-Occupation	她们	她們	tā men	tā men	they	they (females)	they / them (for females)	
-Occupation	老		lǎo	lǎo	old		prefix used before the surname of a person or a numeral indicating the order of birth of the children in a family or to indicate affection or familiarity / old (of people) / venerable (person) / experienced / of long standing / always / all the time / of the past / very / outdated / (of meat etc) tough	Meaning off-topic
-Occupation	师	師	Shī   shī	Shī   shī	division		surname Shi  teacher / master / expert / model / army division / (old) troops / to dispatch troops	Meaning off-topic
-Occupation	医	醫	yī	yī	medical		medical / medicine / doctor / to cure / to treat	Meaning off-topic
-Contact	的		de	de   dī   dí   dì	of	of	of / ~'s (possessive particle) / (used after an attribute) / (used to form a nominal expression) / (used at the end of a declarative sentence for emphasis)  see 的士  really and truly  aim / clear	
-Contact	电话	電話	diàn huà	diàn huà	phone	telephone	telephone / CL: 部 / phone call / CL: 通 / phone number	
-Contact	电	電	diàn	diàn	Electricity	electricity	electric / electricity / electrical	
-Contact	话	話	huà	huà	words	language	dialect / language / spoken words / speech / talk / words / conversation / what sb said / CL: 種｜种, 席, 句, 口, 番	
-Contact	号码	號碼	hào mǎ	hào mǎ	number	number	number / CL: 堆, 個｜个	
-Contact	多少		duō shǎo	duō shǎo   duō shao	How many	how many	number / amount / somewhat  how much / how many / which (number) / as much as	
-Contact	多		duō	duō	many	many	many / much / often / a lot of / numerous / more / in excess / how (to what extent) / multi- / Taiwan pr. [duo2] when it means 'how'	
-Contact	少		shǎo	shǎo   shào	less	few	few / less / to lack / to be missing / to stop (doing sth) / seldom  young	
-Contact	号	號	háo   hào	háo   hào	number		roar / cry / CL: 個｜个  ordinal number / day of a month / mark / sign / business establishment / size / ship suffix / horn (wind instrument) / bugle call / assumed name / to take a pulse / classifier used to indicate number of people	Meaning off-topic
-Contact	码	碼	mǎ	mǎ	code		weight / number / code / to pile / to stack / classifier for length or distance (yard), happenings etc	Meaning off-topic
-Nation	中国	中國	Zhōng guó	Zhōng guó	China	China	China	
-Nation	人		rén	rén	people	person	man / person / people / CL: 個｜个, 位	
-Nation	中		zhōng	Zhōng   zhōng   zhòng	in	middle	China / Chinese / surname Zhong  within / among / in / middle / center / while (doing sth) / during / (dialect) OK / all right  to hit (the mark) / to be hit by / to suffer / to win (a prize, a lottery)	
-Nation	国	國	guó	Guó   guó	country	country	surname Guo  country / nation / state / national / CL: 個｜个	
-Nation	哪		nǎ	nǎ   na   něi	where	how / which	how / which  (particle equivalent to 啊 after noun ending in -n)  which? (interrogative, followed by classifier or numeral-classifier)	
-Nation	英国	英國	Yīng guó	Yīng guó	United Kingdom	United Kingdom	United Kingdom 聯合王國｜联合王国 / United Kingdom of Great Britain and Northern Ireland / abbr. for England 英格蘭｜英格兰	
-Nation	美国	美國	Měi guó	Měi guó	United States	USA	United States / USA / US	
-Nation	英		Yīng   yīng	Yīng   yīng	English	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	
-Nation	美		Měi   měi	Měi   měi	nice	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself	
-Nation	都		Dū   dōu   dū	Dū   dōu   dū	All	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	
-Nation	对	對	duì	duì	Correct	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	
-Nation	加拿大		Jiā ná dà	Jiā ná dà	Canada	Canada / Canadian	Canada / Canadian	
-Nation	加		Jiā   jiā	Jiā   jiā	plus	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	
-Nation	拿		ná	ná	take	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	
-Nation	大		dà   dài	dà   dài	Big	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	
-Greeting 3	忙		máng	máng	busy	busy / hurriedly / to hurry / to rush	busy / hurriedly / to hurry / to rush	
-Greeting 3	早上		zǎo shang	zǎo shang	morning	early morning / CL: 個｜个	early morning / CL: 個｜个	
-Greeting 3	早		zǎo	zǎo	early	early / morning / Good morning! / long ago / prematurely	early / morning / Good morning! / long ago / prematurely	
-Greeting 3	上		shǎng   shàng	shǎng   shàng	on	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	
-Greeting 3	怎么样	怎麼樣	zěn me yàng	zěn me yàng	how about it	how? / how about? / how was it? / how are things?	how? / how about? / how was it? / how are things?	
-Greeting 3	今天		jīn tiān	jīn tiān	Nowadays	today / at the present / now	today / at the present / now	
-Greeting 3	怎		zěn	zěn	How	how	how	
-Greeting 3	样	樣	yàng	yàng	kind	manner / pattern / way / appearance / shape / classifier: kind, type	manner / pattern / way / appearance / shape / classifier: kind, type	
-Greeting 3	今		jīn	jīn	now	today / modern / present / current / this / now	today / modern / present / current / this / now	
-Greeting 3	天		tiān	tiān	day	day / sky / heaven	day / sky / heaven	
-Location 1	家	傢	jiā   Jiā   jiā	jiā   Jiā   jiā	Family	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	
-Location 1	北京		Běi jīng	Běi jīng	Beijing	Beijing, capital of People's Republic of China / Peking / PRC government	Beijing, capital of People's Republic of China / Peking / PRC government	
-Location 1	在		zài	zài	in	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	
-Location 1	北		běi	běi	north	north / to be defeated (classical)	north / to be defeated (classical)	
-Location 1	京		Jīng   jīng	Jīng   jīng	Beijing	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)	
-Location 1	哪儿	哪兒	nǎr	nǎr	where	where? / wherever / anywhere	where? / wherever / anywhere	
-Location 1	纽约	紐約	Niǔ yuē	Niǔ yuē	new York	New York	New York	
-Location 1	香港		Xiāng gǎng	Xiāng gǎng	Hong Kong	Hong Kong	Hong Kong	
-Location 1	儿	兒	ér   r	ér   r	child	child / son  non-syllabic diminutive suffix / retroflex final	child / son  non-syllabic diminutive suffix / retroflex final	
-Location 1	纽	紐	niǔ	niǔ	Button	to turn / to wrench / button / nu (Greek letter Νν)	to turn / to wrench / button / nu (Greek letter Νν)	
-Location 1	约	約	yāo   yuē	yāo   yuē	approximately	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise	
-Location 1	香		xiāng	xiāng	Fragrant	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	
-Location 1	港		Gǎng   gǎng	Gǎng   gǎng	port	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个	
-Location 1	住		zhù	zhù	live	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	
-Location 1	伦敦	倫敦	Lún dūn	Lún dūn	London	London, capital of United Kingdom	London, capital of United Kingdom	
-Location 1	台湾	臺灣	Tái wān	Tái wān	Taiwan	Taiwan	Taiwan	
-Location 1	伦	倫	lún	lún	Lun	human relationship / order / coherence	human relationship / order / coherence	
-Location 1	敦		dūn	dūn	London	kindhearted / place name	kindhearted / place name	
-Location 1	台		Tái   tái   tái   Tái   tái   tái	Tái   tái   tái   Tái   tái   tái	station	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon	
-Location 1	湾	灣	wān	wān	Bay	bay / gulf / to cast anchor / to moor (a boat)	bay / gulf / to cast anchor / to moor (a boat)	
-Phrases 1	谢谢	謝謝	xiè xie	xiè xie	Thank you	to thank / thanks / thank you	to thank / thanks / thank you	
-Phrases 1	不客气	不客氣	bù kè qi	bù kè qi	You're welcome	you're welcome / don't mention it / impolite / rude / blunt	you're welcome / don't mention it / impolite / rude / blunt	
-Phrases 1	谢	謝	Xiè   xiè	Xiè   xiè	thank	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline	
-Phrases 1	客		kè	kè	customer	customer / visitor / guest	customer / visitor / guest	
-Phrases 1	气	氣	qì	qì	gas	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi	
-Phrases 1	对不起	對不起	duì bu qǐ	duì bu qǐ	I am sorry	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	
-Phrases 1	没关系	沒關係	méi guān xi	méi guān xi	It's ok	it doesn't matter	it doesn't matter	
-Phrases 1	起		qǐ	qǐ	Start	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	
-Phrases 1	没	沒	méi   mò	méi   mò	No	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	
-Phrases 1	关	關	Guān   guān	Guān   guān	turn off	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	
-Phrases 1	系	係	xì   xì   jì   xì	xì   xì   jì   xì	system	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry	
-Family 1	爸爸		bà ba	bà ba	father	(informal) father / CL: 個｜个, 位	(informal) father / CL: 個｜个, 位	
-Family 1	妈妈	媽媽	mā ma	mā ma	mom	mama / mommy / mother / CL: 個｜个, 位	mama / mommy / mother / CL: 個｜个, 位	
-Family 1	爱	愛	ài	ài	Love	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)	
-Family 1	家人		jiā rén	jiā rén	family	household / (one's) family	household / (one's) family	
-Family 1	爸		bà	bà	dad	father / dad / pa / papa	father / dad / pa / papa	
-Family 1	妈	媽	mā	mā	mom	ma / mom / mother	ma / mom / mother	
-Family 1	谁	誰	shéi	shéi	Who	who / also pr. [shui2]	who / also pr. [shui2]	
-Family 1	那		Nā   Nuó   nà   nuó	Nā   Nuó   nà   nuó	that	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪	
-Family 1	个	個	gè	gè	More	individual / this / that / size / classifier for people or objects in general	individual / this / that / size / classifier for people or objects in general	
-Family 1	这	這	zhè	zhè	This	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)	
-Family 1	哥哥		gē ge	gē ge	brother	older brother / CL: 個｜个, 位	older brother / CL: 個｜个, 位	
-Family 1	姐姐		jiě jie	jiě jie	sister	older sister / CL: 個｜个	older sister / CL: 個｜个	
-Family 1	有		yǒu	yǒu	Have	to have / there is / there are / to exist / to be	to have / there is / there are / to exist / to be	
-Family 1	哥		gē	gē	brother	elder brother	elder brother	
-Family 1	姐		jiě	jiě	sister	older sister	older sister	
-Family 1	弟弟		dì di	dì di	Little brother	younger brother / CL: 個｜个, 位	younger brother / CL: 個｜个, 位	
-Family 1	和		Hé   hé   hè   hú   huó   huò	Hé   hé   hè   hú   huó   huò	with	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	
-Family 1	妹妹		mèi mei	mèi mei	younger sister	younger sister / young woman / CL: 個｜个	younger sister / young woman / CL: 個｜个	
-Family 1	弟		dì	dì	Younger brother	younger brother / junior male / I (modest word in letter)	younger brother / junior male / I (modest word in letter)	
-Family 1	妹		mèi	mèi	sister	younger sister	younger sister	
-Phrases 2	请问	請問	qǐng wèn	qǐng wèn	Excuse me	Excuse me, may I ask...?	Excuse me, may I ask...?	
-Phrases 2	知道		zhī dào	zhī dào	know	to know / to become aware of / also pr. [zhi1 dao5]	to know / to become aware of / also pr. [zhi1 dao5]	
-Phrases 2	问	問	wèn	wèn	ask	to ask	to ask	
-Phrases 2	请	請	qǐng	qǐng	please	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	
-Phrases 2	知		zhī	zhī	know	to know / to be aware	to know / to be aware	
-Phrases 2	道		dào	dào	Road	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)	
-Phrases 2	说	說	shuì   shuō	shuì   shuō	Say	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)	
-Phrases 2	英语	英語	Yīng yǔ	Yīng yǔ	English	English (language)	English (language)	
-Phrases 2	汉语	漢語	Hàn yǔ	Hàn yǔ	Chinese	Chinese language / CL: 門｜门	Chinese language / CL: 門｜门	
-Phrases 2	汉	漢	Hàn   hàn	Hàn   hàn	Chinese	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man	
-Phrases 2	语	語	yǔ   yù	yǔ   yù	language	dialect / language / speech  to tell to	dialect / language / speech  to tell to	
-Phrases 2	帮助	幫助	bāng zhù	bāng zhù	help	assistance / aid / to help / to assist	assistance / aid / to help / to assist	
-Phrases 2	次		cì	cì	Secondary	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	
-Phrases 2	帮	幫	bāng	bāng	help	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	
-Phrases 2	助		zhù	zhù	help	to help / to assist	to help / to assist	
-Greeting 4	早安		zǎo ān	zǎo ān	good Morning	Good morning!	Good morning!	
-Greeting 4	晚安		wǎn ān	wǎn ān	good night	Good night! / Good evening!	Good night! / Good evening!	
-Greeting 4	一会儿	一會兒	yī huìr	yī huìr	Awhile	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	
-Greeting 4	会	會	huì   kuài	huì   kuài	meeting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	
-Greeting 4	安		Ān   ān	Ān   ān	Secure	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere	
-Greeting 4	最近		zuì jìn	zuì jìn	Recently	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	
-Greeting 4	好久不见	好久不見	hǎo jiǔ bu jiàn	hǎo jiǔ bu jiàn	long time no see	long time no see	long time no see	
-Greeting 4	不错	不錯	bù cuò	bù cuò	Pretty good	correct / right / not bad / pretty good	correct / right / not bad / pretty good	
-Greeting 4	最		zuì	zuì	most	most / the most / -est (superlative suffix)	most / the most / -est (superlative suffix)	
-Greeting 4	近		jìn	jìn	near	near / close to / approximately	near / close to / approximately	
-Greeting 4	久		jiǔ	jiǔ	Long	(long) time / (long) duration of time	(long) time / (long) duration of time	
-Greeting 4	错	錯	Cuò   cuò	Cuò   cuò	wrong	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	
-Drink	要		yāo   yào	yāo   yào	To	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if	
-Drink	热	熱	rè	rè	heat	to warm up / to heat up / hot (of weather) / heat / fervent	to warm up / to heat up / hot (of weather) / heat / fervent	
-Drink	冰		bīng	bīng	ice	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine	
-Drink	牛奶		niú nǎi	niú nǎi	milk	cow's milk / CL: 瓶, 杯	cow's milk / CL: 瓶, 杯	
-Drink	咖啡		kā fēi	kā fēi	coffee	coffee (loanword) / CL: 杯	coffee (loanword) / CL: 杯	
-Drink	牛		Niú   niú	Niú   niú	Cattle	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome	
-Drink	奶		nǎi   nǎi	nǎi   nǎi	milk	breast / milk / to breastfeed  mother / variant of 奶	breast / milk / to breastfeed  mother / variant of 奶	
-Drink	咖		kā	kā	coffee	coffee / class / grade	coffee / class / grade	
-Drink	啡		fēi	fēi	coffee	(phonetic component)	(phonetic component)	
-Location 2	洗手间	洗手間	xǐ shǒu jiān	xǐ shǒu jiān	Toilets	toilet / lavatory / washroom	toilet / lavatory / washroom	
-Location 2	医院	醫院	yī yuàn	yī yuàn	hospital	hospital / CL: 所, 家, 座	hospital / CL: 所, 家, 座	
-Location 2	洗		xǐ	xǐ	wash	to wash / to bathe / to develop (photo)	to wash / to bathe / to develop (photo)	
-Location 2	手		shǒu	shǒu	hand	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	
-Location 2	间	間	jiān   jiàn	jiān   jiàn	between	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	
-Location 2	院		yuàn	yuàn	hospital	courtyard / institution / CL: 個｜个	courtyard / institution / CL: 個｜个	
-Location 2	这儿	這兒	zhèr	zhèr	here	here	here	
-Location 2	那儿	那兒	nàr	nàr	there	there	there	
-Location 2	饭馆	飯館	fàn guǎn	fàn guǎn	restaurant	restaurant / CL: 家	restaurant / CL: 家	
-Location 2	馆	館	guǎn	guǎn	House	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	
-Time 1	年		Nián   nián   nián	Nián   nián   nián	year	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年	
-Time 1	月		yuè	yuè	month	moon / month / monthly / CL: 個｜个, 輪｜轮	moon / month / monthly / CL: 個｜个, 輪｜轮	
-Time 1	几		jī   jī   jǐ	jī   jī   jǐ	a few	small table  almost  how much / how many / several / a few	small table  almost  how much / how many / several / a few	
-Time 1	〇		líng	líng	〇	zero	zero	
-Time 1	星期		xīng qī	xīng qī	week	week / CL: 個｜个 / day of the week / Sunday	week / CL: 個｜个 / day of the week / Sunday	
-Time 1	明天		míng tiān	míng tiān	tomorrow	tomorrow	tomorrow	
-Time 1	日		Rì   rì	Rì   rì	day	abbr. for 日本, Japan  sun / day / date, day of the month	abbr. for 日本, Japan  sun / day / date, day of the month	
-Time 1	星		xīng	xīng	star	star / heavenly body / satellite / small amount	star / heavenly body / satellite / small amount	
-Time 1	期		qī	qī	period	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]	
-Time 1	点	點	diǎn	diǎn	point	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	
-Time 1	现在	現在	xiàn zài	xiàn zài	just now	now / at present / at the moment / modern / current / nowadays	now / at present / at the moment / modern / current / nowadays	
-Time 1	半		bàn	bàn	half	half / semi- / incomplete / (after a number) and a half	half / semi- / incomplete / (after a number) and a half	
-Time 1	现	現	xiàn	xiàn	Present	to appear / present / now / existing / current	to appear / present / now / existing / current	
-Family 2	孩子		hái zi	hái zi	child	child	child	
-Family 2	两	兩	liǎng	liǎng	Two	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	
-Family 2	孩		hái	hái	child	child	child	
-Family 2	子		zǐ   zi	zǐ   zi	child	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)	
-Family 2	女儿	女兒	nǚ ér	nǚ ér	daughter	daughter	daughter	
-Family 2	儿子	兒子	ér zi	ér zi	son	son	son	
-Family 2	岁	歲	suì	suì	year old	classifier for years (of age) / year / year (of crop harvests)	classifier for years (of age) / year / year (of crop harvests)	
-Family 2	女		nǚ	nǚ	Female	female / woman / daughter	female / woman / daughter	
-Family 2	妻子		qī zǐ   qī zi	qī zǐ   qī zi	wife	wife and children  wife / CL: 個｜个	wife and children  wife / CL: 個｜个	
-Family 2	丈夫		zhàng fu	zhàng fu	husband	husband / CL: 個｜个	husband / CL: 個｜个	
-Family 2	妻		qī   qì	qī   qì	wife	wife  to marry off (a daughter)	wife  to marry off (a daughter)	
-Family 2	丈		zhàng	zhàng	length	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male	
-Family 2	夫		fū   fú	fū   fú	husband	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)	
-Family 2	猫	貓	māo	māo	Cat	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem	
-Family 2	它		tā	tā	it	it	it	
-Family 2	狗		gǒu	gǒu	dog	dog / CL: 隻｜只, 條｜条	dog / CL: 隻｜只, 條｜条	
-Telephone	喂		wéi   wèi   wèi	wéi   wèi   wèi	Hey	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	
-Telephone	慢		màn	màn	slow	slow	slow	
-Telephone	一点儿		yī diǎnr	yī diǎnr	a little	erhua variant of 一點｜一点	erhua variant of 一點｜一点	
-Telephone	快		kuài	kuài	fast	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant	
-Telephone	得		dé   de   děi	dé   de   děi	Get	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	
-Telephone	明白		míng bai	míng bai	understand	clear / obvious / unequivocal / to understand / to realize	clear / obvious / unequivocal / to understand / to realize	
-Telephone	白		Bái   bái	Bái   bái	White	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	
-People 1	漂亮		piào liang	piào liang	Pretty	pretty / beautiful	pretty / beautiful	
-People 1	漂		piāo   piǎo   piào	piāo   piǎo   piào	drift	to float / to drift  to bleach  elegant / polished	to float / to drift  to bleach  elegant / polished	
-People 1	亮		liàng	liàng	bright	bright / clear / resonant / to shine / to show / to reveal	bright / clear / resonant / to shine / to show / to reveal	
-People 1	朋友		péng you	péng you	friend	friend / CL: 個｜个, 位	friend / CL: 個｜个, 位	
-People 1	男		nán	nán	male	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个	
-People 1	矮		ǎi	ǎi	short	low / short (in length)	low / short (in length)	
-People 1	朋		péng	péng	Friend	friend	friend	
-People 1	友		yǒu	yǒu	Friendly	friend	friend	
-People 1	可爱	可愛	kě ài	kě ài	lovely	adorable / cute / lovely	adorable / cute / lovely	
-People 1	非常		fēi cháng	fēi cháng	very much	very / very much / unusual / extraordinary	very / very much / unusual / extraordinary	
-People 1	可		kě   kè	kě   kè	can	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗	
-People 1	非		Fēi   fēi	Fēi   fēi	non-	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must	
-People 1	常		Cháng   cháng	Cháng   cháng	often	surname Chang  always / ever / often / frequently / common / general / constant	surname Chang  always / ever / often / frequently / common / general / constant	
-Time 2	上午		shàng wǔ	shàng wǔ	morning	morning / CL: 個｜个	morning / CL: 個｜个	
-Time 2	分		fēn   fèn	fēn   fèn	Minute	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	
-Time 2	下午		xià wǔ	xià wǔ	in the afternoon	afternoon / CL: 個｜个 / p.m.	afternoon / CL: 個｜个 / p.m.	
-Time 2	晚上		wǎn shang	wǎn shang	at night	evening / night / CL: 個｜个 / in the evening	evening / night / CL: 個｜个 / in the evening	
-Time 2	午		wǔ	wǔ	Noon	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)	
-Time 2	晚		wǎn	wǎn	late	evening / night / late	evening / night / late	
-Time 2	下		xià	xià	under	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	
-Time 2	每		měi	měi	each	each / every	each / every	
-Time 2	中午		zhōng wǔ	zhōng wǔ	noon	noon / midday / CL: 個｜个	noon / midday / CL: 個｜个	
-Time 2	周末	週末	zhōu mò	zhōu mò	weekend	weekend	weekend	
-Time 2	周		Zhōu   zhōu   zhōu	Zhōu   zhōu   zhōu	week	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周	
-Time 2	末		mò	mò	end	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man	
-Time 2	昨天		zuó tiān	zuó tiān	yesterday	yesterday	yesterday	
-Time 2	了		le   liǎo   liǎo	le   liǎo   liǎo	The	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	
-Time 2	做		zuò	zuò	do	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	
-Time 2	昨		zuó	zuó	Yesterday	yesterday	yesterday	
-Time 2	今年		jīn nián	jīn nián	this year	this year	this year	
-Time 2	去年		qù nián	qù nián	last year	last year	last year	
-Time 2	明年		míng nián	míng nián	next year	next year	next year	
-Time 2	去		qù	qù	go with	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	
-Location 3	旁边	旁邊	páng biān	páng biān	next to	lateral / side / to the side / beside	lateral / side / to the side / beside	
-Location 3	左边	左邊	zuǒ bian	zuǒ bian	left	left / the left side / to the left of	left / the left side / to the left of	
-Location 3	右边	右邊	yòu bian	yòu bian	right	right side / right, to the right	right side / right, to the right	
-Location 3	旁		páng	páng	Beside	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic	
-Location 3	左		Zuǒ   zuǒ	Zuǒ   zuǒ	left	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	
-Location 3	右		yòu	yòu	right	right (-hand) / the Right (politics) / west (old)	right (-hand) / the Right (politics) / west (old)	
-Location 3	边	邊	biān   bian	biān   bian	side	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality	
-Location 3	前面		qián miàn	qián miàn	front	ahead / in front / preceding / above / also pr. [qian2 mian5]	ahead / in front / preceding / above / also pr. [qian2 mian5]	
-Location 3	后面	後面	hòu miàn	hòu miàn	Behind	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	
-Location 3	学校	學校	xué xiào	xué xiào	school	school / CL: 所	school / CL: 所	
-Location 3	前		qián	qián	before	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	
-Location 3	后		Hòu   hòu   hòu	Hòu   hòu   hòu	Rear	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	
-Location 3	校		jiào   xiào	jiào   xiào	school	to proofread / to check / to compare  school / military officer / CL: 所	to proofread / to check / to compare  school / military officer / CL: 所	
-Location 3	走		zǒu	zǒu	go	to walk / to go / to run / to move (of vehicle) / to visit / to leave / to go away / to die (euph.) / from / through / away (in compound verbs, such as 撤走) / to change (shape, form, meaning)	to walk / to go / to run / to move (of vehicle) / to visit / to leave / to go away / to die (euph.) / from / through / away (in compound verbs, such as 撤走) / to change (shape, form, meaning)	
-Location 3	到		dào	dào	To	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)	
-Location 3	路		Lù   lù	Lù   lù	road	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	
-Location 3	怎么	怎麼	zěn me	zěn me	how	how? / what? / why?	how? / what? / why?	
-Location 3	哪里	哪裏	nǎ lǐ   nǎ lǐ	nǎ lǐ   nǎ lǐ	where	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	
-Location 3	这里	這裡	zhè lǐ	zhè lǐ	Here	here	here	
-Location 3	那里	那裏	nà li   nà li	nà li   nà li	There	there / that place / also written 那裡｜那里  there / that place	there / that place / also written 那裡｜那里  there / that place	
-Location 3	往		wǎng	wǎng	to	to go (in a direction) / to / towards / (of a train) bound for / past / previous	to go (in a direction) / to / towards / (of a train) bound for / past / previous	
-Location 3	里	裡	lǐ   Lǐ   lǐ	lǐ   Lǐ   lǐ	in	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	
-Hobbies 1	喜欢	喜歡	xǐ huan	xǐ huan	like	to like / to be fond of	to like / to be fond of	
-Hobbies 1	看		kān   kàn	kān   kàn	Look	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)	
-Hobbies 1	书	書	Shū   shū	Shū   shū	book	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write	
-Hobbies 1	喜		xǐ	xǐ	like	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad	
-Hobbies 1	欢	歡	huān   huān   huān	huān   huān   huān	Joyous	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢	
-Hobbies 1	玩		wán	wán	play	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	
-Hobbies 1	电脑	電腦	diàn nǎo	diàn nǎo	computer	computer / CL: 臺｜台	computer / CL: 臺｜台	
-Hobbies 1	游戏	遊戲	yóu xì	yóu xì	game	game / CL: 場｜场 / to play	game / CL: 場｜场 / to play	
-Hobbies 1	脑	腦	nǎo	nǎo	brain	brain / mind / head / essence	brain / mind / head / essence	
-Hobbies 1	游		Yóu   yóu   yóu	Yóu   yóu   yóu	tour	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	
-Hobbies 1	戏	戲	xì	xì	play	trick / drama / play / show / CL: 出, 場｜场, 臺｜台	trick / drama / play / show / CL: 出, 場｜场, 臺｜台	
-Hobbies 1	听		yǐn   tīng   tìng	yǐn   tīng   tìng	listen	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	
-Hobbies 1	音乐	音樂	yīn yuè	yīn yuè	music	music / CL: 張｜张, 曲, 段	music / CL: 張｜张, 曲, 段	
-Hobbies 1	歌		gē	gē	song	song / CL: 支, 首 / to sing	song / CL: 支, 首 / to sing	
-Hobbies 1	音		yīn	yīn	sound	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)	
-Hobbies 1	乐	樂	Lè   Yuè   lè   yuè	Lè   Yuè   lè   yuè	fun	surname Le  surname Yue  happy / cheerful / to laugh  music	surname Le  surname Yue  happy / cheerful / to laugh  music	
-Hobbies 1	跳舞		tiào wǔ	tiào wǔ	dancing	to dance	to dance	
-Hobbies 1	唱		chàng	chàng	sing	to sing / to call loudly / to chant	to sing / to call loudly / to chant	
-Hobbies 1	跳		tiào	tiào	jump	to jump / to hop / to skip over / to bounce / to palpitate	to jump / to hop / to skip over / to bounce / to palpitate	
-Hobbies 1	舞		wǔ	wǔ	dance	to dance / to wield / to brandish	to dance / to wield / to brandish	
-Daily Routine 1	起床		qǐ chuáng	qǐ chuáng	get up	to get out of bed / to get up	to get out of bed / to get up	
-Daily Routine 1	上学	上學	shàng xué	shàng xué	go to school	to go to school / to attend school	to go to school / to attend school	
-Daily Routine 1	上班		shàng bān	shàng bān	Go to work	to go to work / to be on duty / to start work / to go to the office	to go to work / to be on duty / to start work / to go to the office	
-Daily Routine 1	早饭	早飯	zǎo fàn	zǎo fàn	breakfast	breakfast / CL: 份, 頓｜顿, 次, 餐	breakfast / CL: 份, 頓｜顿, 次, 餐	
-Daily Routine 1	床		chuáng	chuáng	bed	bed / couch / classifier for beds / CL: 張｜张	bed / couch / classifier for beds / CL: 張｜张	
-Daily Routine 1	班		Bān   bān	Bān   bān	class	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	
-Daily Routine 1	从	從	Cóng   cóng   zòng	Cóng   cóng   zòng	From	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin	
-Daily Routine 1	睡觉	睡覺	shuì jiào	shuì jiào	go to bed	to go to bed / to sleep	to go to bed / to sleep	
-Daily Routine 1	午饭	午飯	wǔ fàn	wǔ fàn	lunch	lunch / CL: 份, 頓｜顿, 次, 餐	lunch / CL: 份, 頓｜顿, 次, 餐	
-Daily Routine 1	睡		shuì	shuì	sleep	to sleep / to lie down	to sleep / to lie down	
-Daily Routine 1	觉	覺	jiào   jué	jiào   jué	feel	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	
-Daily Routine 1	放学	放學	fàng xué	fàng xué	School	to dismiss students at the end of the school day	to dismiss students at the end of the school day	
-Daily Routine 1	下班		xià bān	xià bān	Commute	to finish work / to get off work	to finish work / to get off work	
-Daily Routine 1	回		huí   huí	huí   huí	Times	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	
-Daily Routine 1	晚饭	晚飯	wǎn fàn	wǎn fàn	dinner	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	
-Daily Routine 1	放		fàng	fàng	put	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	
-Payment	钱	錢	Qián   qián	Qián   qián	money	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两	
-Payment	块	塊	kuài	kuài	Piece	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	
-Payment	只		zhǐ   zhǐ   zhī	zhǐ   zhǐ   zhī	only	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	
-Payment	买	買	mǎi	mǎi	buy	to buy / to purchase	to buy / to purchase	
-Payment	一共		yī gòng	yī gòng	Altogether	altogether	altogether	
-Payment	毛		Máo   máo	Máo   máo	hair	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	
-Payment	共		gòng	gòng	Altogether	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party	
-Payment	信用卡		xìn yòng kǎ	xìn yòng kǎ	credit card	credit card	credit card	
-Payment	收		shōu	shōu	Receive	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)	
-Payment	千		qiān   qiān	qiān   qiān	thousand	thousand  see 鞦韆｜秋千	thousand  see 鞦韆｜秋千	
-Payment	信		xìn	xìn	letter	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	
-Payment	用		yòng	yòng	use	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	
-Payment	卡		kǎ   qiǎ	kǎ   qiǎ	card	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]	
-Payment	贵	貴	guì	guì	expensive	expensive / noble / precious / (honorific) your	expensive / noble / precious / (honorific) your	
-Payment	便宜		biàn yí   pián yi	biàn yí   pián yi	Inexpensive	convenient  cheap / inexpensive / small advantages / to let sb off lightly	convenient  cheap / inexpensive / small advantages / to let sb off lightly	
-Payment	现金	現金	xiàn jīn	xiàn jīn	cash	cash	cash	
-Payment	便		biàn   pián	biàn   pián	Then	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	
-Payment	宜		Yí   yí	Yí   yí	should	surname Yi  proper / should / suitable / appropriate	surname Yi  proper / should / suitable / appropriate	
-Payment	金		Jīn   jīn	Jīn   jīn	gold	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音	
-Payment	太		tài	tài	too	highest / greatest / too (much) / very / extremely	highest / greatest / too (much) / very / extremely	
-Payment	万		Mò   Wàn   wàn	Mò   Wàn   wàn	Ten thousand	see 万俟  surname Wan  ten thousand / a great number	see 万俟  surname Wan  ten thousand / a great number	
-Payment	行		háng   xíng	háng   xíng	Row	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	
-Entertainment	想		xiǎng	xiǎng	miss you	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	
-Entertainment	干	乾	Gān   gān   gān   gàn	Gān   gān   gān   gàn	dry	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	
-Entertainment	影		yǐng	yǐng	Shadow	picture / image / film / movie / photograph / reflection / shadow / trace	picture / image / film / movie / photograph / reflection / shadow / trace	
-Entertainment	视	視	shì	shì	Regard	to look at / to regard / to inspect	to look at / to regard / to inspect	
-Entertainment	电视	電視	diàn shì	diàn shì	TV	television / TV / CL: 臺｜台, 個｜个	television / TV / CL: 臺｜台, 個｜个	
-Entertainment	电影	電影	diàn yǐng	diàn yǐng	the film	movie / film / CL: 部, 片, 幕, 場｜场	movie / film / CL: 部, 片, 幕, 場｜场	
-Entertainment	报纸	報紙	bào zhǐ	bào zhǐ	newspaper	newspaper / newsprint / CL: 份, 期, 張｜张	newspaper / newsprint / CL: 份, 期, 張｜张	
-Entertainment	上网	上網	shàng wǎng	shàng wǎng	Internet	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	
-Entertainment	报	報	bào	bào	Report	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张	
-Entertainment	纸	紙	zhǐ	zhǐ	paper	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	
-Entertainment	网	網	wǎng	wǎng	network	net / network	net / network	
-Entertainment	手机	手機	shǒu jī	shǒu jī	Cellular phone	cell phone / mobile phone / CL: 部, 支	cell phone / mobile phone / CL: 部, 支	
-Entertainment	新闻	新聞	xīn wén	xīn wén	news	news / CL: 條｜条, 個｜个	news / CL: 條｜条, 個｜个	
-Entertainment	机	機	Jī   jī	Jī   jī	machine	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台	
-Entertainment	新		Xīn   xīn	Xīn   xīn	new	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	
-Entertainment	闻	聞	Wén   wén	Wén   wén	smell	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at	
-Entertainment	明星		míng xīng	míng xīng	Celebrity	star / celebrity	star / celebrity	
-Entertainment	体育	體育	tǐ yù	tǐ yù	physical education	sports / physical education	sports / physical education	
-Entertainment	节目	節目	jié mù	jié mù	program	program / item (on a program) / CL: 臺｜台, 個｜个, 套	program / item (on a program) / CL: 臺｜台, 個｜个, 套	
-Entertainment	韩国	韓國	Hán guó	Hán guó	Korea	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	
-Entertainment	体	體	tǐ	tǐ	body	body / form / style / system / substance / to experience / aspect (linguistics)	body / form / style / system / substance / to experience / aspect (linguistics)	
-Entertainment	节	節	jiē   jié	jiē   jié	Festival	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个	
-Entertainment	韩	韓	Hán	Hán	Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han	
-Entertainment	育		yù	yù	Educate	to have children / to raise or bring up / to educate	to have children / to raise or bring up / to educate	
-Entertainment	目		mù	mù	Eye	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title	
-Location 4	桌		zhuō	zhuō	table	table / desk / classifier for tables of guests at a banquet etc	table / desk / classifier for tables of guests at a banquet etc	
-Location 4	找		zhǎo	zhǎo	Find	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	
-Location 4	桌子		zhuō zi	zhuō zi	table	table / desk / CL: 張｜张, 套	table / desk / CL: 張｜张, 套	
-Location 4	椅子		yǐ zi	yǐ zi	chair	chair / CL: 把, 套	chair / CL: 把, 套	
-Location 4	椅		yǐ	yǐ	chair	chair	chair	
-Location 4	房间	房間	fáng jiān	fáng jiān	room	room / CL: 間｜间, 個｜个	room / CL: 間｜间, 個｜个	
-Location 4	冰箱		bīng xiāng	bīng xiāng	refrigerator	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	
-Location 4	外		wài	wài	outer	outside / in addition / foreign / external	outside / in addition / foreign / external	
-Location 4	房		Fáng   fáng	Fáng   fáng	room	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)	
-Location 4	箱		xiāng	xiāng	box	box / trunk / chest	box / trunk / chest	
-Restaurant	位		wèi	wèi	Place	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential	
-Restaurant	等		děng	děng	Wait	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	
-Restaurant	一下		yī xià	yī xià	a bit	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	
-Restaurant	进	進	jìn	jìn	Enter	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	
-Restaurant	坐		Zuò   zuò	Zuò   zuò	sit	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	
-Restaurant	菜单	菜單	cài dān	cài dān	menu	menu / CL: 份, 張｜张	menu / CL: 份, 張｜张	
-Restaurant	英文		Yīng wén	Yīng wén	English	English (language)	English (language)	
-Restaurant	菜		cài	cài	dish	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	
-Restaurant	单	單	Shàn   dān	Shàn   dān	single	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	
-Restaurant	文		Wén   wén	Wén   wén	Culture	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	
-Restaurant	服务员	服務員	fú wù yuán	fú wù yuán	Waiter	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	
-Restaurant	点菜	點菜	diǎn cài	diǎn cài	A la carte	to order dishes (in a restaurant)	to order dishes (in a restaurant)	
-Restaurant	买单	買單	mǎi dān	mǎi dān	Pay	to pay the restaurant bill	to pay the restaurant bill	
-Restaurant	订位	訂位	dìng wèi	dìng wèi	booking	to reserve a seat / to book a table / reservation	to reserve a seat / to book a table / reservation	
-Restaurant	服		fú   fù	fú   fù	clothes	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]	
-Restaurant	务	務	wù	wù	Business	affair / business / matter / to be engaged in / to attend to / by all means	affair / business / matter / to be engaged in / to attend to / by all means	
-Restaurant	员	員	yuán	yuán	member	person / employee / member	person / employee / member	
-Restaurant	订	訂	dìng	dìng	Order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	
-Supermarket	些		xiē	xiē	some	some / few / several / measure word indicating a small amount or small number (greater than 1)	some / few / several / measure word indicating a small amount or small number (greater than 1)	
-Supermarket	西		Xī   xī	Xī   xī	WEAT	the West / abbr. for Spain 西班牙 / Spanish  west	the West / abbr. for Spain 西班牙 / Spanish  west	
-Supermarket	东	東	Dōng   dōng	Dōng   dōng	east	surname Dong  east / host (i.e. sitting on east side of guest) / landlord	surname Dong  east / host (i.e. sitting on east side of guest) / landlord	
-Supermarket	东西	東西	dōng xī   dōng xi	dōng xī   dōng xi	thing	east and west  thing / stuff / person / CL: 個｜个, 件	east and west  thing / stuff / person / CL: 個｜个, 件	
-Supermarket	超市		chāo shì	chāo shì	Supermarket	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	
-Supermarket	水果		shuǐ guǒ	shuǐ guǒ	fruit	fruit / CL: 個｜个	fruit / CL: 個｜个	
-Supermarket	超		chāo	chāo	super	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-	
-Supermarket	市		shì	shì	city	market / city / CL: 個｜个	market / city / CL: 個｜个	
-Supermarket	果		guǒ	guǒ	fruit	fruit / result / resolute / indeed / if really	fruit / result / resolute / indeed / if really	
-Supermarket	给	給	gěi   jǐ	gěi   jǐ	give	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	
-Supermarket	苹果	蘋果	píng guǒ	píng guǒ	apple	apple / CL: 個｜个, 顆｜颗	apple / CL: 個｜个, 顆｜颗	
-Supermarket	西瓜		xī guā	xī guā	watermelon	watermelon / CL: 顆｜颗, 粒, 個｜个	watermelon / CL: 顆｜颗, 粒, 個｜个	
-Supermarket	苹		píng   pín   píng	píng   pín   píng	apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple	
-Supermarket	瓜		guā	guā	melon	melon / gourd / squash	melon / gourd / squash	
-Supermarket	鸡蛋	雞蛋	jī dàn	jī dàn	egg	(chicken) egg / hen's egg / CL: 個｜个, 打	(chicken) egg / hen's egg / CL: 個｜个, 打	
-Supermarket	新鲜	新鮮	xīn xiān	xīn xiān	fresh	fresh (experience, food etc) / freshness / novel / uncommon	fresh (experience, food etc) / freshness / novel / uncommon	
-Supermarket	鸡	雞	jī	jī	Chicken	fowl / chicken / CL: 隻｜只 / (slang) prostitute	fowl / chicken / CL: 隻｜只 / (slang) prostitute	
-Supermarket	蛋		dàn	dàn	egg	egg / CL: 個｜个, 打 / oval-shaped thing	egg / CL: 個｜个, 打 / oval-shaped thing	
-Supermarket	鲜	鮮	xiān   xiǎn   xiān	xiān   xiǎn   xiān	fresh	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜	
-Supermarket	蔬菜		shū cài	shū cài	vegetables	vegetables / produce / CL: 種｜种	vegetables / produce / CL: 種｜种	
-Supermarket	蔬		shū	shū	vegetable	vegetables	vegetables	
-Supermarket	包		Bāo   bāo	Bāo   bāo	package	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只	
-Supermarket	米		Mǐ   mǐ	Mǐ   mǐ	Meter	surname Mi  rice / CL: 粒 / meter (classifier)	surname Mi  rice / CL: 粒 / meter (classifier)	
-Supermarket	面包	麵包	miàn bāo	miàn bāo	bread	bread / CL: 片, 袋, 塊｜块	bread / CL: 片, 袋, 塊｜块	
-Supermarket	袋		dài	dài	bag	pouch / bag / sack / pocket	pouch / bag / sack / pocket	
-Supermarket	糖		táng	táng	sugar	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	
-Hobbies 2	为	為	wéi   wèi	wéi   wèi	for	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	
-Hobbies 2	习	習	Xí   xí	Xí   xí	Study	surname Xi  to practice / to study / habit	surname Xi  to practice / to study / habit	
-Hobbies 2	学习	學習	xué xí	xué xí	Learn	to learn / to study	to learn / to study	
-Hobbies 2	中文		Zhōng wén	Zhōng wén	Chinese	Chinese language	Chinese language	
-Hobbies 2	为什么	為什麼	wèi shén me	wèi shén me	why	why? / for what reason?	why? / for what reason?	
-Hobbies 2	因为	因為	yīn wèi	yīn wèi	because	because / owing to / on account of	because / owing to / on account of	
-Hobbies 2	所以		suǒ yǐ	suǒ yǐ	and so	therefore / as a result / so / the reason why	therefore / as a result / so / the reason why	
-Hobbies 2	西班牙		Xī bān yá	Xī bān yá	Spain	Spain	Spain	
-Hobbies 2	因		yīn	yīn	because	cause / reason / because	cause / reason / because	
-Hobbies 2	所		suǒ	suǒ	The	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个	
-Hobbies 2	以		Yǐ   yǐ	Yǐ   yǐ	With	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)	
-Hobbies 2	牙		yá	yá	tooth	tooth / ivory / CL: 顆｜颗	tooth / ivory / CL: 顆｜颗	
-Hobbies 2	旅游	旅遊	lǚ yóu	lǚ yóu	tourism	trip / journey / tourism / travel / tour / to travel	trip / journey / tourism / travel / tour / to travel	
-Hobbies 2	爱好	愛好	ài hào	ài hào	Hobby	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	
-Hobbies 2	西班牙语	西班牙語	Xī bān yá yǔ	Xī bān yá yǔ	Spanish	Spanish language	Spanish language	
-Hobbies 2	轻松	輕鬆	qīng sōng	qīng sōng	Relaxed	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	
-Hobbies 2	旅		lǚ	lǚ	trip	trip / travel / to travel / brigade (army)	trip / travel / to travel / brigade (army)	
-Hobbies 2	轻	輕	qīng	qīng	light	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	
-Hobbies 2	松		Sōng   sōng   sōng	Sōng   sōng   sōng	loose	surname Song  pine / CL: 棵  loose / to loosen / to relax	surname Song  pine / CL: 棵  loose / to loosen / to relax	
-Hobbies 2	照相机	照相機	zhào xiàng jī	zhào xiàng jī	camera	camera / CL: 個｜个, 架, 部, 台, 隻｜只	camera / CL: 個｜个, 架, 部, 台, 隻｜只	
-Hobbies 2	印度		Yìn dù	Yìn dù	India	India	India	
-Hobbies 2	拍照		pāi zhào	pāi zhào	Photograph	to take a picture	to take a picture	
-Hobbies 2	拍		pāi	pāi	beat	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)	
-Hobbies 2	照		zhào	zhào	Photo	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	
-Hobbies 2	印		Yìn   yìn	Yìn   yìn	Print	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image	
-Hobbies 2	相		Xiāng   xiāng   xiàng	Xiāng   xiāng   xiàng	phase	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	
-Hobbies 2	度		dù   duó	dù   duó	degree	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	
-Dining 1	海		Hǎi   hǎi	Hǎi   hǎi	sea	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous	
-Dining 1	本		běn	běn	this	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	
-Dining 1	还	還	Huán   hái   huán	Huán   hái   huán	also	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	
-Dining 1	上海		Shàng hǎi	Shàng hǎi	Shanghai	Shanghai municipality, central east China, abbr. to 滬｜沪	Shanghai municipality, central east China, abbr. to 滬｜沪	
-Dining 1	还是	還是	hái shi	hái shi	still is	or / still / nevertheless / had better	or / still / nevertheless / had better	
-Dining 1	日本		Rì běn	Rì běn	Japan	Japan / Japanese	Japan / Japanese	
-Dining 1	肉		ròu	ròu	meat	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute	
-Dining 1	米饭	米飯	mǐ fàn	mǐ fàn	rice	(cooked) rice	(cooked) rice	
-Dining 1	面条	麵條	miàn tiáo	miàn tiáo	noodles	noodles	noodles	
-Dining 1	鸡肉	雞肉	jī ròu	jī ròu	chicken	chicken meat	chicken meat	
-Dining 1	牛肉		niú ròu	niú ròu	beef	beef	beef	
-Dining 1	猪肉	豬肉	zhū ròu	zhū ròu	pork	pork	pork	
-Dining 1	羊肉		yáng ròu	yáng ròu	Lamb	mutton / goat meat	mutton / goat meat	
-Dining 1	饮料	飲料	yǐn liào	yǐn liào	Drink	drink / beverage	drink / beverage	
-Dining 1	猪	豬	zhū	zhū	pig	hog / pig / swine / CL: 口, 頭｜头	hog / pig / swine / CL: 口, 頭｜头	
-Dining 1	羊		Yáng   yáng	Yáng   yáng	sheep	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只	
-Dining 1	饮	飲	yǐn   yìn	yǐn   yìn	drink	to drink  to give (animals) water to drink	to drink  to give (animals) water to drink	
-Dining 1	料		liào	liào	Fee	material / stuff / grain / feed / to expect / to anticipate / to guess	material / stuff / grain / feed / to expect / to anticipate / to guess	
-Health 1	作		zuō   zuò	zuō   zuò	Make	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works	
-Health 1	工		gōng	gōng	work	work / worker / skill / profession / trade / craft / labor	work / worker / skill / profession / trade / craft / labor	
-Health 1	累		lěi   lèi   Léi   léi	lěi   lèi   Léi   léi	tired	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	
-Health 1	工作		gōng zuò	gōng zuò	jobs	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	
-Health 1	觉得	覺得	jué de	jué de	feel	to think / to feel	to think / to feel	
-Health 1	有点儿	有點兒	yǒu diǎnr	yǒu diǎnr	kind of	slightly / a little / somewhat	slightly / a little / somewhat	
-Health 1	胖		pán   pàng	pán   pàng	fat	healthy / at ease  fat / plump	healthy / at ease  fat / plump	
-Health 1	健康		jiàn kāng	jiàn kāng	health	health / healthy	health / healthy	
-Health 1	不要		bù yào	bù yào	Do not	don't! / must not	don't! / must not	
-Health 1	健		jiàn	jiàn	Healthy	healthy / to invigorate / to strengthen / to be good at / to be strong in	healthy / to invigorate / to strengthen / to be good at / to be strong in	
-Health 1	康		Kāng   kāng	Kāng   kāng	Kang	surname Kang  healthy / peaceful / abundant	surname Kang  healthy / peaceful / abundant	
-Health 1	身体	身體	shēn tǐ	shēn tǐ	body	the body / one's health / CL: 具, 個｜个 / in person	the body / one's health / CL: 具, 個｜个 / in person	
-Health 1	注意		zhù yì	zhù yì	note	to take note of / to pay attention to	to take note of / to pay attention to	
-Health 1	身		shēn	shēn	body	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158	
-Health 1	注		zhù   zhù	zhù   zhù	Note	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment	
-Health 1	意		Yì   yì	Yì   yì	meaning	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate	
-Health 1	开始	開始	kāi shǐ	kāi shǐ	Start	to begin / beginning / to start / initial / CL: 個｜个	to begin / beginning / to start / initial / CL: 個｜个	
-Health 1	锻炼	鍛鍊	duàn liàn	duàn liàn	work out	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	
-Health 1	开	開	kāi	kāi	open	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	
-Health 1	锻	鍛	duàn	duàn	Wrought	to forge / to discipline / wrought	to forge / to discipline / wrought	
-Health 1	始		shǐ	shǐ	beginning	to begin / to start / then / only then	to begin / to start / then / only then	
-Health 1	炼	煉	liàn	liàn	Refine	to refine / to smelt	to refine / to smelt	
-Transportation	铁	鐵	Tiě   tiě	Tiě   tiě	iron	surname Tie  iron (metal) / arms / weapons / hard / strong / violent / unshakeable / determined / close / tight (slang)	surname Tie  iron (metal) / arms / weapons / hard / strong / violent / unshakeable / determined / close / tight (slang)	
-Transportation	店		diàn	diàn	shop	inn / shop / store / CL: 家	inn / shop / store / CL: 家	
-Transportation	地		de   dì	de   dì	Ground	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	
-Transportation	酒		jiǔ	jiǔ	liqueur	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	
-Transportation	酒店		jiǔ diàn	jiǔ diàn	Hotels	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	
-Transportation	地铁	地鐵	dì tiě	dì tiě	subway	subway / metro	subway / metro	
-Transportation	不准		bù zhǔn	bù zhǔn	Forbid	not to allow / to forbid / to prohibit	not to allow / to forbid / to prohibit	
-Transportation	准		zhǔn   zhǔn	zhǔn   zhǔn	quasi-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	
-Transportation	出租车	出租車	chū zū chē	chū zū chē	taxi	taxi / (Taiwan) rental car	taxi / (Taiwan) rental car	
-Transportation	站		zhàn	zhàn	station	station / to stand / to halt / to stop / branch of a company or organization / website	station / to stand / to halt / to stop / branch of a company or organization / website	
-Transportation	车	車	Chē   chē   jū	Chē   chē   jū	car	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)	
-Transportation	出		chū	chū	Out	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	
-Transportation	租		zū	zū	rent	to hire / to rent / to charter / to rent out / to lease out / rent / land tax	to hire / to rent / to charter / to rent out / to lease out / rent / land tax	
-Transportation	可以		kě yǐ	kě yǐ	can	can / may / possible / able to / not bad / pretty good	can / may / possible / able to / not bad / pretty good	
-Transportation	汽车	汽車	qì chē	qì chē	car	car / automobile / bus / CL: 輛｜辆	car / automobile / bus / CL: 輛｜辆	
-Transportation	公共		gōng gòng	gōng gòng	public	public / common / communal	public / common / communal	
-Transportation	船		chuán	chuán	ferry	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	
-Transportation	公		gōng	gōng	public	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)	
-Transportation	汽		qì	qì	vapor	steam / vapor	steam / vapor	
-Shopping 1	件		jiàn	jiàn	Matter	item / component / classifier for events, things, clothes etc	item / component / classifier for events, things, clothes etc	
-Shopping 1	衣		yī   yì	yī   yì	clothes	clothes / CL: 件  to dress / to wear / to put on (clothes)	clothes / CL: 件  to dress / to wear / to put on (clothes)	
-Shopping 1	商		Shāng   shāng	Shāng   shāng	Business	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)	
-Shopping 1	商店		shāng diàn	shāng diàn	store	store / shop / CL: 家, 個｜个	store / shop / CL: 家, 個｜个	
-Shopping 1	衣服		yī fu	yī fu	clothes	clothes / CL: 件, 套	clothes / CL: 件, 套	
-Shopping 1	门	門	Mén   mén	Mén   mén	door	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	
-Shopping 1	欢迎	歡迎	huān yíng	huān yíng	welcome	to welcome / welcome	to welcome / welcome	
-Shopping 1	迎		yíng	yíng	welcome	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)	
-Shopping 1	您		nín	nín	you	you (courteous, as opposed to informal 你)	you (courteous, as opposed to informal 你)	
-Shopping 1	帮忙	幫忙	bāng máng	bāng máng	help	to help / to lend a hand / to do a favor / to do a good turn	to help / to lend a hand / to do a favor / to do a good turn	
-Shopping 1	需要		xū yào	xū yào	need	to need / to want / to demand / to require / requirement / need	to need / to want / to demand / to require / requirement / need	
-Shopping 1	需		xū	xū	need	to require / to need / to want / necessity / need	to require / to need / to want / necessity / need	
-Shopping 1	随便	隨便	suí biàn	suí biàn	casual	as one wishes / as one pleases / at random / negligent / casual / wanton	as one wishes / as one pleases / at random / negligent / casual / wanton	
-Shopping 1	随	隨	Suí   suí	Suí   suí	Follow	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently	
-Languages	读	讀	dòu   dú	dòu   dú	read	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	
-Languages	意思		yì si	yì si	meaning	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc	
-Languages	写	寫	xiě	xiě	write	to write	to write	
-Languages	难	難	nán   nàn	nán   nàn	difficult	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold	
-Languages	思		sī	sī	think	to think / to consider	to think / to consider	
-Time 3	秒		miǎo	miǎo	second	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	
-Time 3	刻		kè	kè	engraved	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	
-Time 3	差		chā   chà   chāi	chā   chà   chāi	difference	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	
-Time 3	小时	小時	xiǎo shí	xiǎo shí	hour	hour / CL: 個｜个	hour / CL: 個｜个	
-Time 3	分钟	分鐘	fēn zhōng	fēn zhōng	minute	minute	minute	
-Time 3	小		xiǎo	xiǎo	small	small / tiny / few / young	small / tiny / few / young	
-Time 3	时	時	Shí   shí	Shí   shí	Time	surname Shi  o'clock / time / when / hour / season / period	surname Shi  o'clock / time / when / hour / season / period	
-Time 3	钟	鍾	Zhōng   zhōng   zhōng	Zhōng   zhōng   zhōng	bell	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座	
-Time 3	整		zhěng	zhěng	whole	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	
-Dining 2	杯		bēi	bēi	cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup	
-Dining 2	啤		pí	pí	beer	beer	beer	
-Dining 2	德		Dé   dé	Dé   dé	Morality	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind	
-Dining 2	德国	德國	Dé guó	Dé guó	Germany	Germany / German	Germany / German	
-Dining 2	啤酒		pí jiǔ	pí jiǔ	beer	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	
-Dining 2	果汁		guǒ zhī	guǒ zhī	fruit juice	fruit juice	fruit juice	
-Dining 2	汁		zhī	zhī	juice	juice	juice	
-Dining 2	香蕉		xiāng jiāo	xiāng jiāo	banana	banana / CL: 枝, 根, 個｜个, 把	banana / CL: 枝, 根, 個｜个, 把	
-Dining 2	蛋糕		dàn gāo	dàn gāo	cake	cake / CL: 塊｜块, 個｜个	cake / CL: 塊｜块, 個｜个	
-Dining 2	蕉		jiāo   qiáo	jiāo   qiáo	banana	banana  see 蕉萃	banana  see 蕉萃	
-Dining 2	糕		gāo	gāo	cake	cake	cake	
-Dining 2	碗		wǎn	wǎn	bowl	bowl / cup / CL: 隻｜只, 個｜个	bowl / cup / CL: 隻｜只, 個｜个	
-Dining 2	杯子		bēi zi	bēi zi	cup	cup / glass / CL: 個｜个, 隻｜只	cup / glass / CL: 個｜个, 隻｜只	
-Dining 2	盘子	盤子	pán zi	pán zi	plate	tray / plate / dish / CL: 個｜个	tray / plate / dish / CL: 個｜个	
-Dining 2	盘	盤	pán	pán	plate	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess	
-Dining 2	筷子		kuài zi	kuài zi	chopsticks	chopsticks / CL: 對｜对, 根, 把, 雙｜双	chopsticks / CL: 對｜对, 根, 把, 雙｜双	
-Dining 2	刀		Dāo   dāo	Dāo   dāo	Knife	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	
-Dining 2	叉		chā   chá   chǎ	chā   chá   chǎ	cross	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	
-Dining 2	筷		kuài	kuài	chopsticks	chopstick	chopstick	
-Dining 2	勺子		sháo zi	sháo zi	Spoon	scoop / ladle / CL: 把	scoop / ladle / CL: 把	
-Dining 2	勺		sháo	sháo	Spoon	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)	
-Existence	室		Shì   shì	Shì   shì	room	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	
-Existence	办	辦	bàn	bàn	do	to do / to manage / to handle / to go about / to run / to set up / to deal with	to do / to manage / to handle / to go about / to run / to set up / to deal with	
-Existence	辆	輛	liàng	liàng	Vehicles	classifier for vehicles	classifier for vehicles	
-Existence	办公室	辦公室	bàn gōng shì	bàn gōng shì	office	office / business premises / bureau / CL: 間｜间	office / business premises / bureau / CL: 間｜间	
-Existence	瓶子		píng zi	píng zi	bottle	bottle / CL: 個｜个	bottle / CL: 個｜个	
-Existence	照片		zhào piàn	zhào piàn	photo	photograph / picture / CL: 張｜张, 套, 幅	photograph / picture / CL: 張｜张, 套, 幅	
-Existence	瓶		píng	píng	bottle	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	
-Existence	片		piān   piàn	piān   piàn	sheet	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc	
-Existence	鸟	鳥	niǎo	niǎo	bird	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam	
-Existence	树	樹	shù	shù	tree	tree / CL: 棵 / to cultivate / to set up	tree / CL: 棵 / to cultivate / to set up	
-Sports 1	步		Bù   bù	Bù   bù	step	surname Bu  a step / a pace / walk / march / stages in a process / situation	surname Bu  a step / a pace / walk / march / stages in a process / situation	
-Sports 1	跑		páo   pǎo	páo   pǎo	run	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off	
-Sports 1	泳		yǒng	yǒng	swimming	swimming / to swim	swimming / to swim	
-Sports 1	游泳		yóu yǒng	yóu yǒng	Swim	swimming / to swim	swimming / to swim	
-Sports 1	跑步		pǎo bù	pǎo bù	Run	to run / to jog / (military) to march at the double	to run / to jog / (military) to march at the double	
-Sports 1	踢		tī	tī	kick	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	
-Sports 1	足球		zú qiú	zú qiú	football	soccer ball / a football / CL: 個｜个 / soccer / football	soccer ball / a football / CL: 個｜个 / soccer / football	
-Sports 1	打		dá   dǎ	dá   dǎ	hit	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from	
-Sports 1	篮球	籃球	lán qiú	lán qiú	basketball	basketball / CL: 個｜个, 隻｜只	basketball / CL: 個｜个, 隻｜只	
-Sports 1	足		jù   zú	jù   zú	leg	excessive  foot / to be sufficient / ample	excessive  foot / to be sufficient / ample	
-Sports 1	篮	籃	lán	lán	basket	basket (receptacle) / basket (in basketball)	basket (receptacle) / basket (in basketball)	
-Sports 1	球		qiú	qiú	ball	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场	
-Sports 1	运动	運動	yùn dòng	yùn dòng	motion	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	
-Sports 1	马	馬	Mǎ   mǎ	Mǎ   mǎ	horse	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess	
-Sports 1	骑	騎	jì   qí	jì   qí	ride	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	
-Sports 1	运	運	yùn	yùn	Transport	to move / to transport / to use / to apply / fortune / luck / fate	to move / to transport / to use / to apply / fortune / luck / fate	
-Sports 1	动	動	dòng	dòng	move	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb	
-Invitiation 1	吧		bā   ba	bā   ba	It	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	
-Invitiation 1	出去		chū qù	chū qù	Out	to go out	to go out	
-Invitiation 1	时间	時間	shí jiān	shí jiān	time	time / period / CL: 段	time / period / CL: 段	
-Invitiation 1	时候	時候	shí hou	shí hou	time	time / length of time / moment / period	time / length of time / moment / period	
-Invitiation 1	空		kōng   kòng	kōng   kòng	air	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	
-Invitiation 1	来	來	lái	lái	Come	to come / to arrive / to come round / ever since / next	to come / to arrive / to come round / ever since / next	
-Invitiation 1	候		hòu	hòu	Wait	to wait / to inquire after / to watch / season / climate / (old) period of five days	to wait / to inquire after / to watch / season / climate / (old) period of five days	
-Invitiation 1	过	過	Guò   guò   guo	Guò   guò   guo	Live	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	
-Invitiation 1	一起		yī qǐ	yī qǐ	together	in the same place / together / with / altogether (in total)	in the same place / together / with / altogether (in total)	
-Invitiation 1	不好意思		bù hǎo yì si	bù hǎo yì si	Feel embarrassed	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	
-Invitiation 1	告诉	告訴	gào sù   gào su	gào sù   gào su	tell	to press charges / to file a complaint  to tell / to inform / to let know	to press charges / to file a complaint  to tell / to inform / to let know	
-Invitiation 1	告		gào	gào	Tell	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue	
-Invitiation 1	诉	訴	sù	sù	Complaint	to complain / to sue / to tell	to complain / to sue / to tell	
-Invitiation 1	约会	約會	yuē huì	yuē huì	appointment	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	
-Invitiation 1	浪漫		làng màn	làng màn	romantic	romantic	romantic	
-Invitiation 1	浪		làng	làng	wave	wave / breaker / unrestrained / dissipated	wave / breaker / unrestrained / dissipated	
-Invitiation 1	漫		màn	màn	Overflow	free / unrestrained / to inundate	free / unrestrained / to inundate	
-Health 2	该	該	gāi	gāi	That	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned	
-Health 2	病		bìng	bìng	disease	illness / CL: 場｜场 / disease / to fall ill / defect	illness / CL: 場｜场 / disease / to fall ill / defect	
-Health 2	舒		Shū   shū	Shū   shū	Shu	surname Shu  to stretch / to unfold / to relax / leisurely	surname Shu  to stretch / to unfold / to relax / leisurely	
-Health 2	应	應	Yìng   yīng   yìng	Yìng   yīng   yìng	should	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	
-Health 2	生病		shēng bìng	shēng bìng	sick	to fall ill	to fall ill	
-Health 2	应该	應該	yīng gāi	yīng gāi	should	ought to / should / must	ought to / should / must	
-Health 2	舒服		shū fu	shū fu	Comfortably	comfortable / feeling well	comfortable / feeling well	
-Health 2	疼		téng	téng	pain	(it) hurts / sore / to love dearly	(it) hurts / sore / to love dearly	
-Health 2	头	頭	tóu   tou	tóu   tou	head	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns	
-Health 2	休息		xiū xi	xiū xi	rest	rest / to rest	rest / to rest	
-Health 2	休		Xiū   xiū	Xiū   xiū	Rest	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't	
-Health 2	息		xī	xī	interest	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]	
-Health 2	肚子		dù zi	dù zi	belly	belly / abdomen / stomach / CL: 個｜个	belly / abdomen / stomach / CL: 個｜个	
-Health 2	肚		dǔ   dù	dǔ   dù	tripe	tripe  belly	tripe  belly	
-Health 2	药	葯	yào   yào	yào   yào	medicine	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	
-Health 2	一定		yī dìng	yī dìng	for sure	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	
-Health 2	感冒		gǎn mào	gǎn mào	cold	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	
-Health 2	感		gǎn	gǎn	sense	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~	
-Health 2	定		dìng	dìng	set	to set / to fix / to determine / to decide / to order	to set / to fix / to determine / to decide / to order	
-Health 2	冒		Mào   mào	Mào   mào	Risk	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover	
-Health 2	留		liú	liú	stay	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve	
-Health 2	请假	請假	qǐng jià	qǐng jià	Ask for leave	to request leave of absence	to request leave of absence	
-Health 2	发烧	發燒	fā shāo	fā shāo	fever	to have a high temperature (from illness) / to have a fever	to have a high temperature (from illness) / to have a fever	
-Health 2	别	別	Bié   bié   biè	Bié   bié   biè	do not	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc	
-Health 2	发	發	fā   fà	fā   fà	hair	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	
-Health 2	假		jiǎ   jià	jiǎ   jià	false	fake / false / artificial / to borrow / if / suppose  vacation	fake / false / artificial / to borrow / if / suppose  vacation	
-Health 2	烧	燒	shāo	shāo	burn	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head	
-Invitation 2	派		pài	pài	send	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie	
-Invitation 2	能		Néng   néng	Néng   néng	can	surname Neng  can / to be able to / might possibly / ability / (physics) energy	surname Neng  can / to be able to / might possibly / ability / (physics) energy	
-Invitation 2	生日		shēng rì	shēng rì	birthday	birthday / CL: 個｜个	birthday / CL: 個｜个	
-Invitation 2	派对	派對	pài duì	pài duì	Party	party (loanword)	party (loanword)	
-Invitation 2	打扮		dǎ ban	dǎ ban	dress up	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	
-Invitation 2	扮		bàn	bàn	Play	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)	
-Invitation 2	希望		xī wàng	xī wàng	hope	to wish for / to desire / hope / CL: 個｜个	to wish for / to desire / hope / CL: 個｜个	
-Invitation 2	跟		gēn	gēn	with	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	
-Invitation 2	希		xī	xī	hope	to hope / to admire / variant of 稀	to hope / to admire / variant of 稀	
-Invitation 2	望		wàng   wàng	wàng   wàng	hope	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望	
-Invitation 2	大家		dà jiā	dà jiā	everyone	everyone / influential family / great expert	everyone / influential family / great expert	
-Invitation 2	公司		gōng sī	gōng sī	the company	(business) company / company / firm / corporation / incorporated / CL: 家	(business) company / company / firm / corporation / incorporated / CL: 家	
-Invitation 2	正在		zhèng zài	zhèng zài	Seizai	just at (that time) / right in (that place) / right in the middle of (doing sth)	just at (that time) / right in (that place) / right in the middle of (doing sth)	
-Invitation 2	正		zhēng   zhèng	zhēng   zhèng	positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive	
-Invitation 2	司		Sī   sī	Sī   sī	Department	surname Si  to take charge of / to manage / department (under a ministry)	surname Si  to take charge of / to manage / department (under a ministry)	
-Invitation 2	事情		shì qing	shì qing	thing	affair / matter / thing / business / CL: 件, 樁｜桩	affair / matter / thing / business / CL: 件, 樁｜桩	
-Invitation 2	才		cái   cái	cái   cái	only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only	
-Invitation 2	事		shì	shì	Thing	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	
-Invitation 2	情		qíng	qíng	situation	feeling / emotion / passion / situation	feeling / emotion / passion / situation	
-Dining 3	费	費	Fèi   fèi	Fèi   fèi	fee	surname Fei  to cost / to spend / fee / wasteful / expenses	surname Fei  to cost / to spend / fee / wasteful / expenses	
-Dining 3	完		wán	wán	Finish	to finish / to be over / whole / complete / entire	to finish / to be over / whole / complete / entire	
-Dining 3	经	經	Jīng   jīng	Jīng   jīng	through	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	
-Dining 3	已		yǐ	yǐ	Already	already / to stop / then / afterwards	already / to stop / then / afterwards	
-Dining 3	已经	已經	yǐ jīng	yǐ jīng	already	already	already	
-Dining 3	小费	小費	xiǎo fèi	xiǎo fèi	tip	tip / gratuity	tip / gratuity	
-Dining 3	饱	飽	bǎo	bǎo	full	to eat till full / satisfied	to eat till full / satisfied	
-Dining 3	好吃		hǎo chī   hào chī	hǎo chī   hào chī	good to eat	tasty / delicious  to be fond of eating / to be gluttonous	tasty / delicious  to be fond of eating / to be gluttonous	
-Dining 3	真		zhēn	zhēn	true	really / truly / indeed / real / true / genuine	really / truly / indeed / real / true / genuine	
-Dining 3	饿	餓	è	è	hungry	to be hungry / hungry / to starve (sb)	to be hungry / hungry / to starve (sb)	
-Dining 3	好喝		hǎo hē	hǎo hē	Tasty	tasty (drinks)	tasty (drinks)	
-Dining 3	渴		kě	kě	thirsty	thirsty	thirsty	
-Dining 3	巧克力		qiǎo kè lì	qiǎo kè lì	chocolate	chocolate (loanword) / CL: 塊｜块	chocolate (loanword) / CL: 塊｜块	
-Dining 3	味道		wèi dao	wèi dao	taste	flavor / smell / hint of	flavor / smell / hint of	
-Dining 3	甜点	甜點	tián diǎn	tián diǎn	dessert	dessert	dessert	
-Dining 3	甜		tián	tián	sweet	sweet	sweet	
-Dining 3	巧		qiǎo	qiǎo	Opportunely	opportunely / coincidentally / as it happens / skillful / timely	opportunely / coincidentally / as it happens / skillful / timely	
-Dining 3	克		kè   Kè   kēi	kè   Kè   kēi	Gram	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat	
-Dining 3	力		Lì   lì	Lì   lì	force	surname Li  power / force / strength / ability / strenuously	surname Li  power / force / strength / ability / strenuously	
-Shopping 2	试	試	shì	shì	test	to test / to try / experiment / examination / test	to test / to try / experiment / examination / test	
-Shopping 2	蓝	藍	Lán   lán	Lán   lán	blue	surname Lan  blue / indigo plant	surname Lan  blue / indigo plant	
-Shopping 2	条	條	tiáo	tiáo	article	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)	
-Shopping 2	裙		qún	qún	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条	
-Shopping 2	裙子		qún zi	qún zi	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条	
-Shopping 2	双	雙	Shuāng   shuāng	Shuāng   shuāng	double	surname Shuang  two / double / pair / both / even (number)	surname Shuang  two / double / pair / both / even (number)	
-Shopping 2	鞋子		xié zi	xié zi	Shoe	shoe	shoe	
-Shopping 2	意大利		Yì dà lì	Yì dà lì	Italy	Italy / Italian	Italy / Italian	
-Shopping 2	色		sè   shǎi	sè   shǎi	color	color / CL: 種｜种 / look / appearance / sex  color / dice	color / CL: 種｜种 / look / appearance / sex  color / dice	
-Shopping 2	鞋		xié	xié	shoe	shoe / CL: 雙｜双, 隻｜只	shoe / CL: 雙｜双, 隻｜只	
-Shopping 2	利		Lì   lì	Lì   lì	Profit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	
-Shopping 2	比		Bǐ   bǐ   bì	Bǐ   bǐ   bì	ratio	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near	
-Shopping 2	衬衫	襯衫	chèn shān	chèn shān	shirt	shirt / blouse / CL: 件	shirt / blouse / CL: 件	
-Shopping 2	衬	襯	chèn	chèn	lining	(of garments) against the skin / to line / lining / to contrast with / to assist financially	(of garments) against the skin / to line / lining / to contrast with / to assist financially	
-Shopping 2	衫		shān	shān	Shirt	garment / jacket with open slits in place of sleeves	garment / jacket with open slits in place of sleeves	
-Shopping 2	裤子	褲子	kù zi	kù zi	pants	trousers / pants / CL: 條｜条	trousers / pants / CL: 條｜条	
-Shopping 2	好看		hǎo kàn	hǎo kàn	good looking	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	
-Shopping 2	裤	褲	kù	kù	pants	underpants / trousers / pants	underpants / trousers / pants	
-Shopping 2	质	質	zhì	zhì	quality	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]	
-Shopping 2	量		liáng   liàng	liáng   liàng	the amount	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word	
-Shopping 2	质量	質量	zhì liàng	zhì liàng	quality	quality / (physics) mass / CL: 個｜个	quality / (physics) mass / CL: 個｜个	
-Body Parts	朵		duǒ	duǒ	Flowers	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc	
-Body Parts	睛		jīng	jīng	eye	eye / eyeball	eye / eyeball	
-Body Parts	绿	綠	lǜ	lǜ	green	green	green	
-Body Parts	耳		ěr	ěr	ear	ear / handle (archaeology) / and that is all (classical Chinese)	ear / handle (archaeology) / and that is all (classical Chinese)	
-Body Parts	眼		yǎn	yǎn	eye	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)	
-Body Parts	耳朵		ěr duo	ěr duo	ear	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	
-Body Parts	眼睛		yǎn jing	yǎn jing	eye	eye / CL: 隻｜只, 雙｜双	eye / CL: 隻｜只, 雙｜双	
-Body Parts	头发	頭髮	tóu fa	tóu fa	hair	hair (on the head)	hair (on the head)	
-Body Parts	脸	臉	liǎn	liǎn	face	face / CL: 張｜张, 個｜个	face / CL: 張｜张, 個｜个	
-Body Parts	又		yòu	yòu	also	(once) again / also / both... and... / and yet / (used for emphasis) anyway	(once) again / also / both... and... / and yet / (used for emphasis) anyway	
-Body Parts	黑		Hēi   hēi	Hēi   hēi	black	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)	
-Body Parts	嘴巴		zuǐ ba	zuǐ ba	mouth	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	
-Body Parts	鼻子		bí zi	bí zi	nose	nose / CL: 個｜个, 隻｜只	nose / CL: 個｜个, 隻｜只	
-Body Parts	脚	腳	jiǎo	jiǎo	foot	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	
-Body Parts	嘴		zuǐ	zuǐ	mouth	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个	
-Body Parts	鼻		bí	bí	nose	nose	nose	
-Body Parts	巴		Bā   bā	Bā   bā	-bar	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail	
-Travel	远	遠	yuǎn   yuàn	yuǎn   yuàn	far	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	
-Travel	离		chī   Lí   lí	chī   Lí   lí	from	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲	
-Travel	走路		zǒu lù	zǒu lù	walk	to walk / to go on foot	to walk / to go on foot	
-Travel	开车	開車	kāi chē	kāi chē	Drive a car	to drive a car	to drive a car	
-Travel	飞机	飛機	fēi jī	fēi jī	aircraft	airplane / CL: 架	airplane / CL: 架	
-Travel	机场	機場	jī chǎng	jī chǎng	airport	airport / airfield / CL: 家, 處｜处	airport / airfield / CL: 家, 處｜处	
-Travel	飞	飛	fēi	fēi	fly	to fly	to fly	
-Travel	场	場	cháng   chǎng	cháng   chǎng	field	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams	
-Travel	靠		kào	kào	by	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	
-Travel	停		tíng	tíng	stop	to stop / to halt / to park (a car)	to stop / to halt / to park (a car)	
-Travel	火车	火車	huǒ chē	huǒ chē	train	train / CL: 列, 節｜节, 班, 趟	train / CL: 列, 節｜节, 班, 趟	
-Travel	票		piào	piào	ticket	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions	
-Travel	机票	機票	jī piào	jī piào	Air tickets	air ticket / passenger ticket / CL: 張｜张	air ticket / passenger ticket / CL: 張｜张	
-Travel	火		Huǒ   huǒ	Huǒ   huǒ	fire	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)	
-Travel	迟到	遲到	chí dào	chí dào	be late	to arrive late	to arrive late	
-Travel	让	讓	ràng	ràng	Let	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	
-Travel	怎么办	怎麼辦	zěn me bàn	zěn me bàn	How to do	what's to be done	what's to be done	
-Travel	迟	遲	Chí   chí	Chí   chí	late	surname Chi  late / delayed / slow	surname Chi  late / delayed / slow	
-Weather	冷		Lěng   lěng	Lěng   lěng	cold	surname Leng  cold	surname Leng  cold	
-Weather	晴		qíng	qíng	clear	clear / fine (weather)	clear / fine (weather)	
-Weather	天气	天氣	tiān qì	tiān qì	the weather	weather	weather	
-Weather	雨		yǔ   yù	yǔ   yù	rain	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	
-Weather	雪		Xuě   xuě	Xuě   xuě	snow	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	
-Weather	阴	陰	Yīn   yīn	Yīn   yīn	Yin	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	
-Weather	着	著	zhāo   zháo   zhe   zhuó	zhāo   zháo   zhe   zhuó	The	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	
-Weather	伞	傘	sǎn   sǎn	sǎn   sǎn	umbrella	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	
-Weather	带	帶	dài	dài	band	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	
-Weather	外面		wài miàn	wài miàn	outside	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	
-Weather	可能		kě néng	kě néng	may	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	
-Weather	刮		guā   guā	guā   guā	scratch	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	
-Weather	风	風	fēng	fēng	wind	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝	
-Weather	如果		rú guǒ	rú guǒ	in case	if / in case / in the event that	if / in case / in the event that	
-Weather	就		jiù	jiù	on	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	
-Weather	从来	從來	cóng lái	cóng lái	Never	always / at all times / never (if used in negative sentence)	always / at all times / never (if used in negative sentence)	
-Weather	如		rú	rú	Such as	as / as if / such as	as / as if / such as	
-Weather	里面	裡面	lǐ miàn	lǐ miàn	inside	inside / interior / also pr. [li3 mian5]	inside / interior / also pr. [li3 mian5]	
-Shopping 3	然		rán	rán	However	correct / right / so / thus / like this / -ly	correct / right / so / thus / like this / -ly	
-Shopping 3	但		dàn	dàn	but	but / yet / however / only / merely / still	but / yet / however / only / merely / still	
-Shopping 3	虽	雖	suī	suī	although	although / even though	although / even though	
-Shopping 3	短		duǎn	duǎn	short	short / brief / to lack / weak point / fault	short / brief / to lack / weak point / fault	
-Shopping 3	长	長	cháng   zhǎng	cháng   zhǎng	long	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	
-Shopping 3	虽然	雖然	suī rán	suī rán	although	although / even though / even if	although / even though / even if	
-Shopping 3	但是		dàn shì	dàn shì	but	but / however	but / however	
-Shopping 3	红	紅	Hóng   hóng	Hóng   hóng	red	surname Hong  red / popular / revolutionary / bonus	surname Hong  red / popular / revolutionary / bonus	
-Shopping 3	颜色	顏色	yán sè	yán sè	colour	color / countenance / appearance / facial expression / pigment / dyestuff	color / countenance / appearance / facial expression / pigment / dyestuff	
-Shopping 3	穿		chuān	chuān	wear	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	
-Shopping 3	颜	顏	Yán   yán	Yán   yán	Color	surname Yan  color / face / countenance	surname Yan  color / face / countenance	
-Shopping 3	黄	黃	Huáng   huáng	Huáng   huáng	yellow	surname Huang or Hwang  yellow / pornographic / to fall through	surname Huang or Hwang  yellow / pornographic / to fall through	
-Shopping 3	手表	手錶	shǒu biǎo	shǒu biǎo	Watch	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	
-Shopping 3	卖	賣	mài	mài	Sell	to sell / to betray / to spare no effort / to show off or flaunt	to sell / to betray / to spare no effort / to show off or flaunt	
-Shopping 3	帽子		mào zi	mào zi	hat	hat / cap / (fig.) label / bad name / CL: 頂｜顶	hat / cap / (fig.) label / bad name / CL: 頂｜顶	
-Shopping 3	帽		mào	mào	cap	hat / cap	hat / cap	
-Shopping 3	表		biǎo   biǎo	biǎo   biǎo	table	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch	
-Shopping 3	紫		zǐ	zǐ	purple	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	
-People 2	绍	紹	Shào   shào	Shào   shào	Introduce	surname Shao  to continue / to carry on	surname Shao  to continue / to carry on	
-People 2	介		jiè	jiè	Introduction	to introduce / to lie between / between / shell / armor	to introduce / to lie between / between / shell / armor	
-People 2	介绍	介紹	jiè shào	jiè shào	Introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	
-People 2	帅	帥	Shuài   shuài	Shuài   shuài	Shuai	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!	
-People 2	笑		xiào	xiào	Lol	laugh / smile / CL: 個｜个	laugh / smile / CL: 個｜个	
-People 2	说话	說話	shuō huà	shuō huà	speak	to speak / to say / to talk / to gossip / to tell stories / talk / word	to speak / to say / to talk / to gossip / to tell stories / talk / word	
-People 2	聪明	聰明	cōng ming	cōng ming	clever	intelligent / clever / bright / smart / acute (of sight and hearing)	intelligent / clever / bright / smart / acute (of sight and hearing)	
-People 2	别人	別人	bié ren	bié ren	other people	other people / others / other person	other people / others / other person	
-People 2	不但		bù dàn	bù dàn	Not only	not only (... but also...)	not only (... but also...)	
-People 2	而且		ér qiě	ér qiě	and	(not only ...) but also / moreover / in addition / furthermore	(not only ...) but also / moreover / in addition / furthermore	
-People 2	聪	聰	cōng	cōng	Clever	quick at hearing / wise / clever / sharp-witted / intelligent / acute	quick at hearing / wise / clever / sharp-witted / intelligent / acute	
-People 2	而		ér	ér	and	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)	
-People 2	且		qiě	qiě	And	and / moreover / yet / for the time being / to be about to / both (... and...)	and / moreover / yet / for the time being / to be about to / both (... and...)	
-Celebration	春		Chūn   chūn	Chūn   chūn	spring	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	
-Celebration	快乐	快樂	kuài lè	kuài lè	happy	happy / merry	happy / merry	
-Celebration	节日	節日	jié rì	jié rì	festival	holiday / festival / CL: 個｜个	holiday / festival / CL: 個｜个	
-Celebration	春节	春節	Chūn jié	Chūn jié	Spring Festival	Spring Festival (Chinese New Year)	Spring Festival (Chinese New Year)	
-Celebration	礼物	禮物	lǐ wù	lǐ wù	gift	gift / present / CL: 件, 個｜个, 份	gift / present / CL: 件, 個｜个, 份	
-Celebration	送		sòng	sòng	give away	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	
-Celebration	新年		xīn nián	xīn nián	new Year	New Year / CL: 個｜个	New Year / CL: 個｜个	
-Celebration	白酒		bái jiǔ	bái jiǔ	Spirit	baijiu, a spirit usually distilled from sorghum	baijiu, a spirit usually distilled from sorghum	
-Celebration	礼	禮	Lǐ   lǐ	Lǐ   lǐ	ceremony	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy	
-Celebration	物		wù	wù	object	thing / object / matter / abbr. for physics 物理	thing / object / matter / abbr. for physics 物理	
-Celebration	干杯	乾杯	gān bēi	gān bēi	Cheers	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	
-Celebration	祝		Zhù   zhù	Zhù   zhù	wish	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	
-Celebration	法国	法國	Fǎ guó	Fǎ guó	France	France / French	France / French	
-Celebration	红酒		hóng jiǔ	hóng jiǔ	Red wine	Red wine	Red wine	
-Celebration	法		Fǎ   fǎ	Fǎ   fǎ	law	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	
-Sports 2	赛	賽	sài	sài	Competition	to compete / competition / match / to surpass / better than / superior to / to excel	to compete / competition / match / to surpass / better than / superior to / to excel	
-Sports 2	练	練	liàn	liàn	practice	to practice / to train / to drill / to perfect (one's skill) / exercise	to practice / to train / to drill / to perfect (one's skill) / exercise	
-Sports 2	练习	練習	liàn xí	liàn xí	Exercise	to practice / exercise / drill / practice / CL: 個｜个	to practice / exercise / drill / practice / CL: 個｜个	
-Sports 2	比赛	比賽	bǐ sài	bǐ sài	game	competition (sports etc) / match / CL: 場｜场, 次 / to compete	competition (sports etc) / match / CL: 場｜场, 次 / to compete	
-Sports 2	好在		hǎo zài	hǎo zài	Fortunately	luckily / fortunately	luckily / fortunately	
-Sports 2	乒乓球		pīng pāng qiú	pīng pāng qiú	pingpong	table tennis / ping-pong / table tennis ball / CL: 個｜个	table tennis / ping-pong / table tennis ball / CL: 個｜个	
-Sports 2	乒		pīng	pīng	Table tennis	(onom.) ping / bing	(onom.) ping / bing	
-Sports 2	乓		pāng	pāng	Bang	(onom.) bang	(onom.) bang	
-Sports 2	参加	參加	cān jiā	cān jiā	participate	to participate / to take part / to join	to participate / to take part / to join	
-Sports 2	第		dì	dì	The first	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	
-Sports 2	参	參	cān   shēn	cān   shēn	Ginseng	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations	
-Sports 2	网球	網球	wǎng qiú	wǎng qiú	tennis	tennis / tennis ball / CL: 個｜个	tennis / tennis ball / CL: 個｜个	
-Sports 2	排球		pái qiú	pái qiú	volleyball	volleyball / CL: 個｜个	volleyball / CL: 個｜个	
-Sports 2	加油		jiā yóu	jiā yóu	Refuel	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	
-Sports 2	排		pái	pái	row	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	
-Sports 2	油		yóu	yóu	oil	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	
-Sports 2	输	輸	shū	shū	lose	to lose / to transport / to donate / to enter (a password)	to lose / to transport / to donate / to enter (a password)	
-Sports 2	赢	贏	yíng	yíng	win	to beat / to win / to profit	to beat / to win / to profit	
-Sports 2	失望		shī wàng	shī wàng	Disappointed	disappointed / to lose hope / to despair	disappointed / to lose hope / to despair	
-Sports 2	信心		xìn xīn	xìn xīn	confidence	confidence / faith (in sb or sth) / CL: 個｜个	confidence / faith (in sb or sth) / CL: 個｜个	
-Sports 2	失		shī	shī	Lose	to lose / to miss / to fail	to lose / to miss / to fail	
-Sports 2	心		xīn	xīn	heart	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个	
-School	同	仝	tóng   tóng   tòng	tóng   tóng   tòng	with	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同	
-School	课	課	kè	kè	class	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination	
-School	教		Jiào   jiāo   jiào	Jiào   jiāo   jiào	teach	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	
-School	教室		jiào shì	jiào shì	Classroom	classroom / CL: 間｜间	classroom / CL: 間｜间	
-School	同学	同學	tóng xué	tóng xué	Classmate	to study at the same school / fellow student / classmate / CL: 位, 個｜个	to study at the same school / fellow student / classmate / CL: 位, 個｜个	
-School	地理		dì lǐ	dì lǐ	Geography	geography	geography	
-School	理		lǐ	lǐ	Reason	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up	
-School	懂		dǒng	dǒng	understand	to understand / to comprehend	to understand / to comprehend	
-School	问题	問題	wèn tí	wèn tí	problem	question / problem / issue / topic / CL: 個｜个	question / problem / issue / topic / CL: 個｜个	
-School	笔	筆	bǐ	bǐ	pen	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝	
-School	题	題	Tí   tí	Tí   tí	question	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道	
-School	美术	美術	měi shù	měi shù	art	art / fine arts / painting / CL: 種｜种	art / fine arts / painting / CL: 種｜种	
-School	术	術	shù   zhú	shù   zhú	Technique	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea	
-School	考试	考試	kǎo shì	kǎo shì	examination	to take an exam / exam / CL: 次	to take an exam / exam / CL: 次	
-School	准备	準備	zhǔn bèi	zhǔn bèi	ready	preparation / to prepare / to intend / to be about to / reserve (fund)	preparation / to prepare / to intend / to be about to / reserve (fund)	
-School	考	攷	kǎo   kǎo	kǎo   kǎo	test	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	
-School	备	備	bèi	bèi	Equipment	to prepare / get ready / to provide or equip	to prepare / get ready / to provide or equip	
-School	科学	科學	kē xué	kē xué	science	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	
-School	科		kē	kē	Family	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个	
-School	下课	下課	xià kè	xià kè	Finish class	to finish class / to get out of class	to finish class / to get out of class	
-Family 3	爷爷	爺爺	yé ye	yé ye	grandfather	(coll.) father's father / paternal grandfather / CL: 個｜个	(coll.) father's father / paternal grandfather / CL: 個｜个	
-Family 3	奶奶		nǎi nai	nǎi nai	grandmother	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	
-Family 3	阿姨		ā yí	ā yí	Auntie	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	
-Family 3	爷	爺	yé	yé	Father	grandpa / old gentleman	grandpa / old gentleman	
-Family 3	阿		Ā   ā   ē	Ā   ā   ē	A	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter	
-Family 3	姨		yí	yí	aunt	mother's sister / aunt	mother's sister / aunt	
-Family 3	兄弟姐妹		xiōng dì jiě mèi	xiōng dì jiě mèi	brothers and sisters	Brothers and Sisters	Brothers and Sisters	
-Family 3	关系	關係	guān xi	guān xi	relationship	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个	
-Family 3	叔叔		shū shu	shū shu	uncle	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	
-Family 3	父母		fù mǔ	fù mǔ	parents	father and mother / parents	father and mother / parents	
-Family 3	兄		xiōng	xiōng	Brother	elder brother	elder brother	
-Family 3	叔		shū	shū	uncle	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]	
-Family 3	父		fù	fù	father	father	father	
-Family 3	母		mǔ	mǔ	mother	mother / elderly female relative / origin / source / (of animals) female	mother / elderly female relative / origin / source / (of animals) female	
-Family 3	像		xiàng	xiàng	image	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	
-Family 3	一样	一樣	yī yàng	yī yàng	same	same / like / equal to / the same as / just like	same / like / equal to / the same as / just like	
-Family 3	亲戚	親戚	qīn qi	qīn qi	relative	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	
-Family 3	戚		Qī   qī	Qī   qī	Qi	surname Qi  relative / parent / grief / sorrow / battle-axe	surname Qi  relative / parent / grief / sorrow / battle-axe	
-Family 3	亲	親	qīn   qìng	qīn   qìng	Dear	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring	
-Gourmet 1	拉面	拉麵	lā miàn	lā miàn	Hand-Pulled Noodle	pulled noodles / ramen	pulled noodles / ramen	
-Gourmet 1	点心	點心	diǎn xin	diǎn xin	dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	
-Gourmet 1	小笼包	小籠包	xiǎo lóng bāo	xiǎo lóng bāo	Dumplings	steamed dumpling	steamed dumpling	
-Gourmet 1	拉		lā	lā	Pull	to pull / to play (a bowed instrument) / to drag / to draw / to chat	to pull / to play (a bowed instrument) / to drag / to draw / to chat	
-Gourmet 1	笼	籠	lóng   lǒng	lóng   lǒng	cage	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]	
-Gourmet 1	粥		yù   zhōu	yù   zhōu	Gruel	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	
-Gourmet 1	油条	油條	yóu tiáo	yóu tiáo	Fritters	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	
-Gourmet 1	豆浆	豆漿	dòu jiāng	dòu jiāng	Milk	soy milk	soy milk	
-Gourmet 1	豆		dòu	dòu	beans	bean / pea / CL: 棵, 粒 / sacrificial vessel	bean / pea / CL: 棵, 粒 / sacrificial vessel	
-Gourmet 1	浆	漿	jiāng   jiàng	jiāng   jiàng	Pulp	broth / serum / to starch  starch paste	broth / serum / to starch  starch paste	
-Gourmet 1	火锅	火鍋	huǒ guō	huǒ guō	Hot Pot	hotpot	hotpot	
-Gourmet 1	包子		bāo zi	bāo zi	bun	steamed stuffed bun / CL: 個｜个	steamed stuffed bun / CL: 個｜个	
-Gourmet 1	炒饭	炒飯	chǎo fàn	chǎo fàn	Fried rice	fried rice / (slang) (Tw) to have sex	fried rice / (slang) (Tw) to have sex	
-Gourmet 1	锅	鍋	guō	guō	pot	pot / pan / boiler / CL: 口, 隻｜只	pot / pan / boiler / CL: 口, 隻｜只	
-Gourmet 1	炒		chǎo	chǎo	fry	to sauté / to stir-fry / to speculate / to hype / to fire (sb)	to sauté / to stir-fry / to speculate / to hype / to fire (sb)	
-Time 4	夏		Xià   xià	Xià   xià	summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	
-Time 4	冬		dōng   Dōng   dōng	dōng   Dōng   dōng	winter	winter  surname Dong  (onom.) beating a drum / rat-a-tat	winter  surname Dong  (onom.) beating a drum / rat-a-tat	
-Time 4	秋		Qiū   qiū   qiū	Qiū   qiū   qiū	autumn	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千	
-Time 4	季		Jì   jì	Jì   jì	season	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields	
-Time 4	澳		Ào   ào	Ào   ào	Australia	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor	
-Time 4	亚	亞	yà	yà	Asia	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]	
-Time 4	季节	季節	jì jié	jì jié	season	time / season / period / CL: 個｜个	time / season / period / CL: 個｜个	
-Time 4	澳大利亚	澳大利亞	Ào dà lì yà	Ào dà lì yà	Australia	Australia	Australia	
-Time 4	越来越	越來越	yuè lái yuè	yuè lái yuè	More	more and more	more and more	
-Time 4	前天		qián tiān	qián tiān	The day before yesterday	the day before yesterday	the day before yesterday	
-Time 4	后天	後天	hòu tiān	hòu tiān	acquired	the day after tomorrow / acquired (not innate) / a posteriori	the day after tomorrow / acquired (not innate) / a posteriori	
-Time 4	堵车	堵車	dǔ chē	dǔ chē	Traffic jam	traffic jam / choking	traffic jam / choking	
-Time 4	大概		dà gài	dà gài	probably	roughly / probably / rough / approximate / about / general idea	roughly / probably / rough / approximate / about / general idea	
-Time 4	准时	準時	zhǔn shí	zhǔn shí	on time	on time / punctual / on schedule	on time / punctual / on schedule	
-Time 4	刚	剛	gāng	gāng	just	hard / firm / strong / just / barely / exactly	hard / firm / strong / just / barely / exactly	
-Time 4	堵		dǔ	dǔ	Blocking	to stop up / (to feel) stifled or suffocated / wall / classifier for walls	to stop up / (to feel) stifled or suffocated / wall / classifier for walls	
-Time 4	概		gài	gài	General	general / approximate	general / approximate	
-Location 5	城		chéng	chéng	city	city walls / city / town / CL: 座, 道, 個｜个	city walls / city / town / CL: 座, 道, 個｜个	
-Location 5	附		fù	fù	Attached	to add / to attach / to be close to / to be attached	to add / to attach / to be close to / to be attached	
-Location 5	园	園	Yuán   yuán	Yuán   yuán	garden	surname Yuan  land used for growing plants / site used for public recreation	surname Yuan  land used for growing plants / site used for public recreation	
-Location 5	城市		chéng shì	chéng shì	city	city / town / CL: 座	city / town / CL: 座	
-Location 5	附近		fù jìn	fù jìn	nearby	(in the) vicinity / nearby / neighboring / next to	(in the) vicinity / nearby / neighboring / next to	
-Location 5	公园	公園	gōng yuán	gōng yuán	park	park (for public recreation) / CL: 個｜个, 座	park (for public recreation) / CL: 個｜个, 座	
-Location 5	图	圖	tú	tú	Map	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek	
-Location 5	方		Fāng   fāng	Fāng   fāng	How to	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter	
-Location 5	中间	中間	zhōng jiān	zhōng jiān	intermediate	between / intermediate / mid / middle	between / intermediate / mid / middle	
-Location 5	图书馆	圖書館	tú shū guǎn	tú shū guǎn	library	library / CL: 家, 個｜个	library / CL: 家, 個｜个	
-Location 5	地方		dì fāng   dì fang	dì fāng   dì fang	local	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	
-Location 5	上面		shàng miàn	shàng miàn	On	on top of / above-mentioned / also pr. [shang4 mian5]	on top of / above-mentioned / also pr. [shang4 mian5]	
-Location 5	下面		xià miàn   xià miàn	xià miàn   xià miàn	below	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	
-Location 5	咖啡馆	咖啡館	kā fēi guǎn	kā fēi guǎn	coffee shop	café / coffee shop / CL: 家	café / coffee shop / CL: 家	
-Shopping 4	折		shé   zhē   zhé	shé   zhē   zhé	fold	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book	
-Shopping 4	角		Jué   jiǎo   jué	Jué   jiǎo   jué	angle	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	
-Shopping 4	花		Huā   huā	Huā   huā	flower	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	
-Shopping 4	打折		dǎ zhé	dǎ zhé	Discount	to give a discount	to give a discount	
-Shopping 4	旧	舊	jiù	jiù	old	old / opposite: new 新 / former / worn (with age)	old / opposite: new 新 / former / worn (with age)	
-Shopping 4	皮		Pí   pí	Pí   pí	skin	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty	
-Shopping 4	换	換	huàn	huàn	change	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)	
-Shopping 4	皮鞋		pí xié	pí xié	leather shoes	leather shoes	leather shoes	
-Shopping 4	经过	經過	jīng guò	jīng guò	through	to pass / to go through / process / course / CL: 個｜个	to pass / to go through / process / course / CL: 個｜个	
-Shopping 4	退货	退貨	tuì huò	tuì huò	Returns	to return merchandise / to withdraw a product	to return merchandise / to withdraw a product	
-Shopping 4	退款		tuì kuǎn	tuì kuǎn	Refund	to refund / refund	to refund / refund	
-Shopping 4	退		tuì	tuì	Retreat	to retreat / to decline / to move back / to withdraw	to retreat / to decline / to move back / to withdraw	
-Shopping 4	货	貨	huò	huò	goods	goods / money / commodity / CL: 個｜个	goods / money / commodity / CL: 個｜个	
-Shopping 4	款		kuǎn	kuǎn	paragraph	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)	
-Shopping 4	袋子		dài zi	dài zi	bag	bag	bag	
-Daily Routine 2	惯	慣	guàn	guàn	used	accustomed to / used to / indulge / to spoil (a child)	accustomed to / used to / indulge / to spoil (a child)	
-Daily Routine 2	刷		shuā   shuà	shuā   shuà	brush	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	
-Daily Routine 2	习惯	習慣	xí guàn	xí guàn	habit	habit / custom / usual practice / to be used to / CL: 個｜个	habit / custom / usual practice / to be used to / CL: 個｜个	
-Daily Routine 2	刷牙		shuā yá	shuā yá	Brush teeth	to brush one's teeth	to brush one's teeth	
-Daily Routine 2	马上	馬上	mǎ shàng	mǎ shàng	immediately	at once / right away / immediately / on horseback (i.e. by military force)	at once / right away / immediately / on horseback (i.e. by military force)	
-Daily Routine 2	以后	以後	yǐ hòu	yǐ hòu	after	after / later / afterwards / following / later on / in the future	after / later / afterwards / following / later on / in the future	
-Daily Routine 2	澡		zǎo	zǎo	bath	bath	bath	
-Daily Routine 2	总	總	zǒng	zǒng	total	always / to assemble / gather / total / overall / head / chief / general / in every case	always / to assemble / gather / total / overall / head / chief / general / in every case	
-Daily Routine 2	洗澡		xǐ zǎo	xǐ zǎo	Bathe	to bathe / to take a shower	to bathe / to take a shower	
-Daily Routine 2	一边	一邊	yī biān	yī biān	One side	one side / either side / on the one hand / on the other hand / doing while	one side / either side / on the one hand / on the other hand / doing while	
-Daily Routine 2	总是	總是	zǒng shì	zǒng shì	always	always	always	
-Daily Routine 2	讲	講	jiǎng	jiǎng	speak	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	
-Daily Routine 2	故		gù	gù	Therefore	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead	
-Daily Routine 2	故事		gù shì   gù shi	gù shì   gù shi	story	old practice / CL: 個｜个  narrative / story / tale	old practice / CL: 個｜个  narrative / story / tale	
-Daily Routine 2	以前		yǐ qián	yǐ qián	before	before / formerly / previous / ago	before / formerly / previous / ago	
-Daily Routine 2	做梦	做夢	zuò mèng	zuò mèng	dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream	
-Daily Routine 2	梦	夢	mèng	mèng	dream	dream / CL: 場｜场, 個｜个	dream / CL: 場｜场, 個｜个	
-Food 3	除		chú	chú	except	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including	
-Food 3	其		qí	qí	its	his / her / its / their / that / such / it (refers to sth preceding it)	his / her / its / their / that / such / it (refers to sth preceding it)	
-Food 3	饺	餃	jiǎo	jiǎo	dumpling	dumplings with meat filling	dumplings with meat filling	
-Food 3	北方		běi fāng	běi fāng	north	north / the northern part a country / China north of the Yellow River	north / the northern part a country / China north of the Yellow River	
-Food 3	除了		chú le	chú le	apart from	besides / apart from (... also...) / in addition to / except (for)	besides / apart from (... also...) / in addition to / except (for)	
-Food 3	其他		qí tā	qí tā	other	other / (sth or sb) else / the rest	other / (sth or sb) else / the rest	
-Food 3	饺子	餃子	jiǎo zi	jiǎo zi	Dumplings	dumpling / pot-sticker / CL: 個｜个, 隻｜只	dumpling / pot-sticker / CL: 個｜个, 隻｜只	
-Food 3	辣		là	là	hot	hot (spicy) / pungent	hot (spicy) / pungent	
-Food 3	极	極	jí	jí	pole	extremely / pole (geography, physics) / utmost / top	extremely / pole (geography, physics) / utmost / top	
-Food 3	苦		kǔ	kǔ	bitter	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly	
-Food 3	盐	鹽	yán	yán	salt	salt / CL: 粒	salt / CL: 粒	
-Food 3	咸		Xián   xián   xián	Xián   xián   xián	salty	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	
-Food 3	南		Nán   nán	Nán   nán	south	surname Nan  south	surname Nan  south	
-Food 3	南方		nán fāng	nán fāng	south	south / the southern part of the country / the South	south / the southern part of the country / the South	
-Food 3	难吃	難吃	nán chī	nán chī	Unpalatable	unpalatable	unpalatable	
-People 3	级	級	jí	jí	level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level	
-People 3	个子	個子	gè zi	gè zi	Stature	height / stature / build / size	height / stature / build / size	
-People 3	年级	年級	nián jí	nián jí	grade	grade / year (in school, college etc) / CL: 個｜个	grade / year (in school, college etc) / CL: 個｜个	
-People 3	小学	小學	xiǎo xué	xiǎo xué	primary school	elementary school / primary school / CL: 個｜个	elementary school / primary school / CL: 個｜个	
-People 3	初中		chū zhōng	chū zhōng	junior high school	junior high school / abbr. for 初級中學｜初级中学	junior high school / abbr. for 初級中學｜初级中学	
-People 3	初		chū	chū	First	at first / (at the) beginning / first / junior / basic	at first / (at the) beginning / first / junior / basic	
-People 3	较	較	jiào	jiào	Relatively	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]	
-People 3	年轻	年輕	nián qīng	nián qīng	young	young	young	
-People 3	比较	比較	bǐ jiào	bǐ jiào	Compare	to compare / to contrast / comparatively / relatively / quite / comparison	to compare / to contrast / comparatively / relatively / quite / comparison	
-People 3	眼镜	眼鏡	yǎn jìng	yǎn jìng	glasses	spectacles / eyeglasses / CL: 副	spectacles / eyeglasses / CL: 副	
-People 3	戴		Dài   dài	Dài   dài	wore	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	
-People 3	镜	鏡	jìng	jìng	mirror	mirror / lens	mirror / lens	
-Location 6	先		xiān	xiān	first	early / prior / former / in advance / first	early / prior / former / in advance / first	
-Location 6	然后	然後	rán hòu	rán hòu	then	after / then (afterwards) / after that / afterwards	after / then (afterwards) / after that / afterwards	
-Location 6	西边	西邊	xī biān	xī biān	The west	west / west side / western part / to the west of	west / west side / western part / to the west of	
-Location 6	东边	東邊	dōng bian	dōng bian	The east	east / east side / eastern part / to the east of	east / east side / eastern part / to the east of	
-Location 6	北边	北邊	běi biān	běi biān	North	north / north side / northern part / to the north of	north / north side / northern part / to the north of	
-Location 6	一直		yī zhí	yī zhí	Up	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	
-Location 6	最后	最後	zuì hòu	zuì hòu	At last	final / last / finally / ultimate	final / last / finally / ultimate	
-Location 6	南边	南邊	nán bian	nán bian	South	south / south side / southern part / to the south of	south / south side / southern part / to the south of	
-Location 6	直		Zhí   zhí	Zhí   zhí	straight	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters	
-Location 6	迷路		mí lù	mí lù	get lost	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	
-Location 6	地址		dì zhǐ	dì zhǐ	address	address / CL: 個｜个	address / CL: 個｜个	
-Location 6	周围	周圍	zhōu wéi	zhōu wéi	around	surroundings / environment / to encompass	surroundings / environment / to encompass	
-Location 6	迷		mí	mí	fan	to bewilder / crazy about / fan / enthusiast / lost / confused	to bewilder / crazy about / fan / enthusiast / lost / confused	
-Location 6	址		zhǐ	zhǐ	site	location / site	location / site	
-Location 6	围	圍	Wéi   wéi	Wéi   wéi	Enclose	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)	
-Daily Routine 3	般		bān   pán	bān   pán	Sort	sort / kind / class / way / manner  see 般樂｜般乐	sort / kind / class / way / manner  see 般樂｜般乐	
-Daily Routine 3	聊		liáo	liáo	chat	to chat / to depend upon (literary) / temporarily / just / slightly	to chat / to depend upon (literary) / temporarily / just / slightly	
-Daily Routine 3	聊天		liáo tiān	liáo tiān	to chat with	to chat / to gossip	to chat / to gossip	
-Daily Routine 3	一般		yī bān	yī bān	general	same / ordinary / so-so / common / general / generally / in general	same / ordinary / so-so / common / general / generally / in general	
-Daily Routine 3	见面	見面	jiàn miàn	jiàn miàn	meet	to meet / to see each other / CL: 次	to meet / to see each other / CL: 次	
-Daily Routine 3	自己		zì jǐ	zì jǐ	Own	oneself / one's own	oneself / one's own	
-Daily Routine 3	一个人	一個人	yī gè rén	yī gè rén	A person	by oneself (without assistance) / alone (without company)	by oneself (without assistance) / alone (without company)	
-Daily Routine 3	自		zì	zì	from	self / oneself / from / since / naturally / surely	self / oneself / from / since / naturally / surely	
-Daily Routine 3	己		jǐ	jǐ	already	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa	
-Travel 2	证	証	zhèng   zhèng	zhèng   zhèng	certificate	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症	
-Travel 2	签	簽	qiān   qiān	qiān   qiān	sign	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag	
-Travel 2	护	護	hù	hù	Protect	to protect	to protect	
-Travel 2	护照	護照	hù zhào	hù zhào	passport	passport / CL: 本, 個｜个	passport / CL: 本, 個｜个	
-Travel 2	签证	簽證	qiān zhèng	qiān zhèng	visa	visa / certificate / to certify / CL: 個｜个	visa / certificate / to certify / CL: 個｜个	
-Travel 2	发现	發現	fā xiàn	fā xiàn	Find	to find / to discover	to find / to discover	
-Travel 2	起飞	起飛	qǐ fēi	qǐ fēi	take off	(of an aircraft) to take off	(of an aircraft) to take off	
-Travel 2	离开	離開	lí kāi	lí kāi	go away	to depart / to leave	to depart / to leave	
-Travel 2	检查	檢查	jiǎn chá	jiǎn chá	an examination	inspection / to examine / to inspect / CL: 次	inspection / to examine / to inspect / CL: 次	
-Travel 2	行李		xíng li	xíng li	Baggage	luggage / CL: 件	luggage / CL: 件	
-Travel 2	安全		ān quán	ān quán	Safety	safe / secure / safety / security	safe / secure / safety / security	
-Travel 2	检	檢	jiǎn	jiǎn	Check	to check / to examine / to inspect / to exercise restraint	to check / to examine / to inspect / to exercise restraint	
-Travel 2	查		Zhā   chá   zhā	Zhā   chá   zhā	check	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查	
-Travel 2	几乎	幾乎	jī hū	jī hū	almost	almost / nearly / practically	almost / nearly / practically	
-Travel 2	忘记	忘記	wàng jì	wàng jì	forget	to forget	to forget	
-Travel 2	海关	海關	hǎi guān	hǎi guān	Customs	customs (i.e. border crossing inspection) / CL: 個｜个	customs (i.e. border crossing inspection) / CL: 個｜个	
-Travel 2	忘		wàng	wàng	forget	to forget / to overlook / to neglect	to forget / to overlook / to neglect	
-Travel 2	记	記	jì	jì	Remember	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots	
-Travel 2	乎		hū	hū	Down	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)	
-Languages 2	言		yán	yán	Speech	words / speech / to say / to talk	words / speech / to say / to talk	
-Languages 2	易		Yì   yì	Yì   yì	easy	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange	
-Languages 2	容		Róng   róng	Róng   róng	Allow	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance	
-Languages 2	种	種	zhǒng   zhòng	zhǒng   zhòng	Kind	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	
-Languages 2	容易		róng yì	róng yì	easily	easy / likely / liable (to)	easy / likely / liable (to)	
-Languages 2	语言	語言	yǔ yán	yǔ yán	Language	language / CL: 門｜门, 種｜种	language / CL: 門｜门, 種｜种	
-Languages 2	更		gēng   gèng	gēng   gèng	more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	
-Languages 2	努力		nǔ lì	nǔ lì	Strive	great effort / to strive / to try hard	great effort / to strive / to try hard	
-Languages 2	汉字	漢字	hàn zì	hàn zì	Chinese character	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	
-Languages 2	努		nǔ	nǔ	Strive	to exert / to strive	to exert / to strive	
-Languages 2	提高		tí gāo	tí gāo	improve	to raise / to increase / to improve	to raise / to increase / to improve	
-Languages 2	水平		shuǐ píng	shuǐ píng	Level	level (of achievement etc) / standard / horizontal	level (of achievement etc) / standard / horizontal	
-Languages 2	后来	後來	hòu lái	hòu lái	later	afterwards / later	afterwards / later	
-Languages 2	提		tí	tí	mention	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid	
-Languages 2	平		Píng   píng	Píng   píng	level	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声	
-Personality and Feelings	看起来	看起來	kàn qǐ lai	kàn qǐ lai	Looks	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	
-Personality and Feelings	奇怪		qí guài	qí guài	strange	strange / odd / to marvel / to be baffled	strange / odd / to marvel / to be baffled	
-Personality and Feelings	生气	生氣	shēng qì	shēng qì	pissed off	to get angry / to take offense / angry / vitality / liveliness	to get angry / to take offense / angry / vitality / liveliness	
-Personality and Feelings	紧张	緊張	jǐn zhāng	jǐn zhāng	tension	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	
-Personality and Feelings	奇		jī   qí	jī   qí	odd	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually	
-Personality and Feelings	怪		guài	guài	strange	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather	
-Personality and Feelings	紧	緊	jǐn	jǐn	tight	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten	
-Personality and Feelings	难过	難過	nán guò	nán guò	Sorry	to feel sad / to feel unwell / (of life) to be difficult	to feel sad / to feel unwell / (of life) to be difficult	
-Personality and Feelings	哭		kū	kū	cry	to cry / to weep	to cry / to weep	
-Personality and Feelings	可怕		kě pà	kě pà	terrible	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	
-Personality and Feelings	热情	熱情	rè qíng	rè qíng	enthusiasm	cordial / enthusiastic / passion / passionate / passionately	cordial / enthusiastic / passion / passionate / passionately	
-Personality and Feelings	关心	關心	guān xīn	guān xīn	care	to be concerned about / to care about	to be concerned about / to care about	
-Personality and Feelings	经常	經常	jīng cháng	jīng cháng	often	frequently / constantly / regularly / often / day-to-day / everyday / daily	frequently / constantly / regularly / often / day-to-day / everyday / daily	
-Personality and Feelings	遇到		yù dào	yù dào	Experience	to meet / to run into / to come across	to meet / to run into / to come across	
-Personality and Feelings	好笑		hǎo xiào	hǎo xiào	funny	laughable / funny / ridiculous	laughable / funny / ridiculous	
-Personality and Feelings	遇		Yù   yù	Yù   yù	Encounter	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance	
-School 2	求		qiú	qiú	begging	to seek / to look for / to request / to demand / to beseech	to seek / to look for / to request / to demand / to beseech	
-School 2	校长	校長	xiào zhǎng	xiào zhǎng	principal	(college, university) president / headmaster / CL: 個｜个, 位, 名	(college, university) president / headmaster / CL: 個｜个, 位, 名	
-School 2	要求		yāo qiú	yāo qiú	Claim	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	
-School 2	食堂		shí táng	shí táng	Cafeteria	dining hall / CL: 個｜个, 間｜间	dining hall / CL: 個｜个, 間｜间	
-School 2	食		shí   sì	shí   sì	food	to eat / food / animal feed / eclipse  to feed	to eat / food / animal feed / eclipse  to feed	
-School 2	堂		táng	táng	Hall	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture	
-School 2	必须	必須	bì xū	bì xū	have to	to have to / must / compulsory / necessarily	to have to / must / compulsory / necessarily	
-School 2	完成		wán chéng	wán chéng	carry out	to complete / to accomplish	to complete / to accomplish	
-School 2	作业	作業	zuò yè	zuò yè	operation	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	
-School 2	高中		gāo zhōng   gāo zhòng	gāo zhōng   gāo zhòng	Senior middle school	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	
-School 2	必		bì	bì	must	certainly / must / will / necessarily	certainly / must / will / necessarily	
-School 2	成		Chéng   chéng	Chéng   chéng	to make	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	
-School 2	须	須	xū   xū	xū   xū	must	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel	
-School 2	业	業	Yè   yè	Yè   yè	industry	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already	
-School 2	向		Xiàng   xiàng   xiàng	Xiàng   xiàng   xiàng	to	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	
-School 2	借		jiè	jiè	borrow	to lend / to borrow / by means of / to take (an opportunity)	to lend / to borrow / by means of / to take (an opportunity)	
-School 2	笔记	筆記	bǐ jì	bǐ jì	notes	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本	
-School 2	铅笔	鉛筆	qiān bǐ	qiān bǐ	pencil	(lead) pencil / CL: 支, 枝, 桿｜杆	(lead) pencil / CL: 支, 枝, 桿｜杆	
-School 2	铅	鉛	qiān	qiān	lead	lead (chemistry)	lead (chemistry)	
-School 2	清楚		qīng chu	qīng chu	clear	clear / distinct / to understand thoroughly / to be clear about	clear / distinct / to understand thoroughly / to be clear about	
-School 2	黑板		hēi bǎn	hēi bǎn	blackboard	blackboard / CL: 塊｜块, 個｜个	blackboard / CL: 塊｜块, 個｜个	
-School 2	笔记本	筆記本	bǐ jì běn	bǐ jì běn	notebook	notebook (stationery) / CL: 本 / notebook (computing)	notebook (stationery) / CL: 本 / notebook (computing)	
-School 2	清		Qīng   qīng	Qīng   qīng	clear	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge	
-School 2	楚		Chǔ   chǔ	Chǔ   chǔ	Chu	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)	
-School 2	板		bǎn   bǎn   pàn	bǎn   bǎn   pàn	board	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	
-School 2	体育馆	體育館	tǐ yù guǎn	tǐ yù guǎn	stadium	gym / gymnasium / stadium / CL: 個｜个	gym / gymnasium / stadium / CL: 個｜个	
-Future	化		huà	huà	Of	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学	
-Future	算		suàn	suàn	Count	to regard as / to figure / to calculate / to compute	to regard as / to figure / to calculate / to compute	
-Future	搬		bān	bān	move	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	
-Future	变	變	biàn	biàn	change	to change / to become different / to transform / to vary / rebellion	to change / to become different / to transform / to vary / rebellion	
-Future	打算		dǎ suàn	dǎ suàn	intend	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	
-Future	变化	變化	biàn huà	biàn huà	Variety	change / variation / to change / to vary / CL: 個｜个	change / variation / to change / to vary / CL: 個｜个	
-Future	机会	機會	jī huì	jī huì	opportunity	opportunity / chance / occasion / CL: 個｜个	opportunity / chance / occasion / CL: 個｜个	
-Future	留学	留學	liú xué	liú xué	Study abroad	to study abroad	to study abroad	
-Future	国家	國家	guó jiā	guó jiā	country	country / nation / state / CL: 個｜个	country / nation / state / CL: 個｜个	
-Future	选择	選擇	xuǎn zé	xuǎn zé	select	to select / to pick / choice / option / alternative	to select / to pick / choice / option / alternative	
-Future	选	選	xuǎn	xuǎn	selected	to choose / to pick / to select / to elect	to choose / to pick / to select / to elect	
-Future	择	擇	zé	zé	Choose	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]	
-Future	结婚	結婚	jié hūn	jié hūn	marry	to marry / to get married / CL: 次	to marry / to get married / CL: 次	
-Future	愿意	願意	yuàn yì	yuàn yì	willing	to wish / to want / ready / willing (to do sth)	to wish / to want / ready / willing (to do sth)	
-Future	认真	認真	rèn zhēn	rèn zhēn	serious	conscientious / earnest / serious / to take seriously / to take to heart	conscientious / earnest / serious / to take seriously / to take to heart	
-Future	结	結	jiē   jié	jiē   jié	Knot	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	
-Future	愿		yuàn   yuàn	yuàn   yuàn	willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing	
-Future	婚		hūn	hūn	marriage	to marry / marriage / wedding / to take a wife	to marry / marriage / wedding / to take a wife	
-Future	当然	當然	dāng rán	dāng rán	of course	only natural / as it should be / certainly / of course / without doubt	only natural / as it should be / certainly / of course / without doubt	
-Future	放心		fàng xīn	fàng xīn	rest assured	to feel relieved / to feel reassured / to be at ease	to feel relieved / to feel reassured / to be at ease	
-Future	害怕		hài pà	hài pà	Afraid	to be afraid / to be scared	to be afraid / to be scared	
-Future	当	噹	dāng   dāng   dàng	dāng   dāng   dàng	when	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)	
-Future	害		hài	hài	harm	to do harm to / to cause trouble to / harm / evil / calamity	to do harm to / to cause trouble to / harm / evil / calamity	
-Future	怕		Pà   pà	Pà   pà	afraid	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps	
-Future	分手		fēn shǒu	fēn shǒu	Breaking up	to part company / to split up / to break up	to part company / to split up / to break up	
-Environment	境		jìng	jìng	territory	border / place / condition / boundary / circumstances / territory	border / place / condition / boundary / circumstances / territory	
-Environment	环	環	Huán   huán	Huán   huán	ring	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in	
-Environment	层	層	céng	céng	Floor	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	
-Environment	方便		fāng biàn	fāng biàn	Convenience	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	
-Environment	环境	環境	huán jìng	huán jìng	surroundings	environment / circumstances / surroundings / CL: 個｜个 / ambient	environment / circumstances / surroundings / CL: 個｜个 / ambient	
-Environment	草		cǎo	cǎo	grass	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	
-Environment	太阳	太陽	tài yang	tài yang	sun	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	
-Environment	星星		xīng xing	xīng xing	star	star in the sky	star in the sky	
-Environment	阳	陽	yáng	yáng	Positive	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯	
-Environment	安静	安靜	ān jìng	ān jìng	be quiet	quiet / peaceful / calm	quiet / peaceful / calm	
-Environment	楼	樓	Lóu   lóu	Lóu   lóu	floor	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	
-Environment	静	靜	jìng	jìng	Quiet	still / calm / quiet / not moving	still / calm / quiet / not moving	
-Environment	声音	聲音	shēng yīn	shēng yīn	sound	voice / sound / CL: 個｜个	voice / sound / CL: 個｜个	
-Environment	影响	影響	yǐng xiǎng	yǐng xiǎng	influences	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	
-Environment	邻居	鄰居	lín jū	lín jū	neighbor	neighbor / next door / CL: 個｜个	neighbor / next door / CL: 個｜个	
-Environment	声	聲	shēng	shēng	sound	sound / voice / tone / noise / classifier for sounds	sound / voice / tone / noise / classifier for sounds	
-Environment	邻	鄰	lín	lín	adjacent	neighbor / adjacent / close to	neighbor / adjacent / close to	
-Environment	响	響	xiǎng	xiǎng	ring	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises	
-Environment	居		Jū   jī   jū	Jū   jī   jū	House	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms	
-Environment	垃圾		lā jī	lā jī	Rubbish	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	
-Environment	桶		tǒng	tǒng	barrel	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	
-Environment	丢	丟	diū	diū	throw	to lose / to put aside / to throw	to lose / to put aside / to throw	
-Environment	脏	臟	zàng   zāng	zàng   zāng	dirty	viscera / (anatomy) organ  dirty / filthy	viscera / (anatomy) organ  dirty / filthy	
-Environment	垃		lā	lā	garbage	see 垃圾 / Taiwan pr. [le4]	see 垃圾 / Taiwan pr. [le4]	
-Environment	圾		jī	jī	Rubbish	see 垃圾 / Taiwan pr. [se4]	see 垃圾 / Taiwan pr. [se4]	
-Work	先生		Xiān sheng   xiān sheng	Xiān sheng   xiān sheng	Mr	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	
-Work	小姐		xiǎo jie	xiǎo jie	Young lady	young lady / miss / (slang) prostitute / CL: 個｜个, 位	young lady / miss / (slang) prostitute / CL: 個｜个, 位	
-Work	经理	經理	jīng lǐ	jīng lǐ	manager	manager / director / CL: 個｜个, 位, 名	manager / director / CL: 個｜个, 位, 名	
-Work	同事		tóng shì	tóng shì	colleague	colleague / co-worker / CL: 個｜个, 位	colleague / co-worker / CL: 個｜个, 位	
-Work	突然		tū rán	tū rán	suddenly	sudden / abrupt / unexpected	sudden / abrupt / unexpected	
-Work	重要		zhòng yào	zhòng yào	important	important / significant / major	important / significant / major	
-Work	会议	會議	huì yì	huì yì	meeting	meeting / conference / CL: 場｜场, 屆｜届	meeting / conference / CL: 場｜场, 屆｜届	
-Work	突		tū	tū	Sudden	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]	
-Work	重		chóng   zhòng	chóng   zhòng	weight	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to	
-Work	议	議	yì	yì	Discuss	to comment on / to discuss / to suggest	to comment on / to discuss / to suggest	
-Work	解决	解決	jiě jué	jiě jué	solve	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	
-Work	办法	辦法	bàn fǎ	bàn fǎ	Method	means / method / way (of doing sth) / CL: 條｜条, 個｜个	means / method / way (of doing sth) / CL: 條｜条, 個｜个	
-Work	相信		xiāng xìn	xiāng xìn	Believe	to be convinced (that sth is true) / to believe / to accept sth as true	to be convinced (that sth is true) / to believe / to accept sth as true	
-Work	决	決	jué	jué	Decide	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly	
-Work	解		Xiè   jiě   jiè   xiè	Xiè   jiě   jiè   xiè	solution	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)	
-Culture	界		jiè	jiè	boundary	boundary / scope / extent / circles / group / kingdom (taxonomy)	boundary / scope / extent / circles / group / kingdom (taxonomy)	
-Culture	河		hé	hé	River	river / CL: 條｜条, 道	river / CL: 條｜条, 道	
-Culture	世		Shì   shì	Shì   shì	world	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble	
-Culture	黄河	黃河	Huáng Hé	Huáng Hé	Yellow River	Yellow River or Huang He	Yellow River or Huang He	
-Culture	动物	動物	dòng wù	dòng wù	animal	animal / CL: 隻｜只, 群, 個｜个	animal / CL: 隻｜只, 群, 個｜个	
-Culture	有名		yǒu míng	yǒu míng	Famous	famous / well-known	famous / well-known	
-Culture	世界		shì jiè	shì jiè	world	world / CL: 個｜个	world / CL: 個｜个	
-Culture	长江	長江	Cháng Jiāng	Cháng Jiāng	Yangtze	Yangtze River, or Chang Jiang	Yangtze River, or Chang Jiang	
-Culture	江		Jiāng   jiāng	Jiāng   jiāng	River	surname Jiang  river / CL: 條｜条, 道	surname Jiang  river / CL: 條｜条, 道	
-Culture	多么	多麼	duō me	duō me	how	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	
-Culture	熊猫	熊貓	xióng māo	xióng māo	panda	panda / CL: 隻｜只	panda / CL: 隻｜只	
-Culture	西安		Xī ān	Xī ān	Xi'an	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	
-Culture	啊		ā   á   ǎ   à   a	ā   á   ǎ   à   a	what	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	
-Culture	熊		Xióng   xióng	Xióng   xióng	Bear	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly	
-Culture	长城	長城	Cháng chéng	Cháng chéng	Great Wall	the Great Wall	the Great Wall	
-Culture	故宫	故宮	Gù gōng   gù gōng	Gù gōng   gù gōng	Forbidden City	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	
-Culture	宫	宮	Gōng   gōng	Gōng   gōng	palace	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale	
-Hobbies 3	山		Shān   shān	Shān   shān	mountain	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable	
-Hobbies 3	者		zhě	zhě	Person	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this	
-Hobbies 3	爬		pá	pá	climb	to crawl / to climb / to get up or sit up	to crawl / to climb / to get up or sit up	
-Hobbies 3	或		huò	huò	or	maybe / perhaps / might / possibly / or	maybe / perhaps / might / possibly / or	
-Hobbies 3	自行车	自行車	zì xíng chē	zì xíng chē	bicycle	bicycle / bike / CL: 輛｜辆	bicycle / bike / CL: 輛｜辆	
-Hobbies 3	或者		huò zhě	huò zhě	or	or / possibly / maybe / perhaps	or / possibly / maybe / perhaps	
-Hobbies 3	爬山		pá shān	pá shān	Climb	to climb a mountain / to mountaineer / hiking / mountaineering	to climb a mountain / to mountaineer / hiking / mountaineering	
-Hobbies 3	功夫		gōng fu	gōng fu	effort	skill / art / kung fu / labor / effort	skill / art / kung fu / labor / effort	
-Hobbies 3	功		gōng	gōng	Gong	meritorious deed or service / achievement / result / service / accomplishment / work (physics)	meritorious deed or service / achievement / result / service / accomplishment / work (physics)	
-Hobbies 3	文化		wén huà	wén huà	culture	culture / civilization / cultural / CL: 個｜个, 種｜种	culture / civilization / cultural / CL: 個｜个, 種｜种	
-Hobbies 3	历史	歷史	lì shǐ	lì shǐ	history	history / CL: 門｜门, 段	history / CL: 門｜门, 段	
-Hobbies 3	兴趣	興趣	xìng qù	xìng qù	interest	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个	
-Hobbies 3	感兴趣	感興趣	gǎn xìng qù	gǎn xìng qù	Interested	to be interested	to be interested	
-Hobbies 3	历	曆	lì   lì	lì   lì	calendar	calendar  to experience / to undergo / to pass through / all / each / every / history	calendar  to experience / to undergo / to pass through / all / each / every / history	
-Hobbies 3	趣		qù	qù	interest	interesting / to interest	interesting / to interest	
-Hobbies 3	史		Shǐ   shǐ	Shǐ   shǐ	history	surname Shi  history / annals / title of an official historian in ancient China	surname Shi  history / annals / title of an official historian in ancient China	
-Hobbies 3	为了	為了	wèi le	wèi le	in order to	in order to / for the purpose of / so as to	in order to / for the purpose of / so as to	
-Hobbies 3	特别	特別	tè bié	tè bié	particular	especially / special / particular / unusual	especially / special / particular / unusual	
-Hobbies 3	了解		liǎo jiě   liǎo jiě	liǎo jiě   liǎo jiě	To understanding	to understand / to realize / to find out  to understand / to realize / to find out	to understand / to realize / to find out  to understand / to realize / to find out	
-Hobbies 3	麻将	麻將	má jiàng	má jiàng	Mahjong	mahjong / CL: 副	mahjong / CL: 副	
-Hobbies 3	特		tè	tè	special	special / unique / distinguished / especially / unusual / very	special / unique / distinguished / especially / unusual / very	
-Hobbies 3	麻		Má   má	Má   má	hemp	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb	
-Hobbies 3	将	將	jiāng   jiàng   qiāng	jiāng   jiàng   qiāng	will	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request	
-Health 3	顾	顧	Gù   gù	Gù   gù	Attend	surname Gu  to look after / to take into consideration / to attend to	surname Gu  to look after / to take into consideration / to attend to	
-Health 3	死		sǐ	sǐ	dead	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	
-Health 3	闷	悶	mēn   mèn	mēn   mèn	stuffy	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	
-Health 3	腿		tuǐ   tuǐ	tuǐ   tuǐ	leg	leg / CL: 條｜条  hip bone / old variant of 腿	leg / CL: 條｜条  hip bone / old variant of 腿	
-Health 3	照顾	照顧	zhào gu	zhào gu	Look after	to take care of / to show consideration / to attend to / to look after	to take care of / to show consideration / to attend to / to look after	
-Health 3	公斤		gōng jīn	gōng jīn	kg	kilogram (kg)	kilogram (kg)	
-Health 3	着急	著急	zháo jí	zháo jí	Worry	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	
-Health 3	瘦		shòu	shòu	thin	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	
-Health 3	斤		jīn	jīn	jin	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g	
-Health 3	急		jí	jí	anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious	
-Health 3	咳嗽		ké sou	ké sou	cough	to cough / CL: 陣｜阵	to cough / CL: 陣｜阵	
-Health 3	抽烟	抽煙	chōu yān	chōu yān	smokes	to smoke (a cigarette, tobacco)	to smoke (a cigarette, tobacco)	
-Health 3	咳		hāi   ké	hāi   ké	cough	sound of sighing  cough	sound of sighing  cough	
-Health 3	嗽		sòu	sòu	cough	cough	cough	
-Health 3	抽		chōu	chōu	Draw	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash	
-Health 3	烟	煙	yān	yān	smoke	cigarette or pipe tobacco / CL: 根 / smoke / mist / vapour / CL: 縷｜缕 / tobacco plant / (of the eyes) to be irritated by smoke	cigarette or pipe tobacco / CL: 根 / smoke / mist / vapour / CL: 縷｜缕 / tobacco plant / (of the eyes) to be irritated by smoke	
-Travel 3	际	際	jì	jì	The occasion	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)	
-Travel 3	柜		jǔ   guì	jǔ   guì	cabinet	Salix multinervis  cupboard / cabinet / wardrobe	Salix multinervis  cupboard / cabinet / wardrobe	
-Travel 3	转	轉	zhuǎi   zhuǎn   zhuàn	zhuǎi   zhuǎn   zhuàn	turn	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions	
-Travel 3	转机	轉機	zhuǎn jī	zhuǎn jī	Connection	(to take) a turn for the better / to change planes	(to take) a turn for the better / to change planes	
-Travel 3	柜台	櫃檯	guì tái	guì tái	counter	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	
-Travel 3	国际	國際	guó jì	guó jì	International	international	international	
-Travel 3	换钱	換錢	huàn qián	huàn qián	Change money	to change money / to sell	to change money / to sell	
-Travel 3	银行	銀行	yín háng	yín háng	bank	bank / CL: 家, 個｜个	bank / CL: 家, 個｜个	
-Travel 3	充电	充電	chōng diàn	chōng diàn	Charging	to recharge batteries / fig. to rest and recuperate	to recharge batteries / fig. to rest and recuperate	
-Travel 3	国内	國內	guó nèi	guó nèi	domestic	domestic / internal (to a country) / civil	domestic / internal (to a country) / civil	
-Travel 3	银	銀	yín	yín	silver	silver / silver-colored / relating to money or currency	silver / silver-colored / relating to money or currency	
-Travel 3	充		chōng	chōng	Charge	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full	
-Travel 3	内	內	nèi	nèi	Inside	inside / inner / internal / within / interior	inside / inner / internal / within / interior	
-Travel 3	充值		chōng zhí	chōng zhí	Recharge	to recharge (money onto a card)	to recharge (money onto a card)	
-Travel 3	漫游	漫遊	màn yóu	màn yóu	roaming	to travel around / to roam / (mobile telephony) roaming	to travel around / to roam / (mobile telephony) roaming	
-Travel 3	电话卡	電話卡	diàn huà kǎ	diàn huà kǎ	phone card	telephone card	telephone card	
-Travel 3	值		zhí	zhí	value	value / (to be) worth / to happen to / to be on duty	value / (to be) worth / to happen to / to be on duty	
-Travel 3	订房	訂房	dìng fáng	dìng fáng	Booking	to reserve a room	to reserve a room	
-Travel 3	退房		tuì fáng	tuì fáng	check out	to check out of a hotel room	to check out of a hotel room	
-Travel 3	取消		qǔ xiāo	qǔ xiāo	cancel	to cancel / cancellation	to cancel / cancellation	
-Travel 3	导游	導遊	dǎo yóu	dǎo yóu	Tourist guide	tour guide / guidebook / to conduct a tour	tour guide / guidebook / to conduct a tour	
-Travel 3	取		qǔ	qǔ	take	to take / to get / to choose / to fetch	to take / to get / to choose / to fetch	
-Travel 3	导	導	dǎo	dǎo	guide	to transmit / to lead / to guide / to conduct / to direct	to transmit / to lead / to guide / to conduct / to direct	
-Travel 3	消		xiāo	xiāo	Eliminate	to disappear / to vanish / to eliminate / to spend (time) / have to / need	to disappear / to vanish / to eliminate / to spend (time) / have to / need	
-Languages 3	答		dā   dá	dā   dá	answer	to answer / to agree  reply / answer / return / respond / echo	to answer / to agree  reply / answer / return / respond / echo	
-Languages 3	句		jù	jù	sentence	sentence / clause / phrase / classifier for phrases or lines of verse	sentence / clause / phrase / classifier for phrases or lines of verse	
-Languages 3	简	簡	jiǎn	jiǎn	simple	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)	
-Languages 3	简单	簡單	jiǎn dān	jiǎn dān	simple	simple / not complicated	simple / not complicated	
-Languages 3	句子		jù zi	jù zi	sentence	sentence / CL: 個｜个	sentence / CL: 個｜个	
-Languages 3	回答		huí dá	huí dá	Reply	to reply / to answer / the answer / CL: 個｜个	to reply / to answer / the answer / CL: 個｜个	
-Languages 3	词典	詞典	cí diǎn	cí diǎn	dictionary	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	
-Languages 3	应用	應用	yìng yòng	yìng yòng	application	to use / to apply / application / applicable	to use / to apply / application / applicable	
-Languages 3	语法	語法	yǔ fǎ	yǔ fǎ	grammar	grammar	grammar	
-Languages 3	流利		liú lì	liú lì	fluent	fluent	fluent	
-Languages 3	词	詞	cí	cí	word	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首	
-Languages 3	流		liú	liú	flow	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade	
-Languages 3	典		diǎn	diǎn	Code	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn	
-Languages 3	下载	下載	xià zǎi	xià zǎi	download	to download / also pr. [xia4 zai4]	to download / also pr. [xia4 zai4]	
-Languages 3	多邻国		duō lín guó	duō lín guó	Duolingo	duolingo	duolingo	
-Languages 3	翻译	翻譯	fān yì	fān yì	translation	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	
-Languages 3	翻		fān	fān	turn	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross	
-Languages 3	载	載	zǎi   zài	zǎi   zài	Load	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously	
-Languages 3	译	譯	yì	yì	Translate	to translate / to interpret	to translate / to interpret	
-House	把		bǎ   bà	bǎ   bà	The	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	
-House	灯	燈	dēng	dēng	light	lamp / light / lantern / CL: 盞｜盏	lamp / light / lantern / CL: 盞｜盏	
-House	空调	空調	kōng tiáo	kōng tiáo	air conditioning	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	
-House	画	畫	huà	huà	painting	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	
-House	厨房	廚房	chú fáng	chú fáng	kitchen	kitchen / CL: 間｜间	kitchen / CL: 間｜间	
-House	客厅	客廳	kè tīng	kè tīng	living room	drawing room (room for arriving guests) / living room / CL: 間｜间	drawing room (room for arriving guests) / living room / CL: 間｜间	
-House	厨	廚	chú	chú	Kitchen	kitchen	kitchen	
-House	厅	廳	tīng	tīng	hall	(reception) hall / living room / office / provincial government department	(reception) hall / living room / office / provincial government department	
-House	客人		kè rén	kè rén	The guests	visitor / guest / customer / client / CL: 位	visitor / guest / customer / client / CL: 位	
-House	打扫	打掃	dǎ sǎo	dǎ sǎo	clean	to clean / to sweep	to clean / to sweep	
-House	干净	乾淨	gān jìng	gān jìng	clean	clean / neat	clean / neat	
-House	扫	掃	sǎo   sào	sǎo   sào	sweep	to sweep  broom	to sweep  broom	
-House	净	淨	jìng	jìng	net	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role	
-House	电梯	電梯	diàn tī	diàn tī	elevator	elevator / escalator / CL: 臺｜台, 部	elevator / escalator / CL: 臺｜台, 部	
-House	坏	壞	huài	huài	Bad	bad / spoiled / broken / to break down / (suffix) to the utmost	bad / spoiled / broken / to break down / (suffix) to the utmost	
-House	被		bèi	bèi	Is	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	
-House	厕所	廁所	cè suǒ	cè suǒ	WC	toilet / lavatory / CL: 間｜间, 處｜处	toilet / lavatory / CL: 間｜间, 處｜处	
-House	厕	廁	cè   sì	cè   sì	toilet	restroom / toilet / lavatory  see 茅廁｜茅厕	restroom / toilet / lavatory  see 茅廁｜茅厕	
-House	梯		tī	tī	ladder	ladder / stairs	ladder / stairs	
-Exam	寒		hán	hán	cold	cold / poor / to tremble	cold / poor / to tremble	
-Exam	暑		shǔ	shǔ	Heat	heat / hot weather / summer heat	heat / hot weather / summer heat	
-Exam	复	復	fù   fù	fù   fù	complex	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate	
-Exam	记得	記得	jì de	jì de	remember	to remember	to remember	
-Exam	复习	復習	fù xí	fù xí	review	to review / revision / CL: 次	to review / revision / CL: 次	
-Exam	数学	數學	shù xué	shù xué	mathematics	mathematics / mathematical	mathematics / mathematical	
-Exam	放假		fàng jià	fàng jià	holiday	to have a holiday or vacation	to have a holiday or vacation	
-Exam	暑假		shǔ jià	shǔ jià	summer vacation	summer vacation / CL: 個｜个	summer vacation / CL: 個｜个	
-Exam	寒假		hán jià	hán jià	winter vacation	winter vacation	winter vacation	
-Exam	终于	終於	zhōng yú	zhōng yú	at last	at last / in the end / finally / eventually	at last / in the end / finally / eventually	
-Exam	结束	結束	jié shù	jié shù	End	termination / to finish / to end / to conclude / to close	termination / to finish / to end / to conclude / to close	
-Exam	放松	放鬆	fàng sōng	fàng sōng	Relax	to loosen / to relax	to loosen / to relax	
-Exam	大学	大學	Dà xué   dà xué	Dà xué   dà xué	the University	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	
-Exam	终	終	zhōng	zhōng	end	end / finish	end / finish	
-Exam	于		Yú   yú   yú	Yú   yú   yú	to	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of	
-Exam	束		Shù   shù	Shù   shù	bundle	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control	
-Exam	成绩	成績	chéng jì	chéng jì	Achievement	achievement / performance records / grades / CL: 項｜项, 個｜个	achievement / performance records / grades / CL: 項｜项, 個｜个	
-Exam	担心	擔心	dān xīn	dān xīn	worry	anxious / worried / uneasy / to worry / to be anxious	anxious / worried / uneasy / to worry / to be anxious	
-Exam	专业	專業	zhuān yè	zhuān yè	profession	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	
-Exam	担	擔	dān   dàn	dān   dàn	Dan	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole	
-Exam	专	專	zhuān	zhuān	Special	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized	
-Exam	绩	績	jì	jì	Merit	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]	
-Travel 4	景		Jǐng   jǐng	Jǐng   jǐng	view	surname Jing  bright / circumstance / scenery	surname Jing  bright / circumstance / scenery	
-Travel 4	街		jiē	jiē	street	street / CL: 條｜条	street / CL: 條｜条	
-Travel 4	地图	地圖	dì tú	dì tú	map	map / CL: 張｜张, 本	map / CL: 張｜张, 本	
-Travel 4	街道		jiē dào	jiē dào	street	street / CL: 條｜条 / subdistrict / residential district	street / CL: 條｜条 / subdistrict / residential district	
-Travel 4	红绿灯	紅綠燈	hóng lǜ dēng	hóng lǜ dēng	traffic light	traffic light / traffic signal	traffic light / traffic signal	
-Travel 4	风景	風景	fēng jǐng	fēng jǐng	landscape	scenery / landscape / CL: 個｜个	scenery / landscape / CL: 個｜个	
-Travel 4	司机	司機	sī jī	sī jī	driver	chauffeur / driver / CL: 個｜个	chauffeur / driver / CL: 個｜个	
-Travel 4	接		jiē	jiē	Meet	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	
-Travel 4	免费	免費	miǎn fèi	miǎn fèi	free	free (of charge)	free (of charge)	
-Travel 4	打车	打車	dǎ chē	dǎ chē	A taxi	to take a taxi (in town) / to hitch a lift	to take a taxi (in town) / to hitch a lift	
-Travel 4	观光	觀光	guān guāng	guān guāng	go sightseeing	to tour / sightseeing / tourism	to tour / sightseeing / tourism	
-Travel 4	免		miǎn	miǎn	Avoid	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	
-Travel 4	观	觀	Guàn   guān   guàn	Guàn   guān   guàn	Watch	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform	
-Travel 4	光		guāng	guāng	Light	light / ray / CL: 道 / bright / only / merely / to use up	light / ray / CL: 道 / bright / only / merely / to use up	
-Travel 4	小心		xiǎo xīn	xiǎo xīn	Be careful	to be careful / to take care	to be careful / to take care	
-Travel 4	时差	時差	shí chā	shí chā	jet lag	time difference / time lag / jet lag	time difference / time lag / jet lag	
-Travel 4	马路	馬路	mǎ lù	mǎ lù	road	street / road / CL: 條｜条	street / road / CL: 條｜条	
-Travel 4	参观	參觀	cān guān	cān guān	Visit	to look around / to tour / to visit	to look around / to tour / to visit	
-Travel 4	博物馆	博物館	bó wù guǎn	bó wù guǎn	museum	museum	museum	
-Travel 4	博		bó	bó	Rich	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble	
-Travel 4	安排		ān pái	ān pái	arrangement	to arrange / to plan / to set up / arrangements / plans	to arrange / to plan / to set up / arrangements / plans	
-Travel 4	活动	活動	huó dòng	huó dòng	activity	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	
-Travel 4	表演		biǎo yǎn	biǎo yǎn	Performance	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	
-Travel 4	海边	海邊	hǎi biān	hǎi biān	seaside	coast / seaside / seashore / beach	coast / seaside / seashore / beach	
-Travel 4	活		huó	huó	live	to live / alive / living / work / workmanship	to live / alive / living / work / workmanship	
-Travel 4	演		yǎn	yǎn	play	to develop / to evolve / to practice / to perform / to play / to act	to develop / to evolve / to practice / to perform / to play / to act	
-Communication 2	邮	郵	yóu	yóu	mail	post (office) / mail	post (office) / mail	
-Communication 2	刚才	剛才	gāng cái   gāng cái	gāng cái   gāng cái	Just now	just now / a moment ago  (just) a moment ago	just now / a moment ago  (just) a moment ago	
-Communication 2	电子邮件	電子郵件	diàn zǐ yóu jiàn	diàn zǐ yóu jiàn	e-mail	email / CL: 封, 份	email / CL: 封, 份	
-Communication 2	主要		zhǔ yào	zhǔ yào	main	main / principal / major / primary	main / principal / major / primary	
-Communication 2	短信		duǎn xìn	duǎn xìn	SMS	text message / SMS	text message / SMS	
-Communication 2	关于	關於	guān yú	guān yú	on	pertaining to / concerning / with regard to / about / a matter of	pertaining to / concerning / with regard to / about / a matter of	
-Communication 2	主		zhǔ	zhǔ	the Lord	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)	
-Communication 2	登录	登錄	dēng lù	dēng lù	log in	to register / to log in	to register / to log in	
-Communication 2	密码	密碼	mì mǎ	mì mǎ	password	secret code / ciphertext / password / PIN	secret code / ciphertext / password / PIN	
-Communication 2	信号	信號	xìn hào	xìn hào	signal	signal	signal	
-Communication 2	登		dēng	dēng	Ascend	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)	
-Communication 2	密		Mì   mì	Mì   mì	dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense	
-Communication 2	录	錄	Lù   lù	Lù   lù	record	surname Lu  diary / record / to hit / to copy	surname Lu  diary / record / to hit / to copy	
-Communication 2	段		Duàn   duàn	Duàn   duàn	segment	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	
-Communication 2	其实	其實	qí shí	qí shí	in fact	actually / in fact / really	actually / in fact / really	
-Communication 2	过去	過去	guò qù   guò qu	guò qù   guò qu	past	(in the) past / former / previous / to go over / to pass by  (verb suffix)	(in the) past / former / previous / to go over / to pass by  (verb suffix)	
-Communication 2	谈	談	Tán   tán	Tán   tán	talk	surname Tan  to speak / to talk / to converse / to chat / to discuss	surname Tan  to speak / to talk / to converse / to chat / to discuss	
-Communication 2	实	實	shí	shí	real	real / true / honest / really / solid / fruit / seed / definitely	real / true / honest / really / solid / fruit / seed / definitely	
-Work 2	同意		tóng yì	tóng yì	agree	to agree / to consent / to approve	to agree / to consent / to approve	
-Work 2	决定	決定	jué dìng	jué dìng	Decide	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	
-Work 2	根据	根據	gēn jù	gēn jù	according to	according to / based on / basis / foundation / CL: 個｜个	according to / based on / basis / foundation / CL: 個｜个	
-Work 2	升职	升職	shēng zhí	shēng zhí	Promotion	to get promoted (at work etc) / promotion	to get promoted (at work etc) / promotion	
-Work 2	根		gēn	gēn	root	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)	
-Work 2	据		jū   jù	jū   jù	according to	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	
-Work 2	升		shēng	shēng	Rise	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗	
-Work 2	职	職	zhí	zhí	Office	office / duty	office / duty	
-Work 2	满意	滿意	mǎn yì	mǎn yì	satisfaction	satisfied / pleased / to one's satisfaction	satisfied / pleased / to one's satisfaction	
-Work 2	认为	認為	rèn wéi	rèn wéi	think	to believe / to think / to consider / to feel	to believe / to think / to consider / to feel	
-Work 2	出差		chū chāi	chū chāi	On a business trip	to go on an official or business trip	to go on an official or business trip	
-Work 2	表现	表現	biǎo xiàn	biǎo xiàn	which performed	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	
-Work 2	满	滿	Mǎn   mǎn	Mǎn   mǎn	full	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented	
-Work 2	老板	老闆	Lǎo bǎn   lǎo bǎn	Lǎo bǎn   lǎo bǎn	boss	Robam (brand)  boss / business proprietor / CL: 個｜个	Robam (brand)  boss / business proprietor / CL: 個｜个	
-Work 2	麻烦	麻煩	má fan	má fan	trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	
-Work 2	开会	開會	kāi huì	kāi huì	Meetings	to hold a meeting / to attend a meeting	to hold a meeting / to attend a meeting	
-Work 2	面试	面試	miàn shì	miàn shì	Interview	to be interviewed (as a candidate) / interview	to be interviewed (as a candidate) / interview	
-Work 2	烦	煩	fán	fán	bother	to feel vexed / to bother / to trouble / superfluous and confusing / edgy	to feel vexed / to bother / to trouble / superfluous and confusing / edgy	
-Festivals	饼	餅	bǐng	bǐng	cake	round flat cake / cookie / cake / pastry / CL: 張｜张	round flat cake / cookie / cake / pastry / CL: 張｜张	
-Festivals	月亮		yuè liang	yuè liang	moon	the moon	the moon	
-Festivals	月饼	月餅	yuè bǐng	yuè bǐng	moon cake	mooncake (esp. for the Mid-Autumn Festival)	mooncake (esp. for the Mid-Autumn Festival)	
-Festivals	中秋节	中秋節	Zhōng qiū jié	Zhōng qiū jié	Mid-Autumn Festival	the Mid-Autumn Festival on 15th of 8th lunar month	the Mid-Autumn Festival on 15th of 8th lunar month	
-Festivals	圆	圓	yuán	yuán	circle	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify	
-Festivals	恭喜		gōng xǐ	gōng xǐ	Congratulation	congratulations / greetings	congratulations / greetings	
-Festivals	红包	紅包	hóng bāo	hóng bāo	Red envelope	money wrapped in red as a gift / bonus payment / kickback / bribe	money wrapped in red as a gift / bonus payment / kickback / bribe	
-Festivals	汤圆	湯圓	tāng yuán	tāng yuán	Dumpling	boiled balls of glutinous rice flour, eaten during the Lantern Festival	boiled balls of glutinous rice flour, eaten during the Lantern Festival	
-Festivals	聚会	聚會	jù huì	jù huì	get together	party / gathering / to meet / to get together	party / gathering / to meet / to get together	
-Festivals	发财	發財	fā cái	fā cái	Make a fortune	to get rich	to get rich	
-Festivals	恭		gōng	gōng	Respectful	respectful	respectful	
-Festivals	聚		jù	jù	Gather	to congregate / to assemble / to mass / to gather together / to amass / to polymerize	to congregate / to assemble / to mass / to gather together / to amass / to polymerize	
-Festivals	财	財	cái	cái	fiscal	money / wealth / riches / property / valuables	money / wealth / riches / property / valuables	
-Festivals	端午节	端午節	Duān wǔ jié	Duān wǔ jié	Dragon boat festival	Dragon Boat Festival (5th day of the 5th lunar month)	Dragon Boat Festival (5th day of the 5th lunar month)	
-Festivals	粽子		zòng zi	zòng zi	Zongzi	glutinous rice and choice of filling wrapped in leaves and boiled	glutinous rice and choice of filling wrapped in leaves and boiled	
-Festivals	划		huá   huá   huà	huá   huá   huà	Draw	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	
-Festivals	龙舟	龍舟	lóng zhōu	lóng zhōu	Dragon Boat	dragon boat / imperial boat	dragon boat / imperial boat	
-Festivals	端		duān	duān	end	end / extremity / item / port / to hold sth level with both hands / to carry / regular	end / extremity / item / port / to hold sth level with both hands / to carry / regular	
-Festivals	粽		zòng	zòng	Dumplings	rice dumplings wrapped in leaves	rice dumplings wrapped in leaves	
-Festivals	龙	龍	Lóng   lóng	Lóng   lóng	Dragon	surname Long  dragon / CL: 條｜条 / imperial	surname Long  dragon / CL: 條｜条 / imperial	
-Festivals	舟		zhōu	zhōu	boat	boat	boat	
-Gourmet 2	珠		zhū	zhū	Pearl	bead / pearl / CL: 粒, 顆｜颗	bead / pearl / CL: 粒, 顆｜颗	
-Gourmet 2	汤	湯	Tāng   shāng   tāng	Tāng   shāng   tāng	soup	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled	
-Gourmet 2	酸		suān	suān	acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid	
-Gourmet 2	珍		zhēn	zhēn	Treasure	precious thing / treasure / culinary delicacy / rare / valuable / to value highly	precious thing / treasure / culinary delicacy / rare / valuable / to value highly	
-Gourmet 2	珍珠奶茶		zhēn zhū nǎi chá	zhēn zhū nǎi chá	Pearl milk tea	pearl milk tea / tapioca milk tea / bubble milk tea	pearl milk tea / tapioca milk tea / bubble milk tea	
-Gourmet 2	酸辣汤	酸辣湯	suān là tāng	suān là tāng	Hot and sour soup	hot and sour soup / sour and spicy soup	hot and sour soup / sour and spicy soup	
-Gourmet 2	北京烤鸭	北京烤鴨	Běi jīng kǎo yā	Běi jīng kǎo yā	Peking duck	Peking Duck	Peking Duck	
-Gourmet 2	春卷	春捲	chūn juǎn	chūn juǎn	Spring Rolls	egg roll / spring roll	egg roll / spring roll	
-Gourmet 2	豆花		dòu huā	dòu huā	Curd	jellied tofu / soft bean curd	jellied tofu / soft bean curd	
-Gourmet 2	烤		kǎo	kǎo	grilled	to roast / to bake / to broil	to roast / to bake / to broil	
-Gourmet 2	鸭	鴨	yā	yā	duck	duck / CL: 隻｜只 / (slang) male prostitute	duck / CL: 隻｜只 / (slang) male prostitute	
-Gourmet 2	卷		juǎn   juàn   juǎn	juǎn   juàn   juǎn	volume	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll	
-Gourmet 2	宫保鸡丁	宮保雞丁	gōng bǎo jī dīng	gōng bǎo jī dīng	Kung Pao Chicken	Kung Pao Chicken / spicy diced chicken	Kung Pao Chicken / spicy diced chicken	
-Gourmet 2	卤肉饭		lǔ ròu fàn	lǔ ròu fàn	Braised pork on rice	Braised pork on rice	Braised pork on rice	
-Gourmet 2	馒头	饅頭	mán tou	mán tou	steamed bread	steamed roll / steamed bun / steamed bread / CL: 個｜个	steamed roll / steamed bun / steamed bread / CL: 個｜个	
-Gourmet 2	保		Bǎo   bǎo	Bǎo   bǎo	Insurance	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure	
-Gourmet 2	卤	滷	lǔ   lǔ	lǔ   lǔ	halogen	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid	
-Gourmet 2	馒	饅	mán	mán	steamed bread	steamed bread	steamed bread	
-Gourmet 2	丁		Dīng   dīng	Dīng   dīng	Ding	surname Ding  fourth of the ten Heavenly Stems 十天干 / fourth in order / letter 'D' or roman 'IV' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 195° / butyl / cubes (of food)	surname Ding  fourth of the ten Heavenly Stems 十天干 / fourth in order / letter 'D' or roman 'IV' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 195° / butyl / cubes (of food)	
-Internet Slang	豪		háo	háo	Howe	grand / heroic	grand / heroic	
-Internet Slang	宅		zhái	zhái	House	residence / (coll.) to stay in at home / to hang around at home	residence / (coll.) to stay in at home / to hang around at home	
-Internet Slang	土		Tǔ   tǔ	Tǔ   tǔ	soil	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音	
-Internet Slang	土豪		tǔ háo	tǔ háo	Local tycoon	local tyrant / local strong man / (slang) nouveau riche	local tyrant / local strong man / (slang) nouveau riche	
-Internet Slang	吃货	吃貨	chī huò	chī huò	Food goods	chowhound / foodie / a good-for-nothing	chowhound / foodie / a good-for-nothing	
-Internet Slang	宅男		zhái nán	zhái nán	Takuotoko	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	
-Internet Slang	菜鸟	菜鳥	cài niǎo	cài niǎo	Rookie	(coll.) sb new to a particular subject / rookie / beginner / newbie	(coll.) sb new to a particular subject / rookie / beginner / newbie	
-Internet Slang	美图		měi tú	měi tú	Mito			
-Internet Slang	萌		méng	méng	Sprout	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	
-Internet Slang	自拍		zì pāi	zì pāi	Selfie	to take a picture or video of oneself	to take a picture or video of oneself	
-Internet Slang	囧		jiǒng	jiǒng	Oops	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	
-Internet Slang	美眉		měi méi	měi méi	Meimei	(coll.) pretty girl	(coll.) pretty girl	
-Internet Slang	高富帅	高富帥	gāo fù shuài	gāo fù shuài	Tall, rich and handsome	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	
-Internet Slang	眉		méi	méi	eyebrow	eyebrow / upper margin	eyebrow / upper margin	
-Internet Slang	富		Fù   fù	Fù   fù	rich	surname Fu  rich / abundant / wealthy	surname Fu  rich / abundant / wealthy	
-Internet Slang	微博		wēi bó	wēi bó	BiHiroshi	micro-blogging / microblog	micro-blogging / microblog	
-Internet Slang	微信		Wēi xìn	Wēi xìn	Micro letter	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	
-Internet Slang	朋友圈		Péng you quān	Péng you quān	Circle of friends	Moments (social networking function of smartphone app WeChat 微信)	Moments (social networking function of smartphone app WeChat 微信)	
-Internet Slang	微		Wēi   wēi	Wēi   wēi	micro-	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]	
-Internet Slang	圈		juān   juàn   quān	juān   juàn   quān	ring	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle	
-Internet Slang	关注	關注	guān zhù	guān zhù	attention	to pay attention to / to follow sth closely / concern / interest / attention	to pay attention to / to follow sth closely / concern / interest / attention	
-Internet Slang	赞	贊	zàn	zàn	awesome	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	
-Internet Slang	转发	轉發	zhuǎn fā	zhuǎn fā	Forwarded	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	
-Internet Slang	好友		hǎo yǒu	hǎo yǒu	Friends	close friend / pal / (social networking website) friend / CL: 個｜个	close friend / pal / (social networking website) friend / CL: 個｜个	
-Internet Slang	粉丝	粉絲	fěn sī	fěn sī	Fans	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	
-Internet Slang	分享		fēn xiǎng	fēn xiǎng	share it	to share (let others have some of sth good)	to share (let others have some of sth good)	
-Internet Slang	评论	評論	píng lùn	píng lùn	comment	to comment on / to discuss / comment / commentary / CL: 篇	to comment on / to discuss / comment / commentary / CL: 篇	
-Internet Slang	粉		fěn	fěn	powder	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink	
-Internet Slang	丝	絲	sī	sī	wire	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc	
-Internet Slang	享		xiǎng	xiǎng	enjoy	to enjoy / to benefit / to have the use of	to enjoy / to benefit / to have the use of	
-Internet Slang	评	評	píng	píng	Review	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)	
-Internet Slang	论	論	Lún   lùn	Lún   lùn	s	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)	
-Business 1	销	銷	xiāo	xiāo	pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin	
-Business 1	收据	收據	shōu jù	shōu jù	receipt	receipt / CL: 張｜张	receipt / CL: 張｜张	
-Business 1	报销	報銷	bào xiāo	bào xiāo	Submit an expense account	to submit an expense account / to apply for reimbursement / to write off / to wipe out	to submit an expense account / to apply for reimbursement / to write off / to wipe out	
-Business 1	费用	費用	fèi yòng	fèi yòng	cost	cost / expenditure / expense / CL: 筆｜笔, 個｜个	cost / expenditure / expense / CL: 筆｜笔, 個｜个	
-Business 1	尽快	儘快	jǐn kuài   jìn kuài	jǐn kuài   jìn kuài	ASAP	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	
-Business 1	回复	回復	huí fù	huí fù	Reply	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	
-Business 1	报告	報告	bào gào	bào gào	report	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	
-Business 1	协议	協議	xié yì	xié yì	protocol	agreement / pact / protocol / CL: 項｜项	agreement / pact / protocol / CL: 項｜项	
-Business 1	尽	儘	jǐn   jìn	jǐn   jìn	Exhausted	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely	
-Business 1	协	協	xié	xié	Assist	to cooperate / to harmonize / to help / to assist / to join	to cooperate / to harmonize / to help / to assist / to join	
-Business 1	合同		hé tong	hé tong	contract	(business) contract / CL: 個｜个	(business) contract / CL: 個｜个	
-Business 1	项目	項目	xiàng mù	xiàng mù	project	item / project / (sports) event / CL: 個｜个	item / project / (sports) event / CL: 個｜个	
-Business 1	签名	簽名	qiān míng	qiān míng	signature	to sign (one's name with a pen etc) / to autograph / signature	to sign (one's name with a pen etc) / to autograph / signature	
-Business 1	汇报	匯報	huì bào   huì bào	huì bào   huì bào	report	to report / to give an account of / to collect information and report back  to report / to give an account of / report	to report / to give an account of / to collect information and report back  to report / to give an account of / report	
-Business 1	合		gě   hé	gě   hé	Close	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒	
-Business 1	项	項	Xiàng   xiàng	Xiàng   xiàng	item	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc	
-Business 1	汇	匯	huì   huì	huì   huì	exchange	to remit / to converge (of rivers) / to exchange  class / collection	to remit / to converge (of rivers) / to exchange  class / collection	
-Business 1	广告	廣告	guǎng gào	guǎng gào	ad	to advertise / a commercial / advertisement / CL: 項｜项	to advertise / a commercial / advertisement / CL: 項｜项	
-Business 1	预算	預算	yù suàn	yù suàn	budget	budget	budget	
-Business 1	资本	資本	zī běn	zī běn	capital	capital (economics)	capital (economics)	
-Business 1	低		dī	dī	low	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	
-Business 1	广	廣	Guǎng   guǎng	Guǎng   guǎng	wide	surname Guang  wide / numerous / to spread	surname Guang  wide / numerous / to spread	
-Business 1	资	資	zī	zī	Capital	resources / capital / to provide / to supply / to support / money / expense	resources / capital / to provide / to supply / to support / money / expense	
-Business 2	险	險	xiǎn	xiǎn	risk	danger / dangerous / rugged	danger / dangerous / rugged	
-Business 2	投		tóu	tóu	cast	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of	
-Business 2	保险	保險	bǎo xiǎn	bǎo xiǎn	Insurance	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	
-Business 2	风险	風險	fēng xiǎn	fēng xiǎn	risk	risk / hazard	risk / hazard	
-Business 2	投资	投資	tóu zī	tóu zī	investment	investment / to invest	investment / to invest	
-Business 2	律师	律師	lǜ shī	lǜ shī	lawyer	lawyer	lawyer	
-Business 2	版权	版權	bǎn quán	bǎn quán	copyright	copyright	copyright	
-Business 2	咨询	咨詢	zī xún	zī xún	advisory	to consult / to seek advice / consultation / (sales) inquiry (formal)	to consult / to seek advice / consultation / (sales) inquiry (formal)	
-Business 2	律		Lǜ   lǜ	Lǜ   lǜ	law	surname Lü  law	surname Lü  law	
-Business 2	版		bǎn	bǎn	Version	a register / block of printing / edition / version / page	a register / block of printing / edition / version / page	
-Business 2	咨		zī	zī	Advisory	to consult	to consult	
-Business 2	权	權	Quán   quán	Quán   quán	right	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary	
-Business 2	询	詢	xún	xún	Query	to ask about / to inquire about	to ask about / to inquire about	
-Business 2	保持		bǎo chí	bǎo chí	maintain	to keep / to maintain / to hold / to preserve	to keep / to maintain / to hold / to preserve	
-Business 2	联系	聯繫	lián xì	lián xì	contact	connection / contact / relation / to get in touch with / to integrate / to link / to touch	connection / contact / relation / to get in touch with / to integrate / to link / to touch	
-Business 2	联	聯	lián	lián	United	to ally / to unite / to join / (poetry) antithetical couplet	to ally / to unite / to join / (poetry) antithetical couplet	
-Business 2	持		chí	chí	hold	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control	
-Business 2	合作		hé zuò	hé zuò	Cooperation	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	
-Business 2	愉快		yú kuài	yú kuài	happy	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	
-Business 2	辛苦		xīn kǔ	xīn kǔ	hard	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	
-Business 2	感谢	感謝	gǎn xiè	gǎn xiè	thank	(express) thanks / gratitude / grateful / thankful / thanks	(express) thanks / gratitude / grateful / thankful / thanks	
-Business 2	愉		yú	yú	Discovery	pleased	pleased	
-Business 2	辛		Xīn   xīn	Xīn   xīn	Xin	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa	
-Emergency	伤	傷	shāng	shāng	hurt	to injure / injury / wound	to injure / injury / wound	
-Emergency	受		shòu	shòu	Suffer	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)	
-Emergency	救		jiù	jiù	save	to save / to assist / to rescue	to save / to assist / to rescue	
-Emergency	警		jǐng	jǐng	police	to alert / to warn / police	to alert / to warn / police	
-Emergency	报警	報警	bào jǐng	bào jǐng	Call the police	to sound an alarm / to report sth to the police	to sound an alarm / to report sth to the police	
-Emergency	救护车	救護車	jiù hù chē	jiù hù chē	ambulance	ambulance / CL: 輛｜辆	ambulance / CL: 輛｜辆	
-Emergency	受伤	受傷	shòu shāng	shòu shāng	Injured	to sustain injuries / wounded (in an accident etc) / harmed	to sustain injuries / wounded (in an accident etc) / harmed	
-Emergency	救命		jiù mìng	jiù mìng	Help	to save sb's life / (interj.) Help! / Save me!	to save sb's life / (interj.) Help! / Save me!	
-Emergency	发生	發生	fā shēng	fā shēng	occur	to happen / to occur / to take place / to break out	to happen / to occur / to take place / to break out	
-Emergency	意外		yì wài	yì wài	accident	unexpected / accident / mishap / CL: 個｜个	unexpected / accident / mishap / CL: 個｜个	
-Emergency	严重	嚴重	yán zhòng	yán zhòng	serious	grave / serious / severe / critical	grave / serious / severe / critical	
-Emergency	严	嚴	Yán   yán	Yán   yán	strict	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father	
-Emergency	命		mìng	mìng	Life	life / fate / order or command / to assign a name, title etc	life / fate / order or command / to assign a name, title etc	
-Emergency	偷		tōu	tōu	steal	to steal / to pilfer / to snatch / thief / stealthily	to steal / to pilfer / to snatch / thief / stealthily	
-Emergency	警察		jǐng chá	jǐng chá	Policemen	police / police officer / CL: 個｜个	police / police officer / CL: 個｜个	
-Emergency	察		Chá   chá	Chá   chá	Observe	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident	
-Work 3	奖	獎	jiǎng	jiǎng	prize	prize / award / encouragement / CL: 個｜个	prize / award / encouragement / CL: 個｜个	
-Work 3	工资	工資	gōng zī	gōng zī	wage	wages / pay / CL: 個｜个, 份, 月	wages / pay / CL: 個｜个, 份, 月	
-Work 3	加班		jiā bān	jiā bān	Overtime	to work overtime	to work overtime	
-Work 3	奖金	獎金	jiǎng jīn	jiǎng jīn	bonus	premium / award money / bonus	premium / award money / bonus	
-Work 3	生意		shēng yì   shēng yi	shēng yì   shēng yi	business	life force / vitality  business / CL: 筆｜笔	life force / vitality  business / CL: 筆｜笔	
-Work 3	压力	壓力	yā lì	yā lì	pressure	pressure	pressure	
-Work 3	责任	責任	zé rèn	zé rèn	responsibility	responsibility / blame / duty / CL: 個｜个	responsibility / blame / duty / CL: 個｜个	
-Work 3	商量		shāng liang	shāng liang	discuss	to consult / to talk over / to discuss	to consult / to talk over / to discuss	
-Work 3	意见	意見	yì jiàn	yì jiàn	opinion	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	
-Work 3	压	壓	yā   yà	yā   yà	Press	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿	
-Work 3	责	責	zé	zé	responsibility	duty / responsibility / to reproach / to blame	duty / responsibility / to reproach / to blame	
-Work 3	任		Rén   rèn	Rén   rèn	Any	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)	
-Work 3	误会	誤會	wù huì	wù huì	misunderstanding	to misunderstand / to mistake / misunderstanding / CL: 個｜个	to misunderstand / to mistake / misunderstanding / CL: 個｜个	
-Work 3	抱歉		bào qiàn	bào qiàn	Sorry	to be sorry / to feel apologetic / sorry!	to be sorry / to feel apologetic / sorry!	
-Work 3	原谅	原諒	yuán liàng	yuán liàng	forgive	to excuse / to forgive / to pardon	to excuse / to forgive / to pardon	
-Work 3	误	誤	wù	wù	error	mistake / error / to miss / to harm / to delay / to neglect / mistakenly	mistake / error / to miss / to harm / to delay / to neglect / mistakenly	
-Work 3	抱		bào	bào	hold	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish	
-Work 3	原		Yuán   yuán	Yuán   yuán	original	Hara (Japanese surname)  former / original / primary / raw / level / cause / source	Hara (Japanese surname)  former / original / primary / raw / level / cause / source	
-Work 3	歉		qiàn	qiàn	apologize	to apologize / to regret / deficient	to apologize / to regret / deficient	
-Work 3	谅	諒	liàng	liàng	Forgive	to show understanding / to excuse / to presume / to expect	to show understanding / to excuse / to presume / to expect	
-Weather 2	干燥	乾燥	gān zào	gān zào	dry	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	
-Weather 2	暖和		nuǎn huo	nuǎn huo	warm	warm / nice and warm	warm / nice and warm	
-Weather 2	凉快	涼快	liáng kuai	liáng kuai	Cool off	nice and cold / pleasantly cool	nice and cold / pleasantly cool	
-Weather 2	燥		zào	zào	dry	dry / parched / impatient	dry / parched / impatient	
-Weather 2	暖		nuǎn	nuǎn	warm	warm / to warm	warm / to warm	
-Weather 2	凉	涼	Liáng   liáng   liàng	Liáng   liáng   liàng	cool	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down	
-Weather 2	温度	溫度	wēn dù	wēn dù	temperature	temperature / CL: 個｜个	temperature / CL: 個｜个	
-Weather 2	大约	大約	dà yuē	dà yuē	about	approximately / probably	approximately / probably	
-Weather 2	温	溫	Wēn   wēn	Wēn   wēn	temperature	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟	
-Duo	鹰	鷹	yīng	yīng	eagle	eagle / falcon / hawk	eagle / falcon / hawk	
-Duo	羽		yǔ	yǔ	feather	feather / 5th note in pentatonic scale	feather / 5th note in pentatonic scale	
-Duo	橙		chéng	chéng	Orange	orange tree / orange (color)	orange tree / orange (color)	
-Duo	猫头鹰	貓頭鷹	māo tóu yīng	māo tóu yīng	owl	owl	owl	
-Duo	羽毛		yǔ máo	yǔ máo	feather	feather / plumage / plume	feather / plumage / plume	
-Duo	多儿		duō er	duō er	And more children			
-Duo	鼓励	鼓勵	gǔ lì	gǔ lì	encourage	to encourage	to encourage	
-Duo	提醒		tí xǐng	tí xǐng	remind	to remind / to call attention to / to warn of	to remind / to call attention to / to warn of	
-Duo	懒	懶	lǎn	lǎn	lazy	lazy	lazy	
-Duo	放弃	放棄	fàng qì	fàng qì	give up	to renounce / to abandon / to give up	to renounce / to abandon / to give up	
-Duo	鼓		gǔ	gǔ	drum	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell	
-Duo	励	勵	Lì   lì	Lì   lì	Encourage	surname Li  to encourage / to urge	surname Li  to encourage / to urge	
-Duo	醒		xǐng	xǐng	wake	to wake up / to be awake / to become aware / to sober up / to come to	to wake up / to be awake / to become aware / to sober up / to come to	
-Duo	弃	棄	qì	qì	abandoned	to abandon / to relinquish / to discard / to throw away	to abandon / to relinquish / to discard / to throw away	
+Lesson	Simplified Chinese	Traditional Chinese	Primary pinyin	CC-CEDICT pinyin	Google_Translate_Definition	Primary English definition	CC-CEDICT English definition	Labels	Alternate Occurences
+Greeting 1	你		nǐ		you	you			你 (Greeting 1), 你们 (Occupation)
+Greeting 1	好		hǎo   hào		it is good	good			好 (Greeting 1), 好久不见 (Greeting 4), 爱好 (Hobbies 2), 好 (Hobbies 2), 不好意思 (Invitiation 1), 好吃 (Dining 3), 好喝 (Dining 3), 好看 (Shopping 2), 好在 (Sports 2), 好笑 (Personality and Feelings), 好友 (Internet Slang)
+Greeting 1	再见	再見	zài jiàn		Goodbye	see you again later			No Matches Found
+Greeting 1	再		zài		again	again			再见 (Greeting 1), 再 (Greeting 1), 再 (Phrases 2)
+Greeting 1	见	見	jiàn		see	to see			再见 (Greeting 1), 见 (Greeting 1), 见 (Greeting 4), 好久不见 (Greeting 4), 见 (Location 4), 见面 (Daily Routine 3), 意见 (Work 3)
+Numbers	三		sān		three	3			No Matches Found
+Numbers	一		yī		One	1			一 (Numbers), 一会儿 (Greeting 4), 一点儿 (Telephone), 一共 (Payment), 一下 (Restaurant), 一点儿 (Languages), 一起 (Invitiation 1), 一定 (Health 2), 一样 (Family 3), 一边 (Daily Routine 2), 一直 (Location 6), 一般 (Daily Routine 3), 一个人 (Daily Routine 3)
+Numbers	七		qī		Seven	7			No Matches Found
+Numbers	八		bā		Eight	8			No Matches Found
+Numbers	十		shí		ten	10			No Matches Found
+Numbers	零		líng		zero	zero			No Matches Found
+Numbers	元		Yuán		yuan	Chinese yuan currency unit			No Matches Found
+Numbers	五		wǔ		Fives	5			No Matches Found
+Numbers	九		jiǔ		nine	9			No Matches Found
+Numbers	百		bǎi		hundred	100			No Matches Found
+Numbers	二		èr		two	2			No Matches Found
+Numbers	四		sì		four	4			No Matches Found
+Numbers	六		liù		six	6			No Matches Found
+Name	叫		jiào		call	to be called			No Matches Found
+Name	我		wǒ		I	I			我 (Name), 我们 (Occupation)
+Name	张	張	Zhāng		Zhang	surname Zhang			张 (Name), 张 (Existence), 紧张 (Personality and Feelings)
+Name	李		Lǐ		Plum	surname Li			李 (Name), 李 (Name), 行李 (Travel 2)
+Name	华	華	Huá		China	given name Huá			No Matches Found
+Name	明		míng		Bright			Meaning off-topic	明 (Name), 明天 (Time 1), 明 (Time 1), 明白 (Telephone), 明年 (Time 2), 明星 (Entertainment), 聪明 (People 2)
+Name	名字		míng zi		first name	name			No Matches Found
+Name	什么	什麼	shén me		what	what?			什么 (Name), 为什么 (Hobbies 2)
+Name	名		míng		name			Meaning off-topic	名字 (Name), 名 (Name), 有名 (Culture), 签名 (Business 1)
+Name	字		zì		word	letter			名字 (Name), 字 (Name), 字 (Languages), 汉字 (Languages 2)
+Name	什		shén   shí		Assorted			Meaning off-topic	什么 (Name), 什 (Name), 为什么 (Hobbies 2)
+Name	么	麼	má   ma   me		What			Meaning off-topic	什么 (Name), 么 (Name), 怎么样 (Greeting 3), 怎么 (Location 3), 为什么 (Hobbies 2), 怎么办 (Travel), 多么 (Culture)
+Name	姓		xìng		surname	Family name			No Matches Found
+Name	王		Wáng		king	surname Wang			No Matches Found
+Name	呢		ne		It	question particle			No Matches Found
+Greeting 2	很		hěn		very	very			No Matches Found
+Greeting 2	高兴	高興	gāo xìng		happy	happy			No Matches Found
+Greeting 2	高		gāo		high	tall			高兴 (Greeting 2), 高 (Greeting 2), 高 (People 1), 提高 (Languages 2), 高中 (School 2), 高富帅 (Internet Slang)
+Greeting 2	兴	興	xìng		Interest			Meaning off-topic	高兴 (Greeting 2), 兴 (Greeting 2), 兴趣 (Hobbies 3), 感兴趣 (Hobbies 3)
+Greeting 2	认识	認識	rèn shi		understanding	to know			No Matches Found
+Greeting 2	也		yě		and also	too			No Matches Found
+Greeting 2	认	認	rèn		recognize			Meaning off-topic	认识 (Greeting 2), 认 (Greeting 2), 认真 (Future), 认为 (Work 2)
+Greeting 2	识	識	shí   zhì		knowledge			Meaning off-topic	认识 (Greeting 2), 识 (Greeting 2)
+Food 1	吃		chī	chī	eat	to eat	to eat / to consume / to eat at (a cafeteria etc) / to eradicate / to destroy / to absorb / to suffer / to stammer (Taiwan pr. for this sense is [ji2])		吃 (Food 1), 好吃 (Dining 3), 难吃 (Food 3), 吃货 (Internet Slang)
+Food 1	饭	飯	fàn	fàn	rice	food	food / cuisine / cooked rice / meal / CL: 碗, 頓｜顿		饭 (Food 1), 饭馆 (Location 2), 早饭 (Daily Routine 1), 午饭 (Daily Routine 1), 晚饭 (Daily Routine 1), 米饭 (Dining 1), 炒饭 (Gourmet 1), 卤肉饭 (Gourmet 2)
+Food 1	鱼	魚	yú	Yú   yú	fish	fish	surname Yu  fish / CL: 條｜条, 尾		No Matches Found
+Food 1	面		miàn	miàn   miàn	surface	noodles	face / side / surface / aspect / top / classifier for flat surfaces such as drums, mirrors, flags etc  flour / noodles / (of food) soft (not crunchy) / (slang) (of a person) ineffectual / spineless		面 (Food 1), 前面 (Location 3), 后面 (Location 3), 面包 (Supermarket), 面条 (Dining 1), 外面 (Weather), 里面 (Weather), 拉面 (Gourmet 1), 上面 (Location 5), 下面 (Location 5), 见面 (Daily Routine 3), 面试 (Work 2)
+Food 1	喝		hē	hē   hè	drink	to drink	to drink / My goodness!  to shout loudly		喝 (Food 1), 好喝 (Dining 3)
+Food 1	水		shuǐ	Shuǐ   shuǐ	water	water	surname Shui  water / river / liquid / beverage / additional charges or income / (of clothes) classifier for number of washes		水 (Food 1), 水果 (Supermarket), 水平 (Languages 2)
+Food 1	茶		chá	chá	tea	tea	tea / tea plant / CL: 杯, 壺｜壶		茶 (Food 1), 珍珠奶茶 (Gourmet 2)
+Food 1	不		bù	bù	Do not	not	(negative prefix) / not / no		不 (Food 1), 不客气 (Phrases 1), 对不起 (Phrases 1), 好久不见 (Greeting 4), 不错 (Greeting 4), 不要 (Health 1), 不准 (Transportation), 不好意思 (Invitiation 1), 不但 (People 2)
+Occupation	是		shì	shì	Yes	to be	is / are / am / yes / to be		是 (Occupation), 还是 (Dining 1), 但是 (Shopping 3), 总是 (Daily Routine 2)
+Occupation	他		tā	tā	he	he	he or him / (used for either sex when the sex is unknown or unimportant) / (used before sb's name for emphasis) / (used as a meaningless mock object) / other / another		他 (Occupation), 他们 (Occupation), 其他 (Food 3)
+Occupation	学生	學生	xué sheng	xué sheng	student	student	student / schoolchild		No Matches Found
+Occupation	学	學	xué	xué	learn	to learn	to learn / to study / to imitate / science / -ology		学生 (Occupation), 学 (Occupation), 学校 (Location 3), 上学 (Daily Routine 1), 放学 (Daily Routine 1), 学习 (Hobbies 2), 同学 (School), 科学 (School), 小学 (People 3), 学 (Languages 2), 留学 (Future), 数学 (Exam), 大学 (Exam)
+Occupation	生		shēng	shēng	Raw		to be born / to give birth / life / to grow / raw / uncooked / student	Meaning off-topic	学生 (Occupation), 生 (Occupation), 医生 (Occupation), 生病 (Health 2), 生日 (Invitation 2), 生气 (Personality and Feelings), 先生 (Work), 发生 (Emergency), 生意 (Work 3)
+Occupation	吗	嗎	mǎ	mǎ   ma	It	question particle for 'yes-no' questions	see 嗎啡｜吗啡, morphine  (question particle for 'yes-no' questions)		No Matches Found
+Occupation	她		tā	tā	she was	she	she		她 (Occupation), 她们 (Occupation)
+Occupation	你们	你們	nǐ men	nǐ men	you guys	you (plural)	you (plural)		No Matches Found
+Occupation	我们	我們	wǒ men	wǒ men	we	we	we / us / ourselves / our		No Matches Found
+Occupation	他们	他們	tā men	tā men	they	they	they		No Matches Found
+Occupation	们	們	men	men	They	plural marker for pronouns	plural marker for pronouns, and nouns referring to individuals		你们 (Occupation), 我们 (Occupation), 他们 (Occupation), 们 (Occupation), 她们 (Occupation)
+Occupation	老师	老師	lǎo shī	lǎo shī	teacher	teacher	teacher / CL: 個｜个, 位		No Matches Found
+Occupation	医生	醫生	yī shēng	yī shēng	Doctors	doctor	doctor / CL: 個｜个, 位, 名		No Matches Found
+Occupation	她们	她們	tā men	tā men	they	they (females)	they / them (for females)		No Matches Found
+Occupation	老		lǎo	lǎo	old		prefix used before the surname of a person or a numeral indicating the order of birth of the children in a family or to indicate affection or familiarity / old (of people) / venerable (person) / experienced / of long standing / always / all the time / of the past / very / outdated / (of meat etc) tough	Meaning off-topic	老师 (Occupation), 老 (Occupation), 老 (People 3), 老板 (Work 2)
+Occupation	师	師	Shī   shī	Shī   shī	division		surname Shi  teacher / master / expert / model / army division / (old) troops / to dispatch troops	Meaning off-topic	老师 (Occupation), 师 (Occupation), 律师 (Business 2)
+Occupation	医	醫	yī	yī	medical		medical / medicine / doctor / to cure / to treat	Meaning off-topic	医生 (Occupation), 医 (Occupation), 医院 (Location 2)
+Contact	的		de	de   dī   dí   dì	of	of	of / ~'s (possessive particle) / (used after an attribute) / (used to form a nominal expression) / (used at the end of a declarative sentence for emphasis)  see 的士  really and truly  aim / clear		No Matches Found
+Contact	电话	電話	diàn huà	diàn huà	phone	telephone	telephone / CL: 部 / phone call / CL: 通 / phone number		电话 (Contact), 电话卡 (Travel 3)
+Contact	电	電	diàn	diàn	Electricity	electricity	electric / electricity / electrical		电话 (Contact), 电 (Contact), 电脑 (Hobbies 1), 电视 (Entertainment), 电影 (Entertainment), 充电 (Travel 3), 电话卡 (Travel 3), 电梯 (House), 电子邮件 (Communication 2)
+Contact	话	話	huà	huà	words	language	dialect / language / spoken words / speech / talk / words / conversation / what sb said / CL: 種｜种, 席, 句, 口, 番		电话 (Contact), 话 (Contact), 说话 (People 2), 话 (People 2), 电话卡 (Travel 3)
+Contact	号码	號碼	hào mǎ	hào mǎ	number	number	number / CL: 堆, 個｜个		No Matches Found
+Contact	多少		duō shǎo	duō shǎo   duō shao	How many	how many	number / amount / somewhat  how much / how many / which (number) / as much as		No Matches Found
+Contact	多		duō	duō	many	many	many / much / often / a lot of / numerous / more / in excess / how (to what extent) / multi- / Taiwan pr. [duo2] when it means 'how'		多少 (Contact), 多 (Contact), 多 (Invitation 2), 多么 (Culture), 多邻国 (Languages 3), 多儿 (Duo)
+Contact	少		shǎo	shǎo   shào	less	few	few / less / to lack / to be missing / to stop (doing sth) / seldom  young		多少 (Contact), 少 (Contact), 少 (Dining 3)
+Contact	号	號	háo   hào	háo   hào	number		roar / cry / CL: 個｜个  ordinal number / day of a month / mark / sign / business establishment / size / ship suffix / horn (wind instrument) / bugle call / assumed name / to take a pulse / classifier used to indicate number of people	Meaning off-topic	号码 (Contact), 号 (Contact), 号 (Time 1), 信号 (Communication 2)
+Contact	码	碼	mǎ	mǎ	code		weight / number / code / to pile / to stack / classifier for length or distance (yard), happenings etc	Meaning off-topic	号码 (Contact), 码 (Contact), 密码 (Communication 2), 码 (Communication 2)
+Nation	中国	中國	Zhōng guó	Zhōng guó	China	China	China		No Matches Found
+Nation	人		rén	rén	people	person	man / person / people / CL: 個｜个, 位		人 (Nation), 家人 (Family 1), 别人 (People 2), 一个人 (Daily Routine 3), 客人 (House)
+Nation	中		zhōng	Zhōng   zhōng   zhòng	in	middle	China / Chinese / surname Zhong  within / among / in / middle / center / while (doing sth) / during / (dialect) OK / all right  to hit (the mark) / to be hit by / to suffer / to win (a prize, a lottery)		中国 (Nation), 中 (Nation), 中午 (Time 2), 中文 (Hobbies 2), 中间 (Location 5), 初中 (People 3), 高中 (School 2), 中秋节 (Festivals)
+Nation	国	國	guó	Guó   guó	country	country	surname Guo  country / nation / state / national / CL: 個｜个		中国 (Nation), 国 (Nation), 英国 (Nation), 美国 (Nation), 国 (Nation), 韩国 (Entertainment), 德国 (Dining 2), 法国 (Celebration), 国家 (Future), 国际 (Travel 3), 国内 (Travel 3), 多邻国 (Languages 3)
+Nation	哪		nǎ	nǎ   na   něi	where	how / which	how / which  (particle equivalent to 啊 after noun ending in -n)  which? (interrogative, followed by classifier or numeral-classifier)		哪 (Nation), 哪儿 (Location 1), 哪里 (Location 3)
+Nation	英国	英國	Yīng guó	Yīng guó	United Kingdom	United Kingdom	United Kingdom 聯合王國｜联合王国 / United Kingdom of Great Britain and Northern Ireland / abbr. for England 英格蘭｜英格兰		No Matches Found
+Nation	美国	美國	Měi guó	Měi guó	United States	USA	United States / USA / US		No Matches Found
+Nation	英		Yīng   yīng	Yīng   yīng	English	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom		英国 (Nation), 英 (Nation), 英语 (Phrases 2), 英文 (Restaurant), 英 (Restaurant)
+Nation	美		Měi   měi	Měi   měi	nice	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself		美国 (Nation), 美 (Nation), 美术 (School), 美图 (Internet Slang), 美眉 (Internet Slang)
+Nation	都		Dū   dōu   dū	Dū   dōu   dū	All	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis		No Matches Found
+Nation	对	對	duì	duì	Correct	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple		对 (Nation), 对不起 (Phrases 1), 派对 (Invitation 2), 对 (Hobbies 3)
+Nation	加拿大		Jiā ná dà	Jiā ná dà	Canada	Canada / Canadian	Canada / Canadian		No Matches Found
+Nation	加		Jiā   jiā	Jiā   jiā	plus	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)		加拿大 (Nation), 加 (Nation), 参加 (Sports 2), 加油 (Sports 2), 加 (Internet Slang), 加班 (Work 3)
+Nation	拿		ná	ná	take	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)		加拿大 (Nation), 拿 (Nation), 拿 (Travel 4)
+Nation	大		dà   dài	dà   dài	Big	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫		加拿大 (Nation), 大 (Nation), 大家 (Invitation 2), 意大利 (Shopping 2), 大 (Shopping 2), 澳大利亚 (Time 4), 大概 (Time 4), 大学 (Exam), 大约 (Weather 2)
+Greeting 3	忙		máng	máng	busy	busy / hurriedly / to hurry / to rush	busy / hurriedly / to hurry / to rush		忙 (Greeting 3), 帮忙 (Shopping 1)
+Greeting 3	早上		zǎo shang	zǎo shang	morning	early morning / CL: 個｜个	early morning / CL: 個｜个		No Matches Found
+Greeting 3	早		zǎo	zǎo	early	early / morning / Good morning! / long ago / prematurely	early / morning / Good morning! / long ago / prematurely		早上 (Greeting 3), 早 (Greeting 3), 早安 (Greeting 4), 早饭 (Daily Routine 1), 早 (Time 3)
+Greeting 3	上		shǎng   shàng	shǎng   shàng	on	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)		早上 (Greeting 3), 上 (Greeting 3), 上午 (Time 2), 晚上 (Time 2), 上 (Time 2), 上学 (Daily Routine 1), 上班 (Daily Routine 1), 上网 (Entertainment), 上 (Location 4), 上海 (Dining 1), 上 (Travel), 上 (School), 上面 (Location 5), 马上 (Daily Routine 2), 上 (Environment)
+Greeting 3	怎么样	怎麼樣	zěn me yàng	zěn me yàng	how about it	how? / how about? / how was it? / how are things?	how? / how about? / how was it? / how are things?		No Matches Found
+Greeting 3	今天		jīn tiān	jīn tiān	Nowadays	today / at the present / now	today / at the present / now		No Matches Found
+Greeting 3	怎		zěn	zěn	How	how	how		怎么样 (Greeting 3), 怎 (Greeting 3), 怎么 (Location 3), 怎么办 (Travel)
+Greeting 3	样	樣	yàng	yàng	kind	manner / pattern / way / appearance / shape / classifier: kind, type	manner / pattern / way / appearance / shape / classifier: kind, type		怎么样 (Greeting 3), 样 (Greeting 3), 一样 (Family 3)
+Greeting 3	今		jīn	jīn	now	today / modern / present / current / this / now	today / modern / present / current / this / now		今天 (Greeting 3), 今 (Greeting 3), 今年 (Time 2)
+Greeting 3	天		tiān	tiān	day	day / sky / heaven	day / sky / heaven		今天 (Greeting 3), 天 (Greeting 3), 明天 (Time 1), 天 (Time 1), 天 (Time 2), 昨天 (Time 2), 天气 (Weather), 前天 (Time 4), 后天 (Time 4), 聊天 (Daily Routine 3)
+Location 1	家	傢	jiā   Jiā   jiā	jiā   Jiā   jiā	Family	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个	see 傢伙｜家伙  surname Jia  home / family / (polite) my (sister, uncle etc) / classifier for families or businesses / refers to the philosophical schools of pre-Han China / noun suffix for a specialist in some activity, such as a musician or revolutionary, corresponding to English -ist, -er, -ary or -ian / CL: 個｜个		家 (Location 1), 家人 (Family 1), 家 (Invitiation 1), 大家 (Invitation 2), 国家 (Future)
+Location 1	北京		Běi jīng	Běi jīng	Beijing	Beijing, capital of People's Republic of China / Peking / PRC government	Beijing, capital of People's Republic of China / Peking / PRC government		北京 (Location 1), 北京烤鸭 (Gourmet 2)
+Location 1	在		zài	zài	in	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)		在 (Location 1), 现在 (Time 1), 在 (Hobbies 1), 正在 (Invitation 2), 好在 (Sports 2)
+Location 1	北		běi	běi	north	north / to be defeated (classical)	north / to be defeated (classical)		北京 (Location 1), 北 (Location 1), 北方 (Food 3), 北边 (Location 6), 北京烤鸭 (Gourmet 2)
+Location 1	京		Jīng   jīng	Jīng   jīng	Beijing	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)		北京 (Location 1), 京 (Location 1), 北京烤鸭 (Gourmet 2)
+Location 1	哪儿	哪兒	nǎr	nǎr	where	where? / wherever / anywhere	where? / wherever / anywhere		No Matches Found
+Location 1	纽约	紐約	Niǔ yuē	Niǔ yuē	new York	New York	New York		No Matches Found
+Location 1	香港		Xiāng gǎng	Xiāng gǎng	Hong Kong	Hong Kong	Hong Kong		No Matches Found
+Location 1	儿	兒	ér   r	ér   r	child	child / son  non-syllabic diminutive suffix / retroflex final	child / son  non-syllabic diminutive suffix / retroflex final		哪儿 (Location 1), 儿 (Location 1), 一会儿 (Greeting 4), 这儿 (Location 2), 那儿 (Location 2), 女儿 (Family 2), 儿子 (Family 2), 儿 (Family 2), 一点儿 (Telephone), 有点儿 (Health 1), 一点儿 (Languages), 多儿 (Duo)
+Location 1	纽	紐	niǔ	niǔ	Button	to turn / to wrench / button / nu (Greek letter Νν)	to turn / to wrench / button / nu (Greek letter Νν)		纽约 (Location 1), 纽 (Location 1)
+Location 1	约	約	yāo   yuē	yāo   yuē	approximately	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise		纽约 (Location 1), 约 (Location 1), 约会 (Invitiation 1), 大约 (Weather 2)
+Location 1	香		xiāng	xiāng	Fragrant	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根		香港 (Location 1), 香 (Location 1), 香蕉 (Dining 2), 香 (Dining 2)
+Location 1	港		Gǎng   gǎng	Gǎng   gǎng	port	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个		香港 (Location 1), 港 (Location 1)
+Location 1	住		zhù	zhù	live	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)		No Matches Found
+Location 1	伦敦	倫敦	Lún dūn	Lún dūn	London	London, capital of United Kingdom	London, capital of United Kingdom		No Matches Found
+Location 1	台湾	臺灣	Tái wān	Tái wān	Taiwan	Taiwan	Taiwan		No Matches Found
+Location 1	伦	倫	lún	lún	Lun	human relationship / order / coherence	human relationship / order / coherence		伦敦 (Location 1), 伦 (Location 1)
+Location 1	敦		dūn	dūn	London	kindhearted / place name	kindhearted / place name		伦敦 (Location 1), 敦 (Location 1)
+Location 1	台		Tái   tái   tái   Tái   tái   tái	Tái   tái   tái   Tái   tái   tái	station	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon		台湾 (Location 1), 台 (Location 1), 柜台 (Travel 3)
+Location 1	湾	灣	wān	wān	Bay	bay / gulf / to cast anchor / to moor (a boat)	bay / gulf / to cast anchor / to moor (a boat)		台湾 (Location 1), 湾 (Location 1)
+Phrases 1	谢谢	謝謝	xiè xie	xiè xie	Thank you	to thank / thanks / thank you	to thank / thanks / thank you		No Matches Found
+Phrases 1	不客气	不客氣	bù kè qi	bù kè qi	You're welcome	you're welcome / don't mention it / impolite / rude / blunt	you're welcome / don't mention it / impolite / rude / blunt		No Matches Found
+Phrases 1	谢	謝	Xiè   xiè	Xiè   xiè	thank	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline		谢谢 (Phrases 1), 谢 (Phrases 1), 感谢 (Business 2)
+Phrases 1	客		kè	kè	customer	customer / visitor / guest	customer / visitor / guest		不客气 (Phrases 1), 客 (Phrases 1), 客厅 (House), 客人 (House)
+Phrases 1	气	氣	qì	qì	gas	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi		不客气 (Phrases 1), 气 (Phrases 1), 天气 (Weather), 生气 (Personality and Feelings)
+Phrases 1	对不起	對不起	duì bu qǐ	duì bu qǐ	I am sorry	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)		No Matches Found
+Phrases 1	没关系	沒關係	méi guān xi	méi guān xi	It's ok	it doesn't matter	it doesn't matter		No Matches Found
+Phrases 1	起		qǐ	qǐ	Start	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group		对不起 (Phrases 1), 起 (Phrases 1), 起床 (Daily Routine 1), 起 (Daily Routine 1), 一起 (Invitiation 1), 起飞 (Travel 2), 看起来 (Personality and Feelings)
+Phrases 1	没	沒	méi   mò	méi   mò	No	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate		没关系 (Phrases 1), 没 (Phrases 1), 没 (Family 1)
+Phrases 1	关	關	Guān   guān	Guān   guān	turn off	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve		没关系 (Phrases 1), 关 (Phrases 1), 关 (Shopping 1), 关系 (Family 3), 海关 (Travel 2), 关心 (Personality and Feelings), 关于 (Communication 2), 关注 (Internet Slang)
+Phrases 1	系	係	xì   xì   jì   xì	xì   xì   jì   xì	system	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry		没关系 (Phrases 1), 系 (Phrases 1), 关系 (Family 3), 联系 (Business 2)
+Family 1	爸爸		bà ba	bà ba	father	(informal) father / CL: 個｜个, 位	(informal) father / CL: 個｜个, 位		No Matches Found
+Family 1	妈妈	媽媽	mā ma	mā ma	mom	mama / mommy / mother / CL: 個｜个, 位	mama / mommy / mother / CL: 個｜个, 位		No Matches Found
+Family 1	爱	愛	ài	ài	Love	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)		爱 (Family 1), 可爱 (People 1), 爱好 (Hobbies 2)
+Family 1	家人		jiā rén	jiā rén	family	household / (one's) family	household / (one's) family		No Matches Found
+Family 1	爸		bà	bà	dad	father / dad / pa / papa	father / dad / pa / papa		爸爸 (Family 1), 爸 (Family 1)
+Family 1	妈	媽	mā	mā	mom	ma / mom / mother	ma / mom / mother		妈妈 (Family 1), 妈 (Family 1)
+Family 1	谁	誰	shéi	shéi	Who	who / also pr. [shui2]	who / also pr. [shui2]		No Matches Found
+Family 1	那		Nā   Nuó   nà   nuó	Nā   Nuó   nà   nuó	that	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪		那 (Family 1), 那儿 (Location 2), 那里 (Location 3)
+Family 1	个	個	gè	gè	More	individual / this / that / size / classifier for people or objects in general	individual / this / that / size / classifier for people or objects in general		个 (Family 1), 个子 (People 3), 一个人 (Daily Routine 3)
+Family 1	这	這	zhè	zhè	This	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)		这 (Family 1), 这儿 (Location 2), 这里 (Location 3)
+Family 1	哥哥		gē ge	gē ge	brother	older brother / CL: 個｜个, 位	older brother / CL: 個｜个, 位		No Matches Found
+Family 1	姐姐		jiě jie	jiě jie	sister	older sister / CL: 個｜个	older sister / CL: 個｜个		No Matches Found
+Family 1	有		yǒu	yǒu	Have	to have / there is / there are / to exist / to be	to have / there is / there are / to exist / to be		有 (Family 1), 有点儿 (Health 1), 有名 (Culture)
+Family 1	哥		gē	gē	brother	elder brother	elder brother		哥哥 (Family 1), 哥 (Family 1)
+Family 1	姐		jiě	jiě	sister	older sister	older sister		姐姐 (Family 1), 姐 (Family 1), 兄弟姐妹 (Family 3), 小姐 (Work)
+Family 1	弟弟		dì di	dì di	Little brother	younger brother / CL: 個｜个, 位	younger brother / CL: 個｜个, 位		No Matches Found
+Family 1	和		Hé   hé   hè   hú   huó   huò	Hé   hé   hè   hú   huó   huò	with	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs		和 (Family 1), 暖和 (Weather 2), 和 (Weather 2)
+Family 1	妹妹		mèi mei	mèi mei	younger sister	younger sister / young woman / CL: 個｜个	younger sister / young woman / CL: 個｜个		No Matches Found
+Family 1	弟		dì	dì	Younger brother	younger brother / junior male / I (modest word in letter)	younger brother / junior male / I (modest word in letter)		弟弟 (Family 1), 弟 (Family 1), 兄弟姐妹 (Family 3)
+Family 1	妹		mèi	mèi	sister	younger sister	younger sister		妹妹 (Family 1), 妹 (Family 1), 兄弟姐妹 (Family 3)
+Phrases 2	请问	請問	qǐng wèn	qǐng wèn	Excuse me	Excuse me, may I ask...?	Excuse me, may I ask...?		No Matches Found
+Phrases 2	知道		zhī dào	zhī dào	know	to know / to become aware of / also pr. [zhi1 dao5]	to know / to become aware of / also pr. [zhi1 dao5]		No Matches Found
+Phrases 2	问	問	wèn	wèn	ask	to ask	to ask		请问 (Phrases 2), 问 (Phrases 2), 问题 (School)
+Phrases 2	请	請	qǐng	qǐng	please	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request		请问 (Phrases 2), 请 (Phrases 2), 请 (Phrases 2), 请 (Invitiation 1), 请假 (Health 2), 请 (Dining 3)
+Phrases 2	知		zhī	zhī	know	to know / to be aware	to know / to be aware		知道 (Phrases 2), 知 (Phrases 2)
+Phrases 2	道		dào	dào	Road	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)		知道 (Phrases 2), 道 (Phrases 2), 味道 (Dining 3), 街道 (Travel 4)
+Phrases 2	说	說	shuì   shuō	shuì   shuō	Say	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)		说 (Phrases 2), 说话 (People 2)
+Phrases 2	英语	英語	Yīng yǔ	Yīng yǔ	English	English (language)	English (language)		No Matches Found
+Phrases 2	汉语	漢語	Hàn yǔ	Hàn yǔ	Chinese	Chinese language / CL: 門｜门	Chinese language / CL: 門｜门		No Matches Found
+Phrases 2	汉	漢	Hàn   hàn	Hàn   hàn	Chinese	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man		汉语 (Phrases 2), 汉 (Phrases 2), 汉字 (Languages 2)
+Phrases 2	语	語	yǔ   yù	yǔ   yù	language	dialect / language / speech  to tell to	dialect / language / speech  to tell to		英语 (Phrases 2), 汉语 (Phrases 2), 语 (Phrases 2), 西班牙语 (Hobbies 2), 语言 (Languages 2), 语法 (Languages 3)
+Phrases 2	帮助	幫助	bāng zhù	bāng zhù	help	assistance / aid / to help / to assist	assistance / aid / to help / to assist		No Matches Found
+Phrases 2	次		cì	cì	Secondary	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time		No Matches Found
+Phrases 2	帮	幫	bāng	bāng	help	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society		帮助 (Phrases 2), 帮 (Phrases 2), 帮 (Supermarket), 帮忙 (Shopping 1)
+Phrases 2	助		zhù	zhù	help	to help / to assist	to help / to assist		帮助 (Phrases 2), 助 (Phrases 2)
+Greeting 4	早安		zǎo ān	zǎo ān	good Morning	Good morning!	Good morning!		No Matches Found
+Greeting 4	晚安		wǎn ān	wǎn ān	good night	Good night! / Good evening!	Good night! / Good evening!		No Matches Found
+Greeting 4	一会儿	一會兒	yī huìr	yī huìr	Awhile	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]		No Matches Found
+Greeting 4	会	會	huì   kuài	huì   kuài	meeting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting		一会儿 (Greeting 4), 会 (Greeting 4), 会 (Time 2), 会 (Hobbies 1), 约会 (Invitiation 1), 机会 (Future), 会议 (Work), 开会 (Work 2), 聚会 (Festivals), 误会 (Work 3)
+Greeting 4	安		Ān   ān	Ān   ān	Secure	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere		早安 (Greeting 4), 晚安 (Greeting 4), 安 (Greeting 4), 安全 (Travel 2), 安静 (Environment), 西安 (Culture), 安排 (Travel 4)
+Greeting 4	最近		zuì jìn	zuì jìn	Recently	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)		No Matches Found
+Greeting 4	好久不见	好久不見	hǎo jiǔ bu jiàn	hǎo jiǔ bu jiàn	long time no see	long time no see	long time no see		No Matches Found
+Greeting 4	不错	不錯	bù cuò	bù cuò	Pretty good	correct / right / not bad / pretty good	correct / right / not bad / pretty good		No Matches Found
+Greeting 4	最		zuì	zuì	most	most / the most / -est (superlative suffix)	most / the most / -est (superlative suffix)		最近 (Greeting 4), 最 (Greeting 4), 最 (Hobbies 1), 最后 (Location 6)
+Greeting 4	近		jìn	jìn	near	near / close to / approximately	near / close to / approximately		最近 (Greeting 4), 近 (Greeting 4), 近 (Travel), 附近 (Location 5)
+Greeting 4	久		jiǔ	jiǔ	Long	(long) time / (long) duration of time	(long) time / (long) duration of time		好久不见 (Greeting 4), 久 (Greeting 4), 久 (Languages 2)
+Greeting 4	错	錯	Cuò   cuò	Cuò   cuò	wrong	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver	surname Cuo  mistake / wrong / bad / interlocking / complex / to grind / to polish / to alternate / to stagger / to miss / to let slip / to evade / to inlay with gold or silver		不错 (Greeting 4), 错 (Greeting 4), 错 (Languages)
+Drink	要		yāo   yào	yāo   yào	To	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if		要 (Drink), 不要 (Health 1), 需要 (Shopping 1), 要求 (School 2), 重要 (Work), 主要 (Communication 2)
+Drink	热	熱	rè	rè	heat	to warm up / to heat up / hot (of weather) / heat / fervent	to warm up / to heat up / hot (of weather) / heat / fervent		热 (Drink), 热情 (Personality and Feelings)
+Drink	冰		bīng	bīng	ice	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine		冰 (Drink), 冰箱 (Location 4)
+Drink	牛奶		niú nǎi	niú nǎi	milk	cow's milk / CL: 瓶, 杯	cow's milk / CL: 瓶, 杯		No Matches Found
+Drink	咖啡		kā fēi	kā fēi	coffee	coffee (loanword) / CL: 杯	coffee (loanword) / CL: 杯		咖啡 (Drink), 咖啡馆 (Location 5)
+Drink	牛		Niú   niú	Niú   niú	Cattle	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome		牛奶 (Drink), 牛 (Drink), 牛肉 (Dining 1)
+Drink	奶		nǎi   nǎi	nǎi   nǎi	milk	breast / milk / to breastfeed  mother / variant of 奶	breast / milk / to breastfeed  mother / variant of 奶		牛奶 (Drink), 奶 (Drink), 奶奶 (Family 3), 珍珠奶茶 (Gourmet 2)
+Drink	咖		kā	kā	coffee	coffee / class / grade	coffee / class / grade		咖啡 (Drink), 咖 (Drink), 咖啡馆 (Location 5)
+Drink	啡		fēi	fēi	coffee	(phonetic component)	(phonetic component)		咖啡 (Drink), 啡 (Drink), 咖啡馆 (Location 5)
+Location 2	洗手间	洗手間	xǐ shǒu jiān	xǐ shǒu jiān	Toilets	toilet / lavatory / washroom	toilet / lavatory / washroom		No Matches Found
+Location 2	医院	醫院	yī yuàn	yī yuàn	hospital	hospital / CL: 所, 家, 座	hospital / CL: 所, 家, 座		No Matches Found
+Location 2	洗		xǐ	xǐ	wash	to wash / to bathe / to develop (photo)	to wash / to bathe / to develop (photo)		洗手间 (Location 2), 洗 (Location 2), 洗 (Shopping 3), 洗澡 (Daily Routine 2)
+Location 2	手		shǒu	shǒu	hand	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只		洗手间 (Location 2), 手 (Location 2), 手机 (Entertainment), 手 (Body Parts), 手表 (Shopping 3), 分手 (Future)
+Location 2	间	間	jiān   jiàn	jiān   jiàn	between	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent		洗手间 (Location 2), 间 (Location 2), 房间 (Location 4), 间 (Location 4), 时间 (Invitiation 1), 中间 (Location 5)
+Location 2	院		yuàn	yuàn	hospital	courtyard / institution / CL: 個｜个	courtyard / institution / CL: 個｜个		医院 (Location 2), 院 (Location 2)
+Location 2	这儿	這兒	zhèr	zhèr	here	here	here		No Matches Found
+Location 2	那儿	那兒	nàr	nàr	there	there	there		No Matches Found
+Location 2	饭馆	飯館	fàn guǎn	fàn guǎn	restaurant	restaurant / CL: 家	restaurant / CL: 家		No Matches Found
+Location 2	馆	館	guǎn	guǎn	House	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家		饭馆 (Location 2), 馆 (Location 2), 馆 (Location 5), 图书馆 (Location 5), 咖啡馆 (Location 5), 体育馆 (School 2), 博物馆 (Travel 4)
+Time 1	年		Nián   nián   nián	Nián   nián   nián	year	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年		年 (Time 1), 今年 (Time 2), 去年 (Time 2), 明年 (Time 2), 新年 (Celebration), 年级 (People 3), 年轻 (People 3)
+Time 1	月		yuè	yuè	month	moon / month / monthly / CL: 個｜个, 輪｜轮	moon / month / monthly / CL: 個｜个, 輪｜轮		月 (Time 1), 月亮 (Festivals), 月饼 (Festivals)
+Time 1	几		jī   jī   jǐ	jī   jī   jǐ	a few	small table  almost  how much / how many / several / a few	small table  almost  how much / how many / several / a few		几 (Time 1), 几乎 (Travel 2), 几 (Travel 2)
+Time 1	〇		líng	líng	〇	zero	zero		No Matches Found
+Time 1	星期		xīng qī	xīng qī	week	week / CL: 個｜个 / day of the week / Sunday	week / CL: 個｜个 / day of the week / Sunday		No Matches Found
+Time 1	明天		míng tiān	míng tiān	tomorrow	tomorrow	tomorrow		No Matches Found
+Time 1	日		Rì   rì	Rì   rì	day	abbr. for 日本, Japan  sun / day / date, day of the month	abbr. for 日本, Japan  sun / day / date, day of the month		日 (Time 1), 日本 (Dining 1), 生日 (Invitation 2), 节日 (Celebration)
+Time 1	星		xīng	xīng	star	star / heavenly body / satellite / small amount	star / heavenly body / satellite / small amount		星期 (Time 1), 星 (Time 1), 明星 (Entertainment), 星星 (Environment)
+Time 1	期		qī	qī	period	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]		星期 (Time 1), 期 (Time 1)
+Time 1	点	點	diǎn	diǎn	point	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items		点 (Time 1), 一点儿 (Telephone), 点菜 (Restaurant), 有点儿 (Health 1), 一点儿 (Languages), 甜点 (Dining 3), 点心 (Gourmet 1), 点 (Internet Slang)
+Time 1	现在	現在	xiàn zài	xiàn zài	just now	now / at present / at the moment / modern / current / nowadays	now / at present / at the moment / modern / current / nowadays		No Matches Found
+Time 1	半		bàn	bàn	half	half / semi- / incomplete / (after a number) and a half	half / semi- / incomplete / (after a number) and a half		No Matches Found
+Time 1	现	現	xiàn	xiàn	Present	to appear / present / now / existing / current	to appear / present / now / existing / current		现在 (Time 1), 现 (Time 1), 现金 (Payment), 发现 (Travel 2), 表现 (Work 2)
+Family 2	孩子		hái zi	hái zi	child	child	child		No Matches Found
+Family 2	两	兩	liǎng	liǎng	Two	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)		No Matches Found
+Family 2	孩		hái	hái	child	child	child		孩子 (Family 2), 孩 (Family 2)
+Family 2	子		zǐ   zi	zǐ   zi	child	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)		孩子 (Family 2), 子 (Family 2), 儿子 (Family 2), 妻子 (Family 2), 桌子 (Location 4), 椅子 (Location 4), 杯子 (Dining 2), 盘子 (Dining 2), 筷子 (Dining 2), 勺子 (Dining 2), 瓶子 (Existence), 肚子 (Health 2), 裙子 (Shopping 2), 鞋子 (Shopping 2), 裤子 (Shopping 2), 鼻子 (Body Parts), 帽子 (Shopping 3), 包子 (Gourmet 1), 袋子 (Shopping 4), 饺子 (Food 3), 个子 (People 3), 句子 (Languages 3), 电子邮件 (Communication 2), 粽子 (Festivals)
+Family 2	女儿	女兒	nǚ ér	nǚ ér	daughter	daughter	daughter		No Matches Found
+Family 2	儿子	兒子	ér zi	ér zi	son	son	son		No Matches Found
+Family 2	岁	歲	suì	suì	year old	classifier for years (of age) / year / year (of crop harvests)	classifier for years (of age) / year / year (of crop harvests)		No Matches Found
+Family 2	女		nǚ	nǚ	Female	female / woman / daughter	female / woman / daughter		女儿 (Family 2), 女 (Family 2), 女 (People 1)
+Family 2	妻子		qī zǐ   qī zi	qī zǐ   qī zi	wife	wife and children  wife / CL: 個｜个	wife and children  wife / CL: 個｜个		No Matches Found
+Family 2	丈夫		zhàng fu	zhàng fu	husband	husband / CL: 個｜个	husband / CL: 個｜个		No Matches Found
+Family 2	妻		qī   qì	qī   qì	wife	wife  to marry off (a daughter)	wife  to marry off (a daughter)		妻子 (Family 2), 妻 (Family 2)
+Family 2	丈		zhàng	zhàng	length	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male		丈夫 (Family 2), 丈 (Family 2)
+Family 2	夫		fū   fú	fū   fú	husband	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)		丈夫 (Family 2), 夫 (Family 2), 功夫 (Hobbies 3)
+Family 2	猫	貓	māo	māo	Cat	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem		猫 (Family 2), 熊猫 (Culture), 猫头鹰 (Duo)
+Family 2	它		tā	tā	it	it	it		No Matches Found
+Family 2	狗		gǒu	gǒu	dog	dog / CL: 隻｜只, 條｜条	dog / CL: 隻｜只, 條｜条		No Matches Found
+Telephone	喂		wéi   wèi   wèi	wéi   wèi   wèi	Hey	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed		No Matches Found
+Telephone	慢		màn	màn	slow	slow	slow		No Matches Found
+Telephone	一点儿		yī diǎnr	yī diǎnr	a little	erhua variant of 一點｜一点	erhua variant of 一點｜一点		一点儿 (Telephone), 一点儿 (Languages)
+Telephone	快		kuài	kuài	fast	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant		快 (Telephone), 快乐 (Celebration), 尽快 (Business 1), 愉快 (Business 2), 凉快 (Weather 2)
+Telephone	得		dé   de   děi	dé   de   děi	Get	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to		得 (Telephone), 得 (Health 1), 觉得 (Health 1), 得 (Travel), 记得 (Exam)
+Telephone	明白		míng bai	míng bai	understand	clear / obvious / unequivocal / to understand / to realize	clear / obvious / unequivocal / to understand / to realize		No Matches Found
+Telephone	白		Bái   bái	Bái   bái	White	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera		明白 (Telephone), 白 (Telephone), 白 (Shopping 3), 白酒 (Celebration)
+People 1	漂亮		piào liang	piào liang	Pretty	pretty / beautiful	pretty / beautiful		No Matches Found
+People 1	漂		piāo   piǎo   piào	piāo   piǎo   piào	drift	to float / to drift  to bleach  elegant / polished	to float / to drift  to bleach  elegant / polished		漂亮 (People 1), 漂 (People 1)
+People 1	亮		liàng	liàng	bright	bright / clear / resonant / to shine / to show / to reveal	bright / clear / resonant / to shine / to show / to reveal		漂亮 (People 1), 亮 (People 1), 月亮 (Festivals)
+People 1	朋友		péng you	péng you	friend	friend / CL: 個｜个, 位	friend / CL: 個｜个, 位		朋友 (People 1), 朋友圈 (Internet Slang)
+People 1	男		nán	nán	male	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个		男 (People 1), 宅男 (Internet Slang)
+People 1	矮		ǎi	ǎi	short	low / short (in length)	low / short (in length)		No Matches Found
+People 1	朋		péng	péng	Friend	friend	friend		朋友 (People 1), 朋 (People 1), 朋友圈 (Internet Slang)
+People 1	友		yǒu	yǒu	Friendly	friend	friend		朋友 (People 1), 友 (People 1), 朋友圈 (Internet Slang), 好友 (Internet Slang)
+People 1	可爱	可愛	kě ài	kě ài	lovely	adorable / cute / lovely	adorable / cute / lovely		No Matches Found
+People 1	非常		fēi cháng	fēi cháng	very much	very / very much / unusual / extraordinary	very / very much / unusual / extraordinary		No Matches Found
+People 1	可		kě   kè	kě   kè	can	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗		可爱 (People 1), 可 (People 1), 可以 (Transportation), 可能 (Weather), 可怕 (Personality and Feelings)
+People 1	非		Fēi   fēi	Fēi   fēi	non-	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must		非常 (People 1), 非 (People 1)
+People 1	常		Cháng   cháng	Cháng   cháng	often	surname Chang  always / ever / often / frequently / common / general / constant	surname Chang  always / ever / often / frequently / common / general / constant		非常 (People 1), 常 (People 1), 经常 (Personality and Feelings)
+Time 2	上午		shàng wǔ	shàng wǔ	morning	morning / CL: 個｜个	morning / CL: 個｜个		No Matches Found
+Time 2	分		fēn   fèn	fēn   fèn	Minute	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component		分 (Time 2), 分 (Payment), 分钟 (Time 3), 分手 (Future), 分享 (Internet Slang)
+Time 2	下午		xià wǔ	xià wǔ	in the afternoon	afternoon / CL: 個｜个 / p.m.	afternoon / CL: 個｜个 / p.m.		No Matches Found
+Time 2	晚上		wǎn shang	wǎn shang	at night	evening / night / CL: 個｜个 / in the evening	evening / night / CL: 個｜个 / in the evening		No Matches Found
+Time 2	午		wǔ	wǔ	Noon	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)		上午 (Time 2), 下午 (Time 2), 午 (Time 2), 中午 (Time 2), 午饭 (Daily Routine 1), 端午节 (Festivals)
+Time 2	晚		wǎn	wǎn	late	evening / night / late	evening / night / late		晚安 (Greeting 4), 晚上 (Time 2), 晚 (Time 2), 晚饭 (Daily Routine 1), 晚 (Time 3)
+Time 2	下		xià	xià	under	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action		下午 (Time 2), 下 (Time 2), 下 (Time 2), 下班 (Daily Routine 1), 下 (Location 4), 一下 (Restaurant), 下 (Transportation), 下 (Weather), 下课 (School), 下面 (Location 5), 下 (Environment), 下载 (Languages 3)
+Time 2	每		měi	měi	each	each / every	each / every		No Matches Found
+Time 2	中午		zhōng wǔ	zhōng wǔ	noon	noon / midday / CL: 個｜个	noon / midday / CL: 個｜个		No Matches Found
+Time 2	周末	週末	zhōu mò	zhōu mò	weekend	weekend	weekend		No Matches Found
+Time 2	周		Zhōu   zhōu   zhōu	Zhōu   zhōu   zhōu	week	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周		周末 (Time 2), 周 (Time 2), 周围 (Location 6)
+Time 2	末		mò	mò	end	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man		周末 (Time 2), 末 (Time 2)
+Time 2	昨天		zuó tiān	zuó tiān	yesterday	yesterday	yesterday		No Matches Found
+Time 2	了		le   liǎo   liǎo	le   liǎo   liǎo	The	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly		了 (Time 2), 了 (Payment), 了 (Health 2), 除了 (Food 3), 为了 (Hobbies 3), 了解 (Hobbies 3), 了 (Hobbies 3)
+Time 2	做		zuò	zuò	do	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance		做 (Time 2), 做 (Daily Routine 1), 做梦 (Daily Routine 2)
+Time 2	昨		zuó	zuó	Yesterday	yesterday	yesterday		昨天 (Time 2), 昨 (Time 2)
+Time 2	今年		jīn nián	jīn nián	this year	this year	this year		No Matches Found
+Time 2	去年		qù nián	qù nián	last year	last year	last year		No Matches Found
+Time 2	明年		míng nián	míng nián	next year	next year	next year		No Matches Found
+Time 2	去		qù	qù	go with	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)		去年 (Time 2), 去 (Time 2), 去 (Hobbies 2), 出去 (Invitiation 1), 去 (Environment), 过去 (Communication 2)
+Location 3	旁边	旁邊	páng biān	páng biān	next to	lateral / side / to the side / beside	lateral / side / to the side / beside		No Matches Found
+Location 3	左边	左邊	zuǒ bian	zuǒ bian	left	left / the left side / to the left of	left / the left side / to the left of		No Matches Found
+Location 3	右边	右邊	yòu bian	yòu bian	right	right side / right, to the right	right side / right, to the right		No Matches Found
+Location 3	旁		páng	páng	Beside	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic		旁边 (Location 3), 旁 (Location 3)
+Location 3	左		Zuǒ   zuǒ	Zuǒ   zuǒ	left	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐		左边 (Location 3), 左 (Location 3), 左 (Location 6)
+Location 3	右		yòu	yòu	right	right (-hand) / the Right (politics) / west (old)	right (-hand) / the Right (politics) / west (old)		右边 (Location 3), 右 (Location 3), 右 (Location 6)
+Location 3	边	邊	biān   bian	biān   bian	side	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality		旁边 (Location 3), 左边 (Location 3), 右边 (Location 3), 边 (Location 3), 一边 (Daily Routine 2), 西边 (Location 6), 东边 (Location 6), 北边 (Location 6), 南边 (Location 6), 海边 (Travel 4)
+Location 3	前面		qián miàn	qián miàn	front	ahead / in front / preceding / above / also pr. [qian2 mian5]	ahead / in front / preceding / above / also pr. [qian2 mian5]		No Matches Found
+Location 3	后面	後面	hòu miàn	hòu miàn	Behind	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	rear / back / behind / later / afterwards / also pr. [hou4 mian5]		No Matches Found
+Location 3	学校	學校	xué xiào	xué xiào	school	school / CL: 所	school / CL: 所		No Matches Found
+Location 3	前		qián	qián	before	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly		前面 (Location 3), 前 (Location 3), 前 (Time 4), 前天 (Time 4), 以前 (Daily Routine 2), 前 (Location 6)
+Location 3	后		Hòu   hòu   hòu	Hòu   hòu   hòu	Rear	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	surname Hou  empress / queen  back / behind / rear / afterwards / after / later		后面 (Location 3), 后 (Location 3), 后 (Time 4), 后天 (Time 4), 以后 (Daily Routine 2), 然后 (Location 6), 最后 (Location 6), 后 (Location 6), 后来 (Languages 2)
+Location 3	校		jiào   xiào	jiào   xiào	school	to proofread / to check / to compare  school / military officer / CL: 所	to proofread / to check / to compare  school / military officer / CL: 所		学校 (Location 3), 校 (Location 3), 校长 (School 2)
+Location 3	走		zǒu	zǒu	go	to walk / to go / to run / to move (of vehicle) / to visit / to leave / to go away / to die (euph.) / from / through / away (in compound verbs, such as 撤走) / to change (shape, form, meaning)	to walk / to go / to run / to move (of vehicle) / to visit / to leave / to go away / to die (euph.) / from / through / away (in compound verbs, such as 撤走) / to change (shape, form, meaning)		走 (Location 3), 走路 (Travel)
+Location 3	到		dào	dào	To	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)		到 (Location 3), 迟到 (Travel), 遇到 (Personality and Feelings)
+Location 3	路		Lù   lù	Lù   lù	road	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind		路 (Location 3), 路 (Travel), 走路 (Travel), 迷路 (Location 6), 马路 (Travel 4)
+Location 3	怎么	怎麼	zěn me	zěn me	how	how? / what? / why?	how? / what? / why?		怎么样 (Greeting 3), 怎么 (Location 3), 怎么办 (Travel)
+Location 3	哪里	哪裏	nǎ lǐ   nǎ lǐ	nǎ lǐ   nǎ lǐ	where	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment		No Matches Found
+Location 3	这里	這裡	zhè lǐ	zhè lǐ	Here	here	here		No Matches Found
+Location 3	那里	那裏	nà li   nà li	nà li   nà li	There	there / that place / also written 那裡｜那里  there / that place	there / that place / also written 那裡｜那里  there / that place		No Matches Found
+Location 3	往		wǎng	wǎng	to	to go (in a direction) / to / towards / (of a train) bound for / past / previous	to go (in a direction) / to / towards / (of a train) bound for / past / previous		No Matches Found
+Location 3	里	裡	lǐ   Lǐ   lǐ	lǐ   Lǐ   lǐ	in	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels		哪里 (Location 3), 这里 (Location 3), 那里 (Location 3), 里 (Location 3), 里 (Location 4), 里面 (Weather)
+Hobbies 1	喜欢	喜歡	xǐ huan	xǐ huan	like	to like / to be fond of	to like / to be fond of		No Matches Found
+Hobbies 1	看		kān   kàn	kān   kàn	Look	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)		看 (Hobbies 1), 好看 (Shopping 2), 看起来 (Personality and Feelings)
+Hobbies 1	书	書	Shū   shū	Shū   shū	book	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write		书 (Hobbies 1), 图书馆 (Location 5)
+Hobbies 1	喜		xǐ	xǐ	like	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad		喜欢 (Hobbies 1), 喜 (Hobbies 1), 恭喜 (Festivals)
+Hobbies 1	欢	歡	huān   huān   huān	huān   huān   huān	Joyous	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢		喜欢 (Hobbies 1), 欢 (Hobbies 1), 欢迎 (Shopping 1)
+Hobbies 1	玩		wán	wán	play	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment		No Matches Found
+Hobbies 1	电脑	電腦	diàn nǎo	diàn nǎo	computer	computer / CL: 臺｜台	computer / CL: 臺｜台		No Matches Found
+Hobbies 1	游戏	遊戲	yóu xì	yóu xì	game	game / CL: 場｜场 / to play	game / CL: 場｜场 / to play		No Matches Found
+Hobbies 1	脑	腦	nǎo	nǎo	brain	brain / mind / head / essence	brain / mind / head / essence		电脑 (Hobbies 1), 脑 (Hobbies 1)
+Hobbies 1	游		Yóu   yóu   yóu	Yóu   yóu   yóu	tour	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel		游戏 (Hobbies 1), 游 (Hobbies 1), 旅游 (Hobbies 2), 游 (Sports 1), 游泳 (Sports 1), 漫游 (Travel 3), 导游 (Travel 3)
+Hobbies 1	戏	戲	xì	xì	play	trick / drama / play / show / CL: 出, 場｜场, 臺｜台	trick / drama / play / show / CL: 出, 場｜场, 臺｜台		游戏 (Hobbies 1), 戏 (Hobbies 1)
+Hobbies 1	听		yǐn   tīng   tìng	yǐn   tīng   tìng	listen	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow		No Matches Found
+Hobbies 1	音乐	音樂	yīn yuè	yīn yuè	music	music / CL: 張｜张, 曲, 段	music / CL: 張｜张, 曲, 段		No Matches Found
+Hobbies 1	歌		gē	gē	song	song / CL: 支, 首 / to sing	song / CL: 支, 首 / to sing		No Matches Found
+Hobbies 1	音		yīn	yīn	sound	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)		音乐 (Hobbies 1), 音 (Hobbies 1), 声音 (Environment)
+Hobbies 1	乐	樂	Lè   Yuè   lè   yuè	Lè   Yuè   lè   yuè	fun	surname Le  surname Yue  happy / cheerful / to laugh  music	surname Le  surname Yue  happy / cheerful / to laugh  music		音乐 (Hobbies 1), 乐 (Hobbies 1), 乐 (Celebration), 快乐 (Celebration)
+Hobbies 1	跳舞		tiào wǔ	tiào wǔ	dancing	to dance	to dance		No Matches Found
+Hobbies 1	唱		chàng	chàng	sing	to sing / to call loudly / to chant	to sing / to call loudly / to chant		No Matches Found
+Hobbies 1	跳		tiào	tiào	jump	to jump / to hop / to skip over / to bounce / to palpitate	to jump / to hop / to skip over / to bounce / to palpitate		跳舞 (Hobbies 1), 跳 (Hobbies 1)
+Hobbies 1	舞		wǔ	wǔ	dance	to dance / to wield / to brandish	to dance / to wield / to brandish		跳舞 (Hobbies 1), 舞 (Hobbies 1)
+Daily Routine 1	起床		qǐ chuáng	qǐ chuáng	get up	to get out of bed / to get up	to get out of bed / to get up		No Matches Found
+Daily Routine 1	上学	上學	shàng xué	shàng xué	go to school	to go to school / to attend school	to go to school / to attend school		No Matches Found
+Daily Routine 1	上班		shàng bān	shàng bān	Go to work	to go to work / to be on duty / to start work / to go to the office	to go to work / to be on duty / to start work / to go to the office		No Matches Found
+Daily Routine 1	早饭	早飯	zǎo fàn	zǎo fàn	breakfast	breakfast / CL: 份, 頓｜顿, 次, 餐	breakfast / CL: 份, 頓｜顿, 次, 餐		No Matches Found
+Daily Routine 1	床		chuáng	chuáng	bed	bed / couch / classifier for beds / CL: 張｜张	bed / couch / classifier for beds / CL: 張｜张		起床 (Daily Routine 1), 床 (Daily Routine 1)
+Daily Routine 1	班		Bān   bān	Bān   bān	class	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups		上班 (Daily Routine 1), 班 (Daily Routine 1), 下班 (Daily Routine 1), 西班牙 (Hobbies 2), 班 (Hobbies 2), 西班牙语 (Hobbies 2), 班 (School 2), 加班 (Work 3)
+Daily Routine 1	从	從	Cóng   cóng   zòng	Cóng   cóng   zòng	From	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin		从 (Daily Routine 1), 从来 (Weather)
+Daily Routine 1	睡觉	睡覺	shuì jiào	shuì jiào	go to bed	to go to bed / to sleep	to go to bed / to sleep		No Matches Found
+Daily Routine 1	午饭	午飯	wǔ fàn	wǔ fàn	lunch	lunch / CL: 份, 頓｜顿, 次, 餐	lunch / CL: 份, 頓｜顿, 次, 餐		No Matches Found
+Daily Routine 1	睡		shuì	shuì	sleep	to sleep / to lie down	to sleep / to lie down		睡觉 (Daily Routine 1), 睡 (Daily Routine 1)
+Daily Routine 1	觉	覺	jiào   jué	jiào   jué	feel	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware		睡觉 (Daily Routine 1), 觉 (Daily Routine 1), 觉 (Health 1), 觉得 (Health 1)
+Daily Routine 1	放学	放學	fàng xué	fàng xué	School	to dismiss students at the end of the school day	to dismiss students at the end of the school day		No Matches Found
+Daily Routine 1	下班		xià bān	xià bān	Commute	to finish work / to get off work	to finish work / to get off work		No Matches Found
+Daily Routine 1	回		huí   huí	huí   huí	Times	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve		回 (Daily Routine 1), 回答 (Languages 3), 回 (Communication 2), 回复 (Business 1)
+Daily Routine 1	晚饭	晚飯	wǎn fàn	wǎn fàn	dinner	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐		No Matches Found
+Daily Routine 1	放		fàng	fàng	put	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)		放学 (Daily Routine 1), 放 (Daily Routine 1), 放心 (Future), 放 (House), 放假 (Exam), 放松 (Exam), 放弃 (Duo)
+Payment	钱	錢	Qián   qián	Qián   qián	money	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两		钱 (Payment), 换钱 (Travel 3)
+Payment	块	塊	kuài	kuài	Piece	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units		块 (Payment), 块 (Dining 2)
+Payment	只		zhǐ   zhǐ   zhī	zhǐ   zhǐ   zhī	only	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc		只 (Payment), 只 (Existence)
+Payment	买	買	mǎi	mǎi	buy	to buy / to purchase	to buy / to purchase		买 (Payment), 买单 (Restaurant)
+Payment	一共		yī gòng	yī gòng	Altogether	altogether	altogether		No Matches Found
+Payment	毛		Máo   máo	Máo   máo	hair	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)		毛 (Payment), 毛 (Duo), 羽毛 (Duo)
+Payment	共		gòng	gòng	Altogether	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party		一共 (Payment), 共 (Payment), 公共 (Transportation)
+Payment	信用卡		xìn yòng kǎ	xìn yòng kǎ	credit card	credit card	credit card		No Matches Found
+Payment	收		shōu	shōu	Receive	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)		收 (Payment), 收据 (Business 1)
+Payment	千		qiān   qiān	qiān   qiān	thousand	thousand  see 鞦韆｜秋千	thousand  see 鞦韆｜秋千		No Matches Found
+Payment	信		xìn	xìn	letter	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random		信用卡 (Payment), 信 (Payment), 信心 (Sports 2), 信 (Sports 2), 相信 (Work), 短信 (Communication 2), 信号 (Communication 2), 微信 (Internet Slang)
+Payment	用		yòng	yòng	use	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore		信用卡 (Payment), 用 (Payment), 用 (Entertainment), 应用 (Languages 3), 费用 (Business 1)
+Payment	卡		kǎ   qiǎ	kǎ   qiǎ	card	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]		信用卡 (Payment), 卡 (Payment), 电话卡 (Travel 3)
+Payment	贵	貴	guì	guì	expensive	expensive / noble / precious / (honorific) your	expensive / noble / precious / (honorific) your		贵 (Payment), 贵 (Business 2)
+Payment	便宜		biàn yí   pián yi	biàn yí   pián yi	Inexpensive	convenient  cheap / inexpensive / small advantages / to let sb off lightly	convenient  cheap / inexpensive / small advantages / to let sb off lightly		No Matches Found
+Payment	现金	現金	xiàn jīn	xiàn jīn	cash	cash	cash		No Matches Found
+Payment	便		biàn   pián	biàn   pián	Then	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜		便宜 (Payment), 便 (Payment), 随便 (Shopping 1), 便 (Shopping 1), 方便 (Environment)
+Payment	宜		Yí   yí	Yí   yí	should	surname Yi  proper / should / suitable / appropriate	surname Yi  proper / should / suitable / appropriate		便宜 (Payment), 宜 (Payment)
+Payment	金		Jīn   jīn	Jīn   jīn	gold	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音		现金 (Payment), 金 (Payment), 奖金 (Work 3)
+Payment	太		tài	tài	too	highest / greatest / too (much) / very / extremely	highest / greatest / too (much) / very / extremely		太 (Payment), 太阳 (Environment)
+Payment	万		Mò   Wàn   wàn	Mò   Wàn   wàn	Ten thousand	see 万俟  surname Wan  ten thousand / a great number	see 万俟  surname Wan  ten thousand / a great number		No Matches Found
+Payment	行		háng   xíng	háng   xíng	Row	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense		行 (Payment), 行李 (Travel 2), 自行车 (Hobbies 3), 银行 (Travel 3), 行 (Travel 3)
+Entertainment	想		xiǎng	xiǎng	miss you	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)		想 (Entertainment), 想 (Personality and Feelings)
+Entertainment	干	乾	Gān   gān   gān   gàn	Gān   gān   gān   gàn	dry	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)		干 (Entertainment), 干杯 (Celebration), 干 (Celebration), 干净 (House), 干燥 (Weather 2)
+Entertainment	影		yǐng	yǐng	Shadow	picture / image / film / movie / photograph / reflection / shadow / trace	picture / image / film / movie / photograph / reflection / shadow / trace		影 (Entertainment), 电影 (Entertainment), 影响 (Environment)
+Entertainment	视	視	shì	shì	Regard	to look at / to regard / to inspect	to look at / to regard / to inspect		视 (Entertainment), 电视 (Entertainment)
+Entertainment	电视	電視	diàn shì	diàn shì	TV	television / TV / CL: 臺｜台, 個｜个	television / TV / CL: 臺｜台, 個｜个		No Matches Found
+Entertainment	电影	電影	diàn yǐng	diàn yǐng	the film	movie / film / CL: 部, 片, 幕, 場｜场	movie / film / CL: 部, 片, 幕, 場｜场		No Matches Found
+Entertainment	报纸	報紙	bào zhǐ	bào zhǐ	newspaper	newspaper / newsprint / CL: 份, 期, 張｜张	newspaper / newsprint / CL: 份, 期, 張｜张		No Matches Found
+Entertainment	上网	上網	shàng wǎng	shàng wǎng	Internet	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net		No Matches Found
+Entertainment	报	報	bào	bào	Report	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张		报纸 (Entertainment), 报 (Entertainment), 报销 (Business 1), 报告 (Business 1), 汇报 (Business 1), 报警 (Emergency)
+Entertainment	纸	紙	zhǐ	zhǐ	paper	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	paper / CL: 張｜张, 沓 / classifier for documents, letter etc		报纸 (Entertainment), 纸 (Entertainment), 纸 (School 2)
+Entertainment	网	網	wǎng	wǎng	network	net / network	net / network		上网 (Entertainment), 网 (Entertainment), 网球 (Sports 2)
+Entertainment	手机	手機	shǒu jī	shǒu jī	Cellular phone	cell phone / mobile phone / CL: 部, 支	cell phone / mobile phone / CL: 部, 支		No Matches Found
+Entertainment	新闻	新聞	xīn wén	xīn wén	news	news / CL: 條｜条, 個｜个	news / CL: 條｜条, 個｜个		No Matches Found
+Entertainment	机	機	Jī   jī	Jī   jī	machine	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台		手机 (Entertainment), 机 (Entertainment), 照相机 (Hobbies 2), 飞机 (Travel), 机场 (Travel), 机票 (Travel), 机会 (Future), 转机 (Travel 3), 司机 (Travel 4)
+Entertainment	新		Xīn   xīn	Xīn   xīn	new	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)		新闻 (Entertainment), 新 (Entertainment), 新鲜 (Supermarket), 新 (Hobbies 2), 新年 (Celebration)
+Entertainment	闻	聞	Wén   wén	Wén   wén	smell	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at		新闻 (Entertainment), 闻 (Entertainment)
+Entertainment	明星		míng xīng	míng xīng	Celebrity	star / celebrity	star / celebrity		No Matches Found
+Entertainment	体育	體育	tǐ yù	tǐ yù	physical education	sports / physical education	sports / physical education		体育 (Entertainment), 体育馆 (School 2)
+Entertainment	节目	節目	jié mù	jié mù	program	program / item (on a program) / CL: 臺｜台, 個｜个, 套	program / item (on a program) / CL: 臺｜台, 個｜个, 套		No Matches Found
+Entertainment	韩国	韓國	Hán guó	Hán guó	Korea	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897		No Matches Found
+Entertainment	体	體	tǐ	tǐ	body	body / form / style / system / substance / to experience / aspect (linguistics)	body / form / style / system / substance / to experience / aspect (linguistics)		体育 (Entertainment), 体 (Entertainment), 身体 (Health 1), 体育馆 (School 2)
+Entertainment	节	節	jiē   jié	jiē   jié	Festival	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个		节目 (Entertainment), 节 (Entertainment), 节日 (Celebration), 春节 (Celebration), 季节 (Time 4), 中秋节 (Festivals), 端午节 (Festivals)
+Entertainment	韩	韓	Hán	Hán	Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han		韩国 (Entertainment), 韩 (Entertainment)
+Entertainment	育		yù	yù	Educate	to have children / to raise or bring up / to educate	to have children / to raise or bring up / to educate		体育 (Entertainment), 育 (Entertainment), 体育馆 (School 2)
+Entertainment	目		mù	mù	Eye	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title		节目 (Entertainment), 目 (Entertainment), 项目 (Business 1)
+Location 4	桌		zhuō	zhuō	table	table / desk / classifier for tables of guests at a banquet etc	table / desk / classifier for tables of guests at a banquet etc		桌 (Location 4), 桌子 (Location 4)
+Location 4	找		zhǎo	zhǎo	Find	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	to try to find / to look for / to call on sb / to find / to seek / to return / to give change		No Matches Found
+Location 4	桌子		zhuō zi	zhuō zi	table	table / desk / CL: 張｜张, 套	table / desk / CL: 張｜张, 套		No Matches Found
+Location 4	椅子		yǐ zi	yǐ zi	chair	chair / CL: 把, 套	chair / CL: 把, 套		No Matches Found
+Location 4	椅		yǐ	yǐ	chair	chair	chair		椅子 (Location 4), 椅 (Location 4)
+Location 4	房间	房間	fáng jiān	fáng jiān	room	room / CL: 間｜间, 個｜个	room / CL: 間｜间, 個｜个		No Matches Found
+Location 4	冰箱		bīng xiāng	bīng xiāng	refrigerator	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个		No Matches Found
+Location 4	外		wài	wài	outer	outside / in addition / foreign / external	outside / in addition / foreign / external		外 (Location 4), 外面 (Weather), 意外 (Emergency)
+Location 4	房		Fáng   fáng	Fáng   fáng	room	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)		房间 (Location 4), 房 (Location 4), 订房 (Travel 3), 退房 (Travel 3), 厨房 (House)
+Location 4	箱		xiāng	xiāng	box	box / trunk / chest	box / trunk / chest		冰箱 (Location 4), 箱 (Location 4)
+Restaurant	位		wèi	wèi	Place	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential		位 (Restaurant), 订位 (Restaurant)
+Restaurant	等		děng	děng	Wait	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once		No Matches Found
+Restaurant	一下		yī xià	yī xià	a bit	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once		No Matches Found
+Restaurant	进	進	jìn	jìn	Enter	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound		No Matches Found
+Restaurant	坐		Zuò   zuò	Zuò   zuò	sit	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座		坐 (Restaurant), 坐 (Transportation)
+Restaurant	菜单	菜單	cài dān	cài dān	menu	menu / CL: 份, 張｜张	menu / CL: 份, 張｜张		No Matches Found
+Restaurant	英文		Yīng wén	Yīng wén	English	English (language)	English (language)		No Matches Found
+Restaurant	菜		cài	cài	dish	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor		菜单 (Restaurant), 菜 (Restaurant), 点菜 (Restaurant), 蔬菜 (Supermarket), 菜 (Dining 1), 菜鸟 (Internet Slang)
+Restaurant	单	單	Shàn   dān	Shàn   dān	single	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个		菜单 (Restaurant), 单 (Restaurant), 买单 (Restaurant), 单 (Languages 3), 简单 (Languages 3)
+Restaurant	文		Wén   wén	Wén   wén	Culture	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67		英文 (Restaurant), 文 (Restaurant), 文 (Hobbies 2), 中文 (Hobbies 2), 文化 (Hobbies 3)
+Restaurant	服务员	服務員	fú wù yuán	fú wù yuán	Waiter	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位		No Matches Found
+Restaurant	点菜	點菜	diǎn cài	diǎn cài	A la carte	to order dishes (in a restaurant)	to order dishes (in a restaurant)		No Matches Found
+Restaurant	买单	買單	mǎi dān	mǎi dān	Pay	to pay the restaurant bill	to pay the restaurant bill		No Matches Found
+Restaurant	订位	訂位	dìng wèi	dìng wèi	booking	to reserve a seat / to book a table / reservation	to reserve a seat / to book a table / reservation		No Matches Found
+Restaurant	服		fú   fù	fú   fù	clothes	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]		服务员 (Restaurant), 服 (Restaurant), 衣服 (Shopping 1), 舒服 (Health 2)
+Restaurant	务	務	wù	wù	Business	affair / business / matter / to be engaged in / to attend to / by all means	affair / business / matter / to be engaged in / to attend to / by all means		服务员 (Restaurant), 务 (Restaurant)
+Restaurant	员	員	yuán	yuán	member	person / employee / member	person / employee / member		服务员 (Restaurant), 员 (Restaurant)
+Restaurant	订	訂	dìng	dìng	Order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order		订位 (Restaurant), 订 (Restaurant), 订房 (Travel 3), 订 (Travel 3)
+Supermarket	些		xiē	xiē	some	some / few / several / measure word indicating a small amount or small number (greater than 1)	some / few / several / measure word indicating a small amount or small number (greater than 1)		No Matches Found
+Supermarket	西		Xī   xī	Xī   xī	WEAT	the West / abbr. for Spain 西班牙 / Spanish  west	the West / abbr. for Spain 西班牙 / Spanish  west		西 (Supermarket), 东西 (Supermarket), 西瓜 (Supermarket), 西班牙 (Hobbies 2), 西 (Hobbies 2), 西班牙语 (Hobbies 2), 西边 (Location 6), 西安 (Culture)
+Supermarket	东	東	Dōng   dōng	Dōng   dōng	east	surname Dong  east / host (i.e. sitting on east side of guest) / landlord	surname Dong  east / host (i.e. sitting on east side of guest) / landlord		东 (Supermarket), 东西 (Supermarket), 东边 (Location 6)
+Supermarket	东西	東西	dōng xī   dōng xi	dōng xī   dōng xi	thing	east and west  thing / stuff / person / CL: 個｜个, 件	east and west  thing / stuff / person / CL: 個｜个, 件		No Matches Found
+Supermarket	超市		chāo shì	chāo shì	Supermarket	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	supermarket / abbr. for 超級市場｜超级市场 / CL: 家		No Matches Found
+Supermarket	水果		shuǐ guǒ	shuǐ guǒ	fruit	fruit / CL: 個｜个	fruit / CL: 個｜个		No Matches Found
+Supermarket	超		chāo	chāo	super	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-		超市 (Supermarket), 超 (Supermarket)
+Supermarket	市		shì	shì	city	market / city / CL: 個｜个	market / city / CL: 個｜个		超市 (Supermarket), 市 (Supermarket), 市 (Location 5), 城市 (Location 5)
+Supermarket	果		guǒ	guǒ	fruit	fruit / result / resolute / indeed / if really	fruit / result / resolute / indeed / if really		水果 (Supermarket), 果 (Supermarket), 苹果 (Supermarket), 果汁 (Dining 2), 如果 (Weather)
+Supermarket	给	給	gěi   jǐ	gěi   jǐ	give	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide		给 (Supermarket), 给 (Invitiation 1)
+Supermarket	苹果	蘋果	píng guǒ	píng guǒ	apple	apple / CL: 個｜个, 顆｜颗	apple / CL: 個｜个, 顆｜颗		No Matches Found
+Supermarket	西瓜		xī guā	xī guā	watermelon	watermelon / CL: 顆｜颗, 粒, 個｜个	watermelon / CL: 顆｜颗, 粒, 個｜个		No Matches Found
+Supermarket	苹		píng   pín   píng	píng   pín   píng	apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple		苹果 (Supermarket), 苹 (Supermarket)
+Supermarket	瓜		guā	guā	melon	melon / gourd / squash	melon / gourd / squash		西瓜 (Supermarket), 瓜 (Supermarket)
+Supermarket	鸡蛋	雞蛋	jī dàn	jī dàn	egg	(chicken) egg / hen's egg / CL: 個｜个, 打	(chicken) egg / hen's egg / CL: 個｜个, 打		No Matches Found
+Supermarket	新鲜	新鮮	xīn xiān	xīn xiān	fresh	fresh (experience, food etc) / freshness / novel / uncommon	fresh (experience, food etc) / freshness / novel / uncommon		No Matches Found
+Supermarket	鸡	雞	jī	jī	Chicken	fowl / chicken / CL: 隻｜只 / (slang) prostitute	fowl / chicken / CL: 隻｜只 / (slang) prostitute		鸡蛋 (Supermarket), 鸡 (Supermarket), 鸡肉 (Dining 1), 宫保鸡丁 (Gourmet 2)
+Supermarket	蛋		dàn	dàn	egg	egg / CL: 個｜个, 打 / oval-shaped thing	egg / CL: 個｜个, 打 / oval-shaped thing		鸡蛋 (Supermarket), 蛋 (Supermarket), 蛋糕 (Dining 2)
+Supermarket	鲜	鮮	xiān   xiǎn   xiān	xiān   xiǎn   xiān	fresh	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜		新鲜 (Supermarket), 鲜 (Supermarket)
+Supermarket	蔬菜		shū cài	shū cài	vegetables	vegetables / produce / CL: 種｜种	vegetables / produce / CL: 種｜种		No Matches Found
+Supermarket	蔬		shū	shū	vegetable	vegetables	vegetables		蔬菜 (Supermarket), 蔬 (Supermarket)
+Supermarket	包		Bāo   bāo	Bāo   bāo	package	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只		包 (Supermarket), 面包 (Supermarket), 小笼包 (Gourmet 1), 包子 (Gourmet 1), 红包 (Festivals)
+Supermarket	米		Mǐ   mǐ	Mǐ   mǐ	Meter	surname Mi  rice / CL: 粒 / meter (classifier)	surname Mi  rice / CL: 粒 / meter (classifier)		米 (Supermarket), 米饭 (Dining 1)
+Supermarket	面包	麵包	miàn bāo	miàn bāo	bread	bread / CL: 片, 袋, 塊｜块	bread / CL: 片, 袋, 塊｜块		No Matches Found
+Supermarket	袋		dài	dài	bag	pouch / bag / sack / pocket	pouch / bag / sack / pocket		袋 (Supermarket), 袋子 (Shopping 4)
+Supermarket	糖		táng	táng	sugar	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	sugar / sweets / candy / CL: 顆｜颗, 塊｜块		No Matches Found
+Hobbies 2	为	為	wéi   wèi	wéi   wèi	for	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to		为 (Hobbies 2), 为什么 (Hobbies 2), 因为 (Hobbies 2), 为了 (Hobbies 3), 为 (Exam), 认为 (Work 2), 为 (Work 2)
+Hobbies 2	习	習	Xí   xí	Xí   xí	Study	surname Xi  to practice / to study / habit	surname Xi  to practice / to study / habit		习 (Hobbies 2), 学习 (Hobbies 2), 练习 (Sports 2), 习惯 (Daily Routine 2), 复习 (Exam)
+Hobbies 2	学习	學習	xué xí	xué xí	Learn	to learn / to study	to learn / to study		No Matches Found
+Hobbies 2	中文		Zhōng wén	Zhōng wén	Chinese	Chinese language	Chinese language		No Matches Found
+Hobbies 2	为什么	為什麼	wèi shén me	wèi shén me	why	why? / for what reason?	why? / for what reason?		No Matches Found
+Hobbies 2	因为	因為	yīn wèi	yīn wèi	because	because / owing to / on account of	because / owing to / on account of		No Matches Found
+Hobbies 2	所以		suǒ yǐ	suǒ yǐ	and so	therefore / as a result / so / the reason why	therefore / as a result / so / the reason why		No Matches Found
+Hobbies 2	西班牙		Xī bān yá	Xī bān yá	Spain	Spain	Spain		西班牙 (Hobbies 2), 西班牙语 (Hobbies 2)
+Hobbies 2	因		yīn	yīn	because	cause / reason / because	cause / reason / because		因为 (Hobbies 2), 因 (Hobbies 2)
+Hobbies 2	所		suǒ	suǒ	The	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个		所以 (Hobbies 2), 所 (Hobbies 2), 厕所 (House)
+Hobbies 2	以		Yǐ   yǐ	Yǐ   yǐ	With	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)		所以 (Hobbies 2), 以 (Hobbies 2), 可以 (Transportation), 以后 (Daily Routine 2), 以前 (Daily Routine 2)
+Hobbies 2	牙		yá	yá	tooth	tooth / ivory / CL: 顆｜颗	tooth / ivory / CL: 顆｜颗		西班牙 (Hobbies 2), 牙 (Hobbies 2), 西班牙语 (Hobbies 2), 牙 (Daily Routine 2), 刷牙 (Daily Routine 2)
+Hobbies 2	旅游	旅遊	lǚ yóu	lǚ yóu	tourism	trip / journey / tourism / travel / tour / to travel	trip / journey / tourism / travel / tour / to travel		No Matches Found
+Hobbies 2	爱好	愛好	ài hào	ài hào	Hobby	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个		No Matches Found
+Hobbies 2	西班牙语	西班牙語	Xī bān yá yǔ	Xī bān yá yǔ	Spanish	Spanish language	Spanish language		No Matches Found
+Hobbies 2	轻松	輕鬆	qīng sōng	qīng sōng	Relaxed	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously		No Matches Found
+Hobbies 2	旅		lǚ	lǚ	trip	trip / travel / to travel / brigade (army)	trip / travel / to travel / brigade (army)		旅游 (Hobbies 2), 旅 (Hobbies 2)
+Hobbies 2	轻	輕	qīng	qīng	light	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage		轻松 (Hobbies 2), 轻 (Hobbies 2), 轻 (People 3), 年轻 (People 3)
+Hobbies 2	松		Sōng   sōng   sōng	Sōng   sōng   sōng	loose	surname Song  pine / CL: 棵  loose / to loosen / to relax	surname Song  pine / CL: 棵  loose / to loosen / to relax		轻松 (Hobbies 2), 松 (Hobbies 2), 放松 (Exam), 松 (Exam)
+Hobbies 2	照相机	照相機	zhào xiàng jī	zhào xiàng jī	camera	camera / CL: 個｜个, 架, 部, 台, 隻｜只	camera / CL: 個｜个, 架, 部, 台, 隻｜只		No Matches Found
+Hobbies 2	印度		Yìn dù	Yìn dù	India	India	India		No Matches Found
+Hobbies 2	拍照		pāi zhào	pāi zhào	Photograph	to take a picture	to take a picture		No Matches Found
+Hobbies 2	拍		pāi	pāi	beat	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)		拍照 (Hobbies 2), 拍 (Hobbies 2), 自拍 (Internet Slang)
+Hobbies 2	照		zhào	zhào	Photo	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before		照相机 (Hobbies 2), 拍照 (Hobbies 2), 照 (Hobbies 2), 照片 (Existence), 照 (Travel 2), 护照 (Travel 2), 照 (Health 3), 照顾 (Health 3)
+Hobbies 2	印		Yìn   yìn	Yìn   yìn	Print	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image		印度 (Hobbies 2), 印 (Hobbies 2)
+Hobbies 2	相		Xiāng   xiāng   xiàng	Xiāng   xiāng   xiàng	phase	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)	surname Xiang  each other / one another / mutually  appearance / portrait / picture / government minister / (physics) phase / (literary) to appraise (esp. by scrutinizing physical features) / to read sb's fortune (by physiognomy, palmistry etc)		照相机 (Hobbies 2), 相 (Hobbies 2), 相信 (Work), 相 (Work)
+Hobbies 2	度		dù   duó	dù   duó	degree	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]	to pass / to spend (time) / measure / limit / extent / degree of intensity / degree (angles, temperature etc) / kilowatt-hour / classifier for events and occurrences  to estimate / Taiwan pr. [duo4]		印度 (Hobbies 2), 度 (Hobbies 2), 温度 (Weather 2), 度 (Weather 2)
+Dining 1	海		Hǎi   hǎi	Hǎi   hǎi	sea	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous		海 (Dining 1), 上海 (Dining 1), 海关 (Travel 2), 海边 (Travel 4)
+Dining 1	本		běn	běn	this	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc		本 (Dining 1), 日本 (Dining 1), 本 (Existence), 笔记本 (School 2), 资本 (Business 1)
+Dining 1	还	還	Huán   hái   huán	Huán   hái   huán	also	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return		还 (Dining 1), 还是 (Dining 1), 还 (Shopping 2)
+Dining 1	上海		Shàng hǎi	Shàng hǎi	Shanghai	Shanghai municipality, central east China, abbr. to 滬｜沪	Shanghai municipality, central east China, abbr. to 滬｜沪		No Matches Found
+Dining 1	还是	還是	hái shi	hái shi	still is	or / still / nevertheless / had better	or / still / nevertheless / had better		No Matches Found
+Dining 1	日本		Rì běn	Rì běn	Japan	Japan / Japanese	Japan / Japanese		No Matches Found
+Dining 1	肉		ròu	ròu	meat	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute		肉 (Dining 1), 鸡肉 (Dining 1), 牛肉 (Dining 1), 猪肉 (Dining 1), 羊肉 (Dining 1), 卤肉饭 (Gourmet 2)
+Dining 1	米饭	米飯	mǐ fàn	mǐ fàn	rice	(cooked) rice	(cooked) rice		No Matches Found
+Dining 1	面条	麵條	miàn tiáo	miàn tiáo	noodles	noodles	noodles		No Matches Found
+Dining 1	鸡肉	雞肉	jī ròu	jī ròu	chicken	chicken meat	chicken meat		No Matches Found
+Dining 1	牛肉		niú ròu	niú ròu	beef	beef	beef		No Matches Found
+Dining 1	猪肉	豬肉	zhū ròu	zhū ròu	pork	pork	pork		No Matches Found
+Dining 1	羊肉		yáng ròu	yáng ròu	Lamb	mutton / goat meat	mutton / goat meat		No Matches Found
+Dining 1	饮料	飲料	yǐn liào	yǐn liào	Drink	drink / beverage	drink / beverage		No Matches Found
+Dining 1	猪	豬	zhū	zhū	pig	hog / pig / swine / CL: 口, 頭｜头	hog / pig / swine / CL: 口, 頭｜头		猪肉 (Dining 1), 猪 (Dining 1)
+Dining 1	羊		Yáng   yáng	Yáng   yáng	sheep	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只		羊肉 (Dining 1), 羊 (Dining 1)
+Dining 1	饮	飲	yǐn   yìn	yǐn   yìn	drink	to drink  to give (animals) water to drink	to drink  to give (animals) water to drink		饮料 (Dining 1), 饮 (Dining 1)
+Dining 1	料		liào	liào	Fee	material / stuff / grain / feed / to expect / to anticipate / to guess	material / stuff / grain / feed / to expect / to anticipate / to guess		饮料 (Dining 1), 料 (Dining 1)
+Health 1	作		zuō   zuò	zuō   zuò	Make	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works		作 (Health 1), 工作 (Health 1), 作业 (School 2), 合作 (Business 2)
+Health 1	工		gōng	gōng	work	work / worker / skill / profession / trade / craft / labor	work / worker / skill / profession / trade / craft / labor		工 (Health 1), 工作 (Health 1), 工资 (Work 3)
+Health 1	累		lěi   lèi   Léi   léi	lěi   lèi   Léi   léi	tired	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around		No Matches Found
+Health 1	工作		gōng zuò	gōng zuò	jobs	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项		No Matches Found
+Health 1	觉得	覺得	jué de	jué de	feel	to think / to feel	to think / to feel		No Matches Found
+Health 1	有点儿	有點兒	yǒu diǎnr	yǒu diǎnr	kind of	slightly / a little / somewhat	slightly / a little / somewhat		No Matches Found
+Health 1	胖		pán   pàng	pán   pàng	fat	healthy / at ease  fat / plump	healthy / at ease  fat / plump		No Matches Found
+Health 1	健康		jiàn kāng	jiàn kāng	health	health / healthy	health / healthy		No Matches Found
+Health 1	不要		bù yào	bù yào	Do not	don't! / must not	don't! / must not		No Matches Found
+Health 1	健		jiàn	jiàn	Healthy	healthy / to invigorate / to strengthen / to be good at / to be strong in	healthy / to invigorate / to strengthen / to be good at / to be strong in		健康 (Health 1), 健 (Health 1)
+Health 1	康		Kāng   kāng	Kāng   kāng	Kang	surname Kang  healthy / peaceful / abundant	surname Kang  healthy / peaceful / abundant		健康 (Health 1), 康 (Health 1)
+Health 1	身体	身體	shēn tǐ	shēn tǐ	body	the body / one's health / CL: 具, 個｜个 / in person	the body / one's health / CL: 具, 個｜个 / in person		No Matches Found
+Health 1	注意		zhù yì	zhù yì	note	to take note of / to pay attention to	to take note of / to pay attention to		No Matches Found
+Health 1	身		shēn	shēn	body	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158		身体 (Health 1), 身 (Health 1)
+Health 1	注		zhù   zhù	zhù   zhù	Note	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment		注意 (Health 1), 注 (Health 1), 关注 (Internet Slang)
+Health 1	意		Yì   yì	Yì   yì	meaning	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate		注意 (Health 1), 意 (Health 1), 意思 (Languages), 不好意思 (Invitiation 1), 意大利 (Shopping 2), 愿意 (Future), 同意 (Work 2), 满意 (Work 2), 意外 (Emergency), 生意 (Work 3), 意见 (Work 3)
+Health 1	开始	開始	kāi shǐ	kāi shǐ	Start	to begin / beginning / to start / initial / CL: 個｜个	to begin / beginning / to start / initial / CL: 個｜个		No Matches Found
+Health 1	锻炼	鍛鍊	duàn liàn	duàn liàn	work out	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself		No Matches Found
+Health 1	开	開	kāi	kāi	open	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format		开始 (Health 1), 开 (Health 1), 开 (Shopping 1), 开车 (Travel), 离开 (Travel 2), 开会 (Work 2)
+Health 1	锻	鍛	duàn	duàn	Wrought	to forge / to discipline / wrought	to forge / to discipline / wrought		锻炼 (Health 1), 锻 (Health 1)
+Health 1	始		shǐ	shǐ	beginning	to begin / to start / then / only then	to begin / to start / then / only then		开始 (Health 1), 始 (Health 1)
+Health 1	炼	煉	liàn	liàn	Refine	to refine / to smelt	to refine / to smelt		锻炼 (Health 1), 炼 (Health 1)
+Transportation	铁	鐵	Tiě   tiě	Tiě   tiě	iron	surname Tie  iron (metal) / arms / weapons / hard / strong / violent / unshakeable / determined / close / tight (slang)	surname Tie  iron (metal) / arms / weapons / hard / strong / violent / unshakeable / determined / close / tight (slang)		铁 (Transportation), 地铁 (Transportation)
+Transportation	店		diàn	diàn	shop	inn / shop / store / CL: 家	inn / shop / store / CL: 家		店 (Transportation), 酒店 (Transportation), 商店 (Shopping 1)
+Transportation	地		de   dì	de   dì	Ground	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片		地 (Transportation), 地铁 (Transportation), 地理 (School), 地方 (Location 5), 地址 (Location 6), 地 (Personality and Feelings), 地图 (Travel 4)
+Transportation	酒		jiǔ	jiǔ	liqueur	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸		酒 (Transportation), 酒店 (Transportation), 啤酒 (Dining 2), 酒 (Dining 3), 白酒 (Celebration), 红酒 (Celebration)
+Transportation	酒店		jiǔ diàn	jiǔ diàn	Hotels	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club		No Matches Found
+Transportation	地铁	地鐵	dì tiě	dì tiě	subway	subway / metro	subway / metro		No Matches Found
+Transportation	不准		bù zhǔn	bù zhǔn	Forbid	not to allow / to forbid / to prohibit	not to allow / to forbid / to prohibit		No Matches Found
+Transportation	准		zhǔn   zhǔn	zhǔn   zhǔn	quasi-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-		不准 (Transportation), 准 (Transportation), 准备 (School), 准 (School), 准时 (Time 4)
+Transportation	出租车	出租車	chū zū chē	chū zū chē	taxi	taxi / (Taiwan) rental car	taxi / (Taiwan) rental car		No Matches Found
+Transportation	站		zhàn	zhàn	station	station / to stand / to halt / to stop / branch of a company or organization / website	station / to stand / to halt / to stop / branch of a company or organization / website		No Matches Found
+Transportation	车	車	Chē   chē   jū	Chē   chē   jū	car	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)		出租车 (Transportation), 车 (Transportation), 汽车 (Transportation), 开车 (Travel), 火车 (Travel), 堵车 (Time 4), 自行车 (Hobbies 3), 打车 (Travel 4), 救护车 (Emergency)
+Transportation	出		chū	chū	Out	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc		出租车 (Transportation), 出 (Transportation), 出去 (Invitiation 1), 出 (Travel 4), 出差 (Work 2)
+Transportation	租		zū	zū	rent	to hire / to rent / to charter / to rent out / to lease out / rent / land tax	to hire / to rent / to charter / to rent out / to lease out / rent / land tax		出租车 (Transportation), 租 (Transportation)
+Transportation	可以		kě yǐ	kě yǐ	can	can / may / possible / able to / not bad / pretty good	can / may / possible / able to / not bad / pretty good		No Matches Found
+Transportation	汽车	汽車	qì chē	qì chē	car	car / automobile / bus / CL: 輛｜辆	car / automobile / bus / CL: 輛｜辆		No Matches Found
+Transportation	公共		gōng gòng	gōng gòng	public	public / common / communal	public / common / communal		No Matches Found
+Transportation	船		chuán	chuán	ferry	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只		No Matches Found
+Transportation	公		gōng	gōng	public	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)		公共 (Transportation), 公 (Transportation), 办公室 (Existence), 公司 (Invitation 2), 公园 (Location 5), 公斤 (Health 3)
+Transportation	汽		qì	qì	vapor	steam / vapor	steam / vapor		汽车 (Transportation), 汽 (Transportation)
+Shopping 1	件		jiàn	jiàn	Matter	item / component / classifier for events, things, clothes etc	item / component / classifier for events, things, clothes etc		件 (Shopping 1), 电子邮件 (Communication 2)
+Shopping 1	衣		yī   yì	yī   yì	clothes	clothes / CL: 件  to dress / to wear / to put on (clothes)	clothes / CL: 件  to dress / to wear / to put on (clothes)		衣 (Shopping 1), 衣服 (Shopping 1)
+Shopping 1	商		Shāng   shāng	Shāng   shāng	Business	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)		商 (Shopping 1), 商店 (Shopping 1), 商量 (Work 3)
+Shopping 1	商店		shāng diàn	shāng diàn	store	store / shop / CL: 家, 個｜个	store / shop / CL: 家, 個｜个		No Matches Found
+Shopping 1	衣服		yī fu	yī fu	clothes	clothes / CL: 件, 套	clothes / CL: 件, 套		No Matches Found
+Shopping 1	门	門	Mén   mén	Mén   mén	door	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)		No Matches Found
+Shopping 1	欢迎	歡迎	huān yíng	huān yíng	welcome	to welcome / welcome	to welcome / welcome		No Matches Found
+Shopping 1	迎		yíng	yíng	welcome	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)		欢迎 (Shopping 1), 迎 (Shopping 1)
+Shopping 1	您		nín	nín	you	you (courteous, as opposed to informal 你)	you (courteous, as opposed to informal 你)		No Matches Found
+Shopping 1	帮忙	幫忙	bāng máng	bāng máng	help	to help / to lend a hand / to do a favor / to do a good turn	to help / to lend a hand / to do a favor / to do a good turn		No Matches Found
+Shopping 1	需要		xū yào	xū yào	need	to need / to want / to demand / to require / requirement / need	to need / to want / to demand / to require / requirement / need		No Matches Found
+Shopping 1	需		xū	xū	need	to require / to need / to want / necessity / need	to require / to need / to want / necessity / need		需要 (Shopping 1), 需 (Shopping 1)
+Shopping 1	随便	隨便	suí biàn	suí biàn	casual	as one wishes / as one pleases / at random / negligent / casual / wanton	as one wishes / as one pleases / at random / negligent / casual / wanton		No Matches Found
+Shopping 1	随	隨	Suí   suí	Suí   suí	Follow	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently		随便 (Shopping 1), 随 (Shopping 1)
+Languages	读	讀	dòu   dú	dòu   dú	read	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音		No Matches Found
+Languages	意思		yì si	yì si	meaning	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc		意思 (Languages), 不好意思 (Invitiation 1)
+Languages	写	寫	xiě	xiě	write	to write	to write		No Matches Found
+Languages	难	難	nán   nàn	nán   nàn	difficult	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold		难 (Languages), 难吃 (Food 3), 难过 (Personality and Feelings)
+Languages	思		sī	sī	think	to think / to consider	to think / to consider		意思 (Languages), 思 (Languages), 不好意思 (Invitiation 1)
+Time 3	秒		miǎo	miǎo	second	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly		No Matches Found
+Time 3	刻		kè	kè	engraved	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals		No Matches Found
+Time 3	差		chā   chà   chāi	chā   chà   chāi	difference	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission		差 (Time 3), 时差 (Travel 4), 差 (Travel 4), 出差 (Work 2), 差 (Work 2)
+Time 3	小时	小時	xiǎo shí	xiǎo shí	hour	hour / CL: 個｜个	hour / CL: 個｜个		No Matches Found
+Time 3	分钟	分鐘	fēn zhōng	fēn zhōng	minute	minute	minute		No Matches Found
+Time 3	小		xiǎo	xiǎo	small	small / tiny / few / young	small / tiny / few / young		小时 (Time 3), 小 (Time 3), 小费 (Dining 3), 小 (Shopping 2), 小笼包 (Gourmet 1), 小学 (People 3), 小姐 (Work), 小心 (Travel 4)
+Time 3	时	時	Shí   shí	Shí   shí	Time	surname Shi  o'clock / time / when / hour / season / period	surname Shi  o'clock / time / when / hour / season / period		小时 (Time 3), 时 (Time 3), 时间 (Invitiation 1), 时候 (Invitiation 1), 准时 (Time 4), 时差 (Travel 4)
+Time 3	钟	鍾	Zhōng   zhōng   zhōng	Zhōng   zhōng   zhōng	bell	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座		分钟 (Time 3), 钟 (Time 3), 钟 (Time 3)
+Time 3	整		zhěng	zhěng	whole	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb		No Matches Found
+Dining 2	杯		bēi	bēi	cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup		杯 (Dining 2), 杯子 (Dining 2), 干杯 (Celebration)
+Dining 2	啤		pí	pí	beer	beer	beer		啤 (Dining 2), 啤酒 (Dining 2)
+Dining 2	德		Dé   dé	Dé   dé	Morality	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind		德 (Dining 2), 德国 (Dining 2)
+Dining 2	德国	德國	Dé guó	Dé guó	Germany	Germany / German	Germany / German		No Matches Found
+Dining 2	啤酒		pí jiǔ	pí jiǔ	beer	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸		No Matches Found
+Dining 2	果汁		guǒ zhī	guǒ zhī	fruit juice	fruit juice	fruit juice		No Matches Found
+Dining 2	汁		zhī	zhī	juice	juice	juice		果汁 (Dining 2), 汁 (Dining 2)
+Dining 2	香蕉		xiāng jiāo	xiāng jiāo	banana	banana / CL: 枝, 根, 個｜个, 把	banana / CL: 枝, 根, 個｜个, 把		No Matches Found
+Dining 2	蛋糕		dàn gāo	dàn gāo	cake	cake / CL: 塊｜块, 個｜个	cake / CL: 塊｜块, 個｜个		No Matches Found
+Dining 2	蕉		jiāo   qiáo	jiāo   qiáo	banana	banana  see 蕉萃	banana  see 蕉萃		香蕉 (Dining 2), 蕉 (Dining 2)
+Dining 2	糕		gāo	gāo	cake	cake	cake		蛋糕 (Dining 2), 糕 (Dining 2)
+Dining 2	碗		wǎn	wǎn	bowl	bowl / cup / CL: 隻｜只, 個｜个	bowl / cup / CL: 隻｜只, 個｜个		No Matches Found
+Dining 2	杯子		bēi zi	bēi zi	cup	cup / glass / CL: 個｜个, 隻｜只	cup / glass / CL: 個｜个, 隻｜只		No Matches Found
+Dining 2	盘子	盤子	pán zi	pán zi	plate	tray / plate / dish / CL: 個｜个	tray / plate / dish / CL: 個｜个		No Matches Found
+Dining 2	盘	盤	pán	pán	plate	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess		盘子 (Dining 2), 盘 (Dining 2)
+Dining 2	筷子		kuài zi	kuài zi	chopsticks	chopsticks / CL: 對｜对, 根, 把, 雙｜双	chopsticks / CL: 對｜对, 根, 把, 雙｜双		No Matches Found
+Dining 2	刀		Dāo   dāo	Dāo   dāo	Knife	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs		No Matches Found
+Dining 2	叉		chā   chá   chǎ	chā   chá   chǎ	cross	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)		No Matches Found
+Dining 2	筷		kuài	kuài	chopsticks	chopstick	chopstick		筷子 (Dining 2), 筷 (Dining 2)
+Dining 2	勺子		sháo zi	sháo zi	Spoon	scoop / ladle / CL: 把	scoop / ladle / CL: 把		No Matches Found
+Dining 2	勺		sháo	sháo	Spoon	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)		勺子 (Dining 2), 勺 (Dining 2)
+Existence	室		Shì   shì	Shì   shì	room	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy		室 (Existence), 办公室 (Existence), 室 (School), 教室 (School)
+Existence	办	辦	bàn	bàn	do	to do / to manage / to handle / to go about / to run / to set up / to deal with	to do / to manage / to handle / to go about / to run / to set up / to deal with		办 (Existence), 办公室 (Existence), 怎么办 (Travel), 办 (Travel), 办法 (Work)
+Existence	辆	輛	liàng	liàng	Vehicles	classifier for vehicles	classifier for vehicles		No Matches Found
+Existence	办公室	辦公室	bàn gōng shì	bàn gōng shì	office	office / business premises / bureau / CL: 間｜间	office / business premises / bureau / CL: 間｜间		No Matches Found
+Existence	瓶子		píng zi	píng zi	bottle	bottle / CL: 個｜个	bottle / CL: 個｜个		No Matches Found
+Existence	照片		zhào piàn	zhào piàn	photo	photograph / picture / CL: 張｜张, 套, 幅	photograph / picture / CL: 張｜张, 套, 幅		No Matches Found
+Existence	瓶		píng	píng	bottle	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids		瓶子 (Existence), 瓶 (Existence), 瓶 (Celebration)
+Existence	片		piān   piàn	piān   piàn	sheet	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc		照片 (Existence), 片 (Existence)
+Existence	鸟	鳥	niǎo	niǎo	bird	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam		鸟 (Existence), 菜鸟 (Internet Slang)
+Existence	树	樹	shù	shù	tree	tree / CL: 棵 / to cultivate / to set up	tree / CL: 棵 / to cultivate / to set up		No Matches Found
+Sports 1	步		Bù   bù	Bù   bù	step	surname Bu  a step / a pace / walk / march / stages in a process / situation	surname Bu  a step / a pace / walk / march / stages in a process / situation		步 (Sports 1), 跑步 (Sports 1)
+Sports 1	跑		páo   pǎo	páo   pǎo	run	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off		跑 (Sports 1), 跑步 (Sports 1)
+Sports 1	泳		yǒng	yǒng	swimming	swimming / to swim	swimming / to swim		泳 (Sports 1), 游泳 (Sports 1)
+Sports 1	游泳		yóu yǒng	yóu yǒng	Swim	swimming / to swim	swimming / to swim		No Matches Found
+Sports 1	跑步		pǎo bù	pǎo bù	Run	to run / to jog / (military) to march at the double	to run / to jog / (military) to march at the double		No Matches Found
+Sports 1	踢		tī	tī	kick	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)		No Matches Found
+Sports 1	足球		zú qiú	zú qiú	football	soccer ball / a football / CL: 個｜个 / soccer / football	soccer ball / a football / CL: 個｜个 / soccer / football		No Matches Found
+Sports 1	打		dá   dǎ	dá   dǎ	hit	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from		打 (Sports 1), 打扮 (Invitation 2), 打折 (Shopping 4), 打算 (Future), 打扫 (House), 打车 (Travel 4)
+Sports 1	篮球	籃球	lán qiú	lán qiú	basketball	basketball / CL: 個｜个, 隻｜只	basketball / CL: 個｜个, 隻｜只		No Matches Found
+Sports 1	足		jù   zú	jù   zú	leg	excessive  foot / to be sufficient / ample	excessive  foot / to be sufficient / ample		足球 (Sports 1), 足 (Sports 1)
+Sports 1	篮	籃	lán	lán	basket	basket (receptacle) / basket (in basketball)	basket (receptacle) / basket (in basketball)		篮球 (Sports 1), 篮 (Sports 1)
+Sports 1	球		qiú	qiú	ball	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场		足球 (Sports 1), 篮球 (Sports 1), 球 (Sports 1), 乒乓球 (Sports 2), 网球 (Sports 2), 排球 (Sports 2)
+Sports 1	运动	運動	yùn dòng	yùn dòng	motion	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场		No Matches Found
+Sports 1	马	馬	Mǎ   mǎ	Mǎ   mǎ	horse	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess		马 (Sports 1), 马上 (Daily Routine 2), 马路 (Travel 4)
+Sports 1	骑	騎	jì   qí	jì   qí	ride	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses		No Matches Found
+Sports 1	运	運	yùn	yùn	Transport	to move / to transport / to use / to apply / fortune / luck / fate	to move / to transport / to use / to apply / fortune / luck / fate		运动 (Sports 1), 运 (Sports 1)
+Sports 1	动	動	dòng	dòng	move	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb		运动 (Sports 1), 动 (Sports 1), 动物 (Culture), 活动 (Travel 4)
+Invitiation 1	吧		bā   ba	bā   ba	It	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.		No Matches Found
+Invitiation 1	出去		chū qù	chū qù	Out	to go out	to go out		No Matches Found
+Invitiation 1	时间	時間	shí jiān	shí jiān	time	time / period / CL: 段	time / period / CL: 段		No Matches Found
+Invitiation 1	时候	時候	shí hou	shí hou	time	time / length of time / moment / period	time / length of time / moment / period		No Matches Found
+Invitiation 1	空		kōng   kòng	kōng   kòng	air	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time		空 (Invitiation 1), 空调 (House), 空 (House)
+Invitiation 1	来	來	lái	lái	Come	to come / to arrive / to come round / ever since / next	to come / to arrive / to come round / ever since / next		来 (Invitiation 1), 从来 (Weather), 越来越 (Time 4), 后来 (Languages 2), 看起来 (Personality and Feelings), 来 (Environment)
+Invitiation 1	候		hòu	hòu	Wait	to wait / to inquire after / to watch / season / climate / (old) period of five days	to wait / to inquire after / to watch / season / climate / (old) period of five days		时候 (Invitiation 1), 候 (Invitiation 1)
+Invitiation 1	过	過	Guò   guò   guo	Guò   guò   guo	Live	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)		过 (Invitiation 1), 过 (Celebration), 经过 (Shopping 4), 难过 (Personality and Feelings), 过 (Travel 4), 过去 (Communication 2)
+Invitiation 1	一起		yī qǐ	yī qǐ	together	in the same place / together / with / altogether (in total)	in the same place / together / with / altogether (in total)		No Matches Found
+Invitiation 1	不好意思		bù hǎo yì si	bù hǎo yì si	Feel embarrassed	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)		No Matches Found
+Invitiation 1	告诉	告訴	gào sù   gào su	gào sù   gào su	tell	to press charges / to file a complaint  to tell / to inform / to let know	to press charges / to file a complaint  to tell / to inform / to let know		No Matches Found
+Invitiation 1	告		gào	gào	Tell	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue		告诉 (Invitiation 1), 告 (Invitiation 1), 报告 (Business 1), 广告 (Business 1)
+Invitiation 1	诉	訴	sù	sù	Complaint	to complain / to sue / to tell	to complain / to sue / to tell		告诉 (Invitiation 1), 诉 (Invitiation 1)
+Invitiation 1	约会	約會	yuē huì	yuē huì	appointment	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet		No Matches Found
+Invitiation 1	浪漫		làng màn	làng màn	romantic	romantic	romantic		No Matches Found
+Invitiation 1	浪		làng	làng	wave	wave / breaker / unrestrained / dissipated	wave / breaker / unrestrained / dissipated		浪漫 (Invitiation 1), 浪 (Invitiation 1)
+Invitiation 1	漫		màn	màn	Overflow	free / unrestrained / to inundate	free / unrestrained / to inundate		浪漫 (Invitiation 1), 漫 (Invitiation 1), 漫游 (Travel 3)
+Health 2	该	該	gāi	gāi	That	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned		该 (Health 2), 应该 (Health 2)
+Health 2	病		bìng	bìng	disease	illness / CL: 場｜场 / disease / to fall ill / defect	illness / CL: 場｜场 / disease / to fall ill / defect		病 (Health 2), 生病 (Health 2)
+Health 2	舒		Shū   shū	Shū   shū	Shu	surname Shu  to stretch / to unfold / to relax / leisurely	surname Shu  to stretch / to unfold / to relax / leisurely		舒 (Health 2), 舒服 (Health 2)
+Health 2	应	應	Yìng   yīng   yìng	Yìng   yīng   yìng	should	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with		应 (Health 2), 应该 (Health 2), 应用 (Languages 3), 应 (Languages 3)
+Health 2	生病		shēng bìng	shēng bìng	sick	to fall ill	to fall ill		No Matches Found
+Health 2	应该	應該	yīng gāi	yīng gāi	should	ought to / should / must	ought to / should / must		No Matches Found
+Health 2	舒服		shū fu	shū fu	Comfortably	comfortable / feeling well	comfortable / feeling well		No Matches Found
+Health 2	疼		téng	téng	pain	(it) hurts / sore / to love dearly	(it) hurts / sore / to love dearly		No Matches Found
+Health 2	头	頭	tóu   tou	tóu   tou	head	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns		头 (Health 2), 头发 (Body Parts), 馒头 (Gourmet 2), 猫头鹰 (Duo)
+Health 2	休息		xiū xi	xiū xi	rest	rest / to rest	rest / to rest		No Matches Found
+Health 2	休		Xiū   xiū	Xiū   xiū	Rest	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't		休息 (Health 2), 休 (Health 2)
+Health 2	息		xī	xī	interest	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]		休息 (Health 2), 息 (Health 2)
+Health 2	肚子		dù zi	dù zi	belly	belly / abdomen / stomach / CL: 個｜个	belly / abdomen / stomach / CL: 個｜个		No Matches Found
+Health 2	肚		dǔ   dù	dǔ   dù	tripe	tripe  belly	tripe  belly		肚子 (Health 2), 肚 (Health 2)
+Health 2	药	葯	yào   yào	yào   yào	medicine	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison		No Matches Found
+Health 2	一定		yī dìng	yī dìng	for sure	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must		No Matches Found
+Health 2	感冒		gǎn mào	gǎn mào	cold	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand		No Matches Found
+Health 2	感		gǎn	gǎn	sense	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~		感冒 (Health 2), 感 (Health 2), 感兴趣 (Hobbies 3), 感谢 (Business 2)
+Health 2	定		dìng	dìng	set	to set / to fix / to determine / to decide / to order	to set / to fix / to determine / to decide / to order		一定 (Health 2), 定 (Health 2), 决定 (Work 2), 定 (Work 2)
+Health 2	冒		Mào   mào	Mào   mào	Risk	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover		感冒 (Health 2), 冒 (Health 2)
+Health 2	留		liú	liú	stay	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve		留 (Health 2), 留学 (Future)
+Health 2	请假	請假	qǐng jià	qǐng jià	Ask for leave	to request leave of absence	to request leave of absence		No Matches Found
+Health 2	发烧	發燒	fā shāo	fā shāo	fever	to have a high temperature (from illness) / to have a fever	to have a high temperature (from illness) / to have a fever		No Matches Found
+Health 2	别	別	Bié   bié   biè	Bié   bié   biè	do not	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc		别 (Health 2), 别人 (People 2), 特别 (Hobbies 3)
+Health 2	发	發	fā   fà	fā   fà	hair	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]		发烧 (Health 2), 发 (Health 2), 头发 (Body Parts), 发 (Body Parts), 发现 (Travel 2), 发 (Travel 2), 发 (Communication 2), 发财 (Festivals), 转发 (Internet Slang), 发生 (Emergency)
+Health 2	假		jiǎ   jià	jiǎ   jià	false	fake / false / artificial / to borrow / if / suppose  vacation	fake / false / artificial / to borrow / if / suppose  vacation		请假 (Health 2), 假 (Health 2), 放假 (Exam), 暑假 (Exam), 寒假 (Exam)
+Health 2	烧	燒	shāo	shāo	burn	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head		发烧 (Health 2), 烧 (Health 2)
+Invitation 2	派		pài	pài	send	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie		派 (Invitation 2), 派对 (Invitation 2)
+Invitation 2	能		Néng   néng	Néng   néng	can	surname Neng  can / to be able to / might possibly / ability / (physics) energy	surname Neng  can / to be able to / might possibly / ability / (physics) energy		能 (Invitation 2), 可能 (Weather)
+Invitation 2	生日		shēng rì	shēng rì	birthday	birthday / CL: 個｜个	birthday / CL: 個｜个		No Matches Found
+Invitation 2	派对	派對	pài duì	pài duì	Party	party (loanword)	party (loanword)		No Matches Found
+Invitation 2	打扮		dǎ ban	dǎ ban	dress up	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress		No Matches Found
+Invitation 2	扮		bàn	bàn	Play	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)		打扮 (Invitation 2), 扮 (Invitation 2)
+Invitation 2	希望		xī wàng	xī wàng	hope	to wish for / to desire / hope / CL: 個｜个	to wish for / to desire / hope / CL: 個｜个		No Matches Found
+Invitation 2	跟		gēn	gēn	with	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)		No Matches Found
+Invitation 2	希		xī	xī	hope	to hope / to admire / variant of 稀	to hope / to admire / variant of 稀		希望 (Invitation 2), 希 (Invitation 2)
+Invitation 2	望		wàng   wàng	wàng   wàng	hope	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望		希望 (Invitation 2), 望 (Invitation 2), 失望 (Sports 2)
+Invitation 2	大家		dà jiā	dà jiā	everyone	everyone / influential family / great expert	everyone / influential family / great expert		No Matches Found
+Invitation 2	公司		gōng sī	gōng sī	the company	(business) company / company / firm / corporation / incorporated / CL: 家	(business) company / company / firm / corporation / incorporated / CL: 家		No Matches Found
+Invitation 2	正在		zhèng zài	zhèng zài	Seizai	just at (that time) / right in (that place) / right in the middle of (doing sth)	just at (that time) / right in (that place) / right in the middle of (doing sth)		No Matches Found
+Invitation 2	正		zhēng   zhèng	zhēng   zhèng	positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive		正在 (Invitation 2), 正 (Invitation 2)
+Invitation 2	司		Sī   sī	Sī   sī	Department	surname Si  to take charge of / to manage / department (under a ministry)	surname Si  to take charge of / to manage / department (under a ministry)		公司 (Invitation 2), 司 (Invitation 2), 司机 (Travel 4)
+Invitation 2	事情		shì qing	shì qing	thing	affair / matter / thing / business / CL: 件, 樁｜桩	affair / matter / thing / business / CL: 件, 樁｜桩		No Matches Found
+Invitation 2	才		cái   cái	cái   cái	only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only		才 (Invitation 2), 刚才 (Communication 2)
+Invitation 2	事		shì	shì	Thing	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回		事情 (Invitation 2), 事 (Invitation 2), 故事 (Daily Routine 2), 同事 (Work), 事 (Emergency)
+Invitation 2	情		qíng	qíng	situation	feeling / emotion / passion / situation	feeling / emotion / passion / situation		事情 (Invitation 2), 情 (Invitation 2), 热情 (Personality and Feelings)
+Dining 3	费	費	Fèi   fèi	Fèi   fèi	fee	surname Fei  to cost / to spend / fee / wasteful / expenses	surname Fei  to cost / to spend / fee / wasteful / expenses		费 (Dining 3), 小费 (Dining 3), 免费 (Travel 4), 费用 (Business 1)
+Dining 3	完		wán	wán	Finish	to finish / to be over / whole / complete / entire	to finish / to be over / whole / complete / entire		完 (Dining 3), 完成 (School 2)
+Dining 3	经	經	Jīng   jīng	Jīng   jīng	through	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济		经 (Dining 3), 已经 (Dining 3), 经 (Shopping 4), 经过 (Shopping 4), 经常 (Personality and Feelings), 经理 (Work)
+Dining 3	已		yǐ	yǐ	Already	already / to stop / then / afterwards	already / to stop / then / afterwards		已 (Dining 3), 已经 (Dining 3)
+Dining 3	已经	已經	yǐ jīng	yǐ jīng	already	already	already		No Matches Found
+Dining 3	小费	小費	xiǎo fèi	xiǎo fèi	tip	tip / gratuity	tip / gratuity		No Matches Found
+Dining 3	饱	飽	bǎo	bǎo	full	to eat till full / satisfied	to eat till full / satisfied		No Matches Found
+Dining 3	好吃		hǎo chī   hào chī	hǎo chī   hào chī	good to eat	tasty / delicious  to be fond of eating / to be gluttonous	tasty / delicious  to be fond of eating / to be gluttonous		No Matches Found
+Dining 3	真		zhēn	zhēn	true	really / truly / indeed / real / true / genuine	really / truly / indeed / real / true / genuine		真 (Dining 3), 认真 (Future)
+Dining 3	饿	餓	è	è	hungry	to be hungry / hungry / to starve (sb)	to be hungry / hungry / to starve (sb)		No Matches Found
+Dining 3	好喝		hǎo hē	hǎo hē	Tasty	tasty (drinks)	tasty (drinks)		No Matches Found
+Dining 3	渴		kě	kě	thirsty	thirsty	thirsty		No Matches Found
+Dining 3	巧克力		qiǎo kè lì	qiǎo kè lì	chocolate	chocolate (loanword) / CL: 塊｜块	chocolate (loanword) / CL: 塊｜块		No Matches Found
+Dining 3	味道		wèi dao	wèi dao	taste	flavor / smell / hint of	flavor / smell / hint of		No Matches Found
+Dining 3	甜点	甜點	tián diǎn	tián diǎn	dessert	dessert	dessert		No Matches Found
+Dining 3	甜		tián	tián	sweet	sweet	sweet		甜点 (Dining 3), 甜 (Dining 3), 甜 (Food 3)
+Dining 3	巧		qiǎo	qiǎo	Opportunely	opportunely / coincidentally / as it happens / skillful / timely	opportunely / coincidentally / as it happens / skillful / timely		巧克力 (Dining 3), 巧 (Dining 3)
+Dining 3	克		kè   Kè   kēi	kè   Kè   kēi	Gram	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat		巧克力 (Dining 3), 克 (Dining 3)
+Dining 3	力		Lì   lì	Lì   lì	force	surname Li  power / force / strength / ability / strenuously	surname Li  power / force / strength / ability / strenuously		巧克力 (Dining 3), 力 (Dining 3), 努力 (Languages 2), 力 (Languages 2), 压力 (Work 3)
+Shopping 2	试	試	shì	shì	test	to test / to try / experiment / examination / test	to test / to try / experiment / examination / test		试 (Shopping 2), 考试 (School), 面试 (Work 2)
+Shopping 2	蓝	藍	Lán   lán	Lán   lán	blue	surname Lan  blue / indigo plant	surname Lan  blue / indigo plant		No Matches Found
+Shopping 2	条	條	tiáo	tiáo	article	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)		面条 (Dining 1), 条 (Shopping 2), 油条 (Gourmet 1)
+Shopping 2	裙		qún	qún	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条		裙 (Shopping 2), 裙子 (Shopping 2)
+Shopping 2	裙子		qún zi	qún zi	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条		No Matches Found
+Shopping 2	双	雙	Shuāng   shuāng	Shuāng   shuāng	double	surname Shuang  two / double / pair / both / even (number)	surname Shuang  two / double / pair / both / even (number)		No Matches Found
+Shopping 2	鞋子		xié zi	xié zi	Shoe	shoe	shoe		No Matches Found
+Shopping 2	意大利		Yì dà lì	Yì dà lì	Italy	Italy / Italian	Italy / Italian		No Matches Found
+Shopping 2	色		sè   shǎi	sè   shǎi	color	color / CL: 種｜种 / look / appearance / sex  color / dice	color / CL: 種｜种 / look / appearance / sex  color / dice		色 (Shopping 2), 颜色 (Shopping 3), 色 (Shopping 3)
+Shopping 2	鞋		xié	xié	shoe	shoe / CL: 雙｜双, 隻｜只	shoe / CL: 雙｜双, 隻｜只		鞋子 (Shopping 2), 鞋 (Shopping 2), 皮鞋 (Shopping 4)
+Shopping 2	利		Lì   lì	Lì   lì	Profit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit		意大利 (Shopping 2), 利 (Shopping 2), 澳大利亚 (Time 4), 流利 (Languages 3), 利 (Languages 3)
+Shopping 2	比		Bǐ   bǐ   bì	Bǐ   bǐ   bì	ratio	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near		比 (Shopping 2), 比赛 (Sports 2), 比较 (People 3)
+Shopping 2	衬衫	襯衫	chèn shān	chèn shān	shirt	shirt / blouse / CL: 件	shirt / blouse / CL: 件		No Matches Found
+Shopping 2	衬	襯	chèn	chèn	lining	(of garments) against the skin / to line / lining / to contrast with / to assist financially	(of garments) against the skin / to line / lining / to contrast with / to assist financially		衬衫 (Shopping 2), 衬 (Shopping 2)
+Shopping 2	衫		shān	shān	Shirt	garment / jacket with open slits in place of sleeves	garment / jacket with open slits in place of sleeves		衬衫 (Shopping 2), 衫 (Shopping 2)
+Shopping 2	裤子	褲子	kù zi	kù zi	pants	trousers / pants / CL: 條｜条	trousers / pants / CL: 條｜条		No Matches Found
+Shopping 2	好看		hǎo kàn	hǎo kàn	good looking	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated		No Matches Found
+Shopping 2	裤	褲	kù	kù	pants	underpants / trousers / pants	underpants / trousers / pants		裤子 (Shopping 2), 裤 (Shopping 2)
+Shopping 2	质	質	zhì	zhì	quality	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]		质 (Shopping 2), 质量 (Shopping 2)
+Shopping 2	量		liáng   liàng	liáng   liàng	the amount	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word		量 (Shopping 2), 质量 (Shopping 2), 商量 (Work 3)
+Shopping 2	质量	質量	zhì liàng	zhì liàng	quality	quality / (physics) mass / CL: 個｜个	quality / (physics) mass / CL: 個｜个		No Matches Found
+Body Parts	朵		duǒ	duǒ	Flowers	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc		朵 (Body Parts), 耳朵 (Body Parts)
+Body Parts	睛		jīng	jīng	eye	eye / eyeball	eye / eyeball		睛 (Body Parts), 眼睛 (Body Parts)
+Body Parts	绿	綠	lǜ	lǜ	green	green	green		绿 (Body Parts), 红绿灯 (Travel 4)
+Body Parts	耳		ěr	ěr	ear	ear / handle (archaeology) / and that is all (classical Chinese)	ear / handle (archaeology) / and that is all (classical Chinese)		耳 (Body Parts), 耳朵 (Body Parts)
+Body Parts	眼		yǎn	yǎn	eye	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)		眼 (Body Parts), 眼睛 (Body Parts), 眼镜 (People 3)
+Body Parts	耳朵		ěr duo	ěr duo	ear	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)		No Matches Found
+Body Parts	眼睛		yǎn jing	yǎn jing	eye	eye / CL: 隻｜只, 雙｜双	eye / CL: 隻｜只, 雙｜双		No Matches Found
+Body Parts	头发	頭髮	tóu fa	tóu fa	hair	hair (on the head)	hair (on the head)		No Matches Found
+Body Parts	脸	臉	liǎn	liǎn	face	face / CL: 張｜张, 個｜个	face / CL: 張｜张, 個｜个		No Matches Found
+Body Parts	又		yòu	yòu	also	(once) again / also / both... and... / and yet / (used for emphasis) anyway	(once) again / also / both... and... / and yet / (used for emphasis) anyway		No Matches Found
+Body Parts	黑		Hēi   hēi	Hēi   hēi	black	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)		黑 (Body Parts), 黑板 (School 2)
+Body Parts	嘴巴		zuǐ ba	zuǐ ba	mouth	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	mouth / CL: 張｜张 / slap in the face / CL: 個｜个		No Matches Found
+Body Parts	鼻子		bí zi	bí zi	nose	nose / CL: 個｜个, 隻｜只	nose / CL: 個｜个, 隻｜只		No Matches Found
+Body Parts	脚	腳	jiǎo	jiǎo	foot	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks		No Matches Found
+Body Parts	嘴		zuǐ	zuǐ	mouth	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个		嘴巴 (Body Parts), 嘴 (Body Parts)
+Body Parts	鼻		bí	bí	nose	nose	nose		鼻子 (Body Parts), 鼻 (Body Parts)
+Body Parts	巴		Bā   bā	Bā   bā	-bar	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail		嘴巴 (Body Parts), 巴 (Body Parts)
+Travel	远	遠	yuǎn   yuàn	yuǎn   yuàn	far	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)		No Matches Found
+Travel	离		chī   Lí   lí	chī   Lí   lí	from	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲		离 (Travel), 离开 (Travel 2)
+Travel	走路		zǒu lù	zǒu lù	walk	to walk / to go on foot	to walk / to go on foot		No Matches Found
+Travel	开车	開車	kāi chē	kāi chē	Drive a car	to drive a car	to drive a car		No Matches Found
+Travel	飞机	飛機	fēi jī	fēi jī	aircraft	airplane / CL: 架	airplane / CL: 架		No Matches Found
+Travel	机场	機場	jī chǎng	jī chǎng	airport	airport / airfield / CL: 家, 處｜处	airport / airfield / CL: 家, 處｜处		No Matches Found
+Travel	飞	飛	fēi	fēi	fly	to fly	to fly		飞机 (Travel), 飞 (Travel), 起飞 (Travel 2)
+Travel	场	場	cháng   chǎng	cháng   chǎng	field	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams		机场 (Travel), 场 (Travel)
+Travel	靠		kào	kào	by	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)		No Matches Found
+Travel	停		tíng	tíng	stop	to stop / to halt / to park (a car)	to stop / to halt / to park (a car)		No Matches Found
+Travel	火车	火車	huǒ chē	huǒ chē	train	train / CL: 列, 節｜节, 班, 趟	train / CL: 列, 節｜节, 班, 趟		No Matches Found
+Travel	票		piào	piào	ticket	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions		票 (Travel), 机票 (Travel)
+Travel	机票	機票	jī piào	jī piào	Air tickets	air ticket / passenger ticket / CL: 張｜张	air ticket / passenger ticket / CL: 張｜张		No Matches Found
+Travel	火		Huǒ   huǒ	Huǒ   huǒ	fire	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)		火车 (Travel), 火 (Travel), 火锅 (Gourmet 1)
+Travel	迟到	遲到	chí dào	chí dào	be late	to arrive late	to arrive late		No Matches Found
+Travel	让	讓	ràng	ràng	Let	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)		No Matches Found
+Travel	怎么办	怎麼辦	zěn me bàn	zěn me bàn	How to do	what's to be done	what's to be done		No Matches Found
+Travel	迟	遲	Chí   chí	Chí   chí	late	surname Chi  late / delayed / slow	surname Chi  late / delayed / slow		迟到 (Travel), 迟 (Travel)
+Weather	冷		Lěng   lěng	Lěng   lěng	cold	surname Leng  cold	surname Leng  cold		No Matches Found
+Weather	晴		qíng	qíng	clear	clear / fine (weather)	clear / fine (weather)		No Matches Found
+Weather	天气	天氣	tiān qì	tiān qì	the weather	weather	weather		No Matches Found
+Weather	雨		yǔ   yù	yǔ   yù	rain	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet		No Matches Found
+Weather	雪		Xuě   xuě	Xuě   xuě	snow	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean		No Matches Found
+Weather	阴	陰	Yīn   yīn	Yīn   yīn	Yin	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia		No Matches Found
+Weather	着	著	zhāo   zháo   zhe   zhuó	zhāo   zháo   zhe   zhuó	The	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply		着 (Weather), 着急 (Health 3), 着 (Health 3)
+Weather	伞	傘	sǎn   sǎn	sǎn   sǎn	umbrella	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞		No Matches Found
+Weather	带	帶	dài	dài	band	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise		No Matches Found
+Weather	外面		wài miàn	wài miàn	outside	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance		No Matches Found
+Weather	可能		kě néng	kě néng	may	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个		No Matches Found
+Weather	刮		guā   guā	guā   guā	scratch	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)		No Matches Found
+Weather	风	風	fēng	fēng	wind	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝		风 (Weather), 风景 (Travel 4), 风险 (Business 2)
+Weather	如果		rú guǒ	rú guǒ	in case	if / in case / in the event that	if / in case / in the event that		No Matches Found
+Weather	就		jiù	jiù	on	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning		No Matches Found
+Weather	从来	從來	cóng lái	cóng lái	Never	always / at all times / never (if used in negative sentence)	always / at all times / never (if used in negative sentence)		No Matches Found
+Weather	如		rú	rú	Such as	as / as if / such as	as / as if / such as		如果 (Weather), 如 (Weather)
+Weather	里面	裡面	lǐ miàn	lǐ miàn	inside	inside / interior / also pr. [li3 mian5]	inside / interior / also pr. [li3 mian5]		No Matches Found
+Shopping 3	然		rán	rán	However	correct / right / so / thus / like this / -ly	correct / right / so / thus / like this / -ly		然 (Shopping 3), 虽然 (Shopping 3), 然后 (Location 6), 当然 (Future), 突然 (Work)
+Shopping 3	但		dàn	dàn	but	but / yet / however / only / merely / still	but / yet / however / only / merely / still		但 (Shopping 3), 但是 (Shopping 3), 不但 (People 2)
+Shopping 3	虽	雖	suī	suī	although	although / even though	although / even though		虽 (Shopping 3), 虽然 (Shopping 3)
+Shopping 3	短		duǎn	duǎn	short	short / brief / to lack / weak point / fault	short / brief / to lack / weak point / fault		短 (Shopping 3), 短信 (Communication 2)
+Shopping 3	长	長	cháng   zhǎng	cháng   zhǎng	long	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance		长 (Shopping 3), 长 (People 3), 校长 (School 2), 长江 (Culture), 长城 (Culture)
+Shopping 3	虽然	雖然	suī rán	suī rán	although	although / even though / even if	although / even though / even if		No Matches Found
+Shopping 3	但是		dàn shì	dàn shì	but	but / however	but / however		No Matches Found
+Shopping 3	红	紅	Hóng   hóng	Hóng   hóng	red	surname Hong  red / popular / revolutionary / bonus	surname Hong  red / popular / revolutionary / bonus		红 (Shopping 3), 红酒 (Celebration), 红绿灯 (Travel 4), 红包 (Festivals)
+Shopping 3	颜色	顏色	yán sè	yán sè	colour	color / countenance / appearance / facial expression / pigment / dyestuff	color / countenance / appearance / facial expression / pigment / dyestuff		No Matches Found
+Shopping 3	穿		chuān	chuān	wear	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread		No Matches Found
+Shopping 3	颜	顏	Yán   yán	Yán   yán	Color	surname Yan  color / face / countenance	surname Yan  color / face / countenance		颜色 (Shopping 3), 颜 (Shopping 3)
+Shopping 3	黄	黃	Huáng   huáng	Huáng   huáng	yellow	surname Huang or Hwang  yellow / pornographic / to fall through	surname Huang or Hwang  yellow / pornographic / to fall through		黄 (Shopping 3), 黄河 (Culture)
+Shopping 3	手表	手錶	shǒu biǎo	shǒu biǎo	Watch	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	wrist watch / CL: 塊｜块, 隻｜只, 個｜个		No Matches Found
+Shopping 3	卖	賣	mài	mài	Sell	to sell / to betray / to spare no effort / to show off or flaunt	to sell / to betray / to spare no effort / to show off or flaunt		No Matches Found
+Shopping 3	帽子		mào zi	mào zi	hat	hat / cap / (fig.) label / bad name / CL: 頂｜顶	hat / cap / (fig.) label / bad name / CL: 頂｜顶		No Matches Found
+Shopping 3	帽		mào	mào	cap	hat / cap	hat / cap		帽子 (Shopping 3), 帽 (Shopping 3)
+Shopping 3	表		biǎo   biǎo	biǎo   biǎo	table	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch		手表 (Shopping 3), 表 (Shopping 3), 表演 (Travel 4), 表现 (Work 2)
+Shopping 3	紫		zǐ	zǐ	purple	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki		No Matches Found
+People 2	绍	紹	Shào   shào	Shào   shào	Introduce	surname Shao  to continue / to carry on	surname Shao  to continue / to carry on		绍 (People 2), 介绍 (People 2)
+People 2	介		jiè	jiè	Introduction	to introduce / to lie between / between / shell / armor	to introduce / to lie between / between / shell / armor		介 (People 2), 介绍 (People 2)
+People 2	介绍	介紹	jiè shào	jiè shào	Introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction		No Matches Found
+People 2	帅	帥	Shuài   shuài	Shuài   shuài	Shuai	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!		帅 (People 2), 高富帅 (Internet Slang)
+People 2	笑		xiào	xiào	Lol	laugh / smile / CL: 個｜个	laugh / smile / CL: 個｜个		笑 (People 2), 好笑 (Personality and Feelings)
+People 2	说话	說話	shuō huà	shuō huà	speak	to speak / to say / to talk / to gossip / to tell stories / talk / word	to speak / to say / to talk / to gossip / to tell stories / talk / word		No Matches Found
+People 2	聪明	聰明	cōng ming	cōng ming	clever	intelligent / clever / bright / smart / acute (of sight and hearing)	intelligent / clever / bright / smart / acute (of sight and hearing)		No Matches Found
+People 2	别人	別人	bié ren	bié ren	other people	other people / others / other person	other people / others / other person		No Matches Found
+People 2	不但		bù dàn	bù dàn	Not only	not only (... but also...)	not only (... but also...)		No Matches Found
+People 2	而且		ér qiě	ér qiě	and	(not only ...) but also / moreover / in addition / furthermore	(not only ...) but also / moreover / in addition / furthermore		No Matches Found
+People 2	聪	聰	cōng	cōng	Clever	quick at hearing / wise / clever / sharp-witted / intelligent / acute	quick at hearing / wise / clever / sharp-witted / intelligent / acute		聪明 (People 2), 聪 (People 2)
+People 2	而		ér	ér	and	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)		而且 (People 2), 而 (People 2)
+People 2	且		qiě	qiě	And	and / moreover / yet / for the time being / to be about to / both (... and...)	and / moreover / yet / for the time being / to be about to / both (... and...)		而且 (People 2), 且 (People 2)
+Celebration	春		Chūn   chūn	Chūn   chūn	spring	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life		春 (Celebration), 春节 (Celebration), 春 (Time 4), 春卷 (Gourmet 2)
+Celebration	快乐	快樂	kuài lè	kuài lè	happy	happy / merry	happy / merry		No Matches Found
+Celebration	节日	節日	jié rì	jié rì	festival	holiday / festival / CL: 個｜个	holiday / festival / CL: 個｜个		No Matches Found
+Celebration	春节	春節	Chūn jié	Chūn jié	Spring Festival	Spring Festival (Chinese New Year)	Spring Festival (Chinese New Year)		No Matches Found
+Celebration	礼物	禮物	lǐ wù	lǐ wù	gift	gift / present / CL: 件, 個｜个, 份	gift / present / CL: 件, 個｜个, 份		No Matches Found
+Celebration	送		sòng	sòng	give away	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send		No Matches Found
+Celebration	新年		xīn nián	xīn nián	new Year	New Year / CL: 個｜个	New Year / CL: 個｜个		No Matches Found
+Celebration	白酒		bái jiǔ	bái jiǔ	Spirit	baijiu, a spirit usually distilled from sorghum	baijiu, a spirit usually distilled from sorghum		No Matches Found
+Celebration	礼	禮	Lǐ   lǐ	Lǐ   lǐ	ceremony	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy		礼物 (Celebration), 礼 (Celebration)
+Celebration	物		wù	wù	object	thing / object / matter / abbr. for physics 物理	thing / object / matter / abbr. for physics 物理		礼物 (Celebration), 物 (Celebration), 动物 (Culture), 博物馆 (Travel 4)
+Celebration	干杯	乾杯	gān bēi	gān bēi	Cheers	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup		No Matches Found
+Celebration	祝		Zhù   zhù	Zhù   zhù	wish	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	surname Zhu  to wish / to express good wishes / to pray / (old) wizard		No Matches Found
+Celebration	法国	法國	Fǎ guó	Fǎ guó	France	France / French	France / French		No Matches Found
+Celebration	红酒		hóng jiǔ	hóng jiǔ	Red wine	Red wine	Red wine		No Matches Found
+Celebration	法		Fǎ   fǎ	Fǎ   fǎ	law	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist		法国 (Celebration), 法 (Celebration), 办法 (Work), 法 (Work), 语法 (Languages 3)
+Sports 2	赛	賽	sài	sài	Competition	to compete / competition / match / to surpass / better than / superior to / to excel	to compete / competition / match / to surpass / better than / superior to / to excel		赛 (Sports 2), 比赛 (Sports 2)
+Sports 2	练	練	liàn	liàn	practice	to practice / to train / to drill / to perfect (one's skill) / exercise	to practice / to train / to drill / to perfect (one's skill) / exercise		练 (Sports 2), 练习 (Sports 2)
+Sports 2	练习	練習	liàn xí	liàn xí	Exercise	to practice / exercise / drill / practice / CL: 個｜个	to practice / exercise / drill / practice / CL: 個｜个		No Matches Found
+Sports 2	比赛	比賽	bǐ sài	bǐ sài	game	competition (sports etc) / match / CL: 場｜场, 次 / to compete	competition (sports etc) / match / CL: 場｜场, 次 / to compete		No Matches Found
+Sports 2	好在		hǎo zài	hǎo zài	Fortunately	luckily / fortunately	luckily / fortunately		No Matches Found
+Sports 2	乒乓球		pīng pāng qiú	pīng pāng qiú	pingpong	table tennis / ping-pong / table tennis ball / CL: 個｜个	table tennis / ping-pong / table tennis ball / CL: 個｜个		No Matches Found
+Sports 2	乒		pīng	pīng	Table tennis	(onom.) ping / bing	(onom.) ping / bing		乒乓球 (Sports 2), 乒 (Sports 2)
+Sports 2	乓		pāng	pāng	Bang	(onom.) bang	(onom.) bang		乒乓球 (Sports 2), 乓 (Sports 2)
+Sports 2	参加	參加	cān jiā	cān jiā	participate	to participate / to take part / to join	to participate / to take part / to join		No Matches Found
+Sports 2	第		dì	dì	The first	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just		No Matches Found
+Sports 2	参	參	cān   shēn	cān   shēn	Ginseng	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations		参加 (Sports 2), 参 (Sports 2), 参观 (Travel 4)
+Sports 2	网球	網球	wǎng qiú	wǎng qiú	tennis	tennis / tennis ball / CL: 個｜个	tennis / tennis ball / CL: 個｜个		No Matches Found
+Sports 2	排球		pái qiú	pái qiú	volleyball	volleyball / CL: 個｜个	volleyball / CL: 個｜个		No Matches Found
+Sports 2	加油		jiā yóu	jiā yóu	Refuel	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on		No Matches Found
+Sports 2	排		pái	pái	row	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc		排球 (Sports 2), 排 (Sports 2), 安排 (Travel 4), 排 (Travel 4)
+Sports 2	油		yóu	yóu	oil	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning		加油 (Sports 2), 油 (Sports 2), 油条 (Gourmet 1), 油 (Gourmet 1)
+Sports 2	输	輸	shū	shū	lose	to lose / to transport / to donate / to enter (a password)	to lose / to transport / to donate / to enter (a password)		No Matches Found
+Sports 2	赢	贏	yíng	yíng	win	to beat / to win / to profit	to beat / to win / to profit		No Matches Found
+Sports 2	失望		shī wàng	shī wàng	Disappointed	disappointed / to lose hope / to despair	disappointed / to lose hope / to despair		No Matches Found
+Sports 2	信心		xìn xīn	xìn xīn	confidence	confidence / faith (in sb or sth) / CL: 個｜个	confidence / faith (in sb or sth) / CL: 個｜个		No Matches Found
+Sports 2	失		shī	shī	Lose	to lose / to miss / to fail	to lose / to miss / to fail		失望 (Sports 2), 失 (Sports 2)
+Sports 2	心		xīn	xīn	heart	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个		信心 (Sports 2), 心 (Sports 2), 点心 (Gourmet 1), 关心 (Personality and Feelings), 放心 (Future), 担心 (Exam), 小心 (Travel 4)
+School	同	仝	tóng   tóng   tòng	tóng   tóng   tòng	with	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同		同 (School), 同学 (School), 同事 (Work), 同意 (Work 2), 合同 (Business 1)
+School	课	課	kè	kè	class	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination		课 (School), 下课 (School)
+School	教		Jiào   jiāo   jiào	Jiào   jiāo   jiào	teach	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	surname Jiao  to teach  religion / teaching / to make / to cause / to tell		教 (School), 教室 (School), 教 (School 2)
+School	教室		jiào shì	jiào shì	Classroom	classroom / CL: 間｜间	classroom / CL: 間｜间		No Matches Found
+School	同学	同學	tóng xué	tóng xué	Classmate	to study at the same school / fellow student / classmate / CL: 位, 個｜个	to study at the same school / fellow student / classmate / CL: 位, 個｜个		No Matches Found
+School	地理		dì lǐ	dì lǐ	Geography	geography	geography		No Matches Found
+School	理		lǐ	lǐ	Reason	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up		地理 (School), 理 (School), 经理 (Work)
+School	懂		dǒng	dǒng	understand	to understand / to comprehend	to understand / to comprehend		No Matches Found
+School	问题	問題	wèn tí	wèn tí	problem	question / problem / issue / topic / CL: 個｜个	question / problem / issue / topic / CL: 個｜个		No Matches Found
+School	笔	筆	bǐ	bǐ	pen	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝		笔 (School), 笔记 (School 2), 铅笔 (School 2), 笔记本 (School 2)
+School	题	題	Tí   tí	Tí   tí	question	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道		问题 (School), 题 (School), 题 (School)
+School	美术	美術	měi shù	měi shù	art	art / fine arts / painting / CL: 種｜种	art / fine arts / painting / CL: 種｜种		No Matches Found
+School	术	術	shù   zhú	shù   zhú	Technique	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea		美术 (School), 术 (School)
+School	考试	考試	kǎo shì	kǎo shì	examination	to take an exam / exam / CL: 次	to take an exam / exam / CL: 次		No Matches Found
+School	准备	準備	zhǔn bèi	zhǔn bèi	ready	preparation / to prepare / to intend / to be about to / reserve (fund)	preparation / to prepare / to intend / to be about to / reserve (fund)		No Matches Found
+School	考	攷	kǎo   kǎo	kǎo   kǎo	test	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father		考试 (School), 考 (School), 考 (Languages 2)
+School	备	備	bèi	bèi	Equipment	to prepare / get ready / to provide or equip	to prepare / get ready / to provide or equip		准备 (School), 备 (School)
+School	科学	科學	kē xué	kē xué	science	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种		No Matches Found
+School	科		kē	kē	Family	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个		科学 (School), 科 (School)
+School	下课	下課	xià kè	xià kè	Finish class	to finish class / to get out of class	to finish class / to get out of class		No Matches Found
+Family 3	爷爷	爺爺	yé ye	yé ye	grandfather	(coll.) father's father / paternal grandfather / CL: 個｜个	(coll.) father's father / paternal grandfather / CL: 個｜个		No Matches Found
+Family 3	奶奶		nǎi nai	nǎi nai	grandmother	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts		No Matches Found
+Family 3	阿姨		ā yí	ā yí	Auntie	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个		No Matches Found
+Family 3	爷	爺	yé	yé	Father	grandpa / old gentleman	grandpa / old gentleman		爷爷 (Family 3), 爷 (Family 3)
+Family 3	阿		Ā   ā   ē	Ā   ā   ē	A	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter		阿姨 (Family 3), 阿 (Family 3)
+Family 3	姨		yí	yí	aunt	mother's sister / aunt	mother's sister / aunt		阿姨 (Family 3), 姨 (Family 3)
+Family 3	兄弟姐妹		xiōng dì jiě mèi	xiōng dì jiě mèi	brothers and sisters	Brothers and Sisters	Brothers and Sisters		No Matches Found
+Family 3	关系	關係	guān xi	guān xi	relationship	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个		没关系 (Phrases 1), 关系 (Family 3)
+Family 3	叔叔		shū shu	shū shu	uncle	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个		No Matches Found
+Family 3	父母		fù mǔ	fù mǔ	parents	father and mother / parents	father and mother / parents		No Matches Found
+Family 3	兄		xiōng	xiōng	Brother	elder brother	elder brother		兄弟姐妹 (Family 3), 兄 (Family 3)
+Family 3	叔		shū	shū	uncle	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]		叔叔 (Family 3), 叔 (Family 3)
+Family 3	父		fù	fù	father	father	father		父母 (Family 3), 父 (Family 3)
+Family 3	母		mǔ	mǔ	mother	mother / elderly female relative / origin / source / (of animals) female	mother / elderly female relative / origin / source / (of animals) female		父母 (Family 3), 母 (Family 3)
+Family 3	像		xiàng	xiàng	image	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)		No Matches Found
+Family 3	一样	一樣	yī yàng	yī yàng	same	same / like / equal to / the same as / just like	same / like / equal to / the same as / just like		No Matches Found
+Family 3	亲戚	親戚	qīn qi	qīn qi	relative	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位		No Matches Found
+Family 3	戚		Qī   qī	Qī   qī	Qi	surname Qi  relative / parent / grief / sorrow / battle-axe	surname Qi  relative / parent / grief / sorrow / battle-axe		亲戚 (Family 3), 戚 (Family 3)
+Family 3	亲	親	qīn   qìng	qīn   qìng	Dear	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring		亲戚 (Family 3), 亲 (Family 3)
+Gourmet 1	拉面	拉麵	lā miàn	lā miàn	Hand-Pulled Noodle	pulled noodles / ramen	pulled noodles / ramen		No Matches Found
+Gourmet 1	点心	點心	diǎn xin	diǎn xin	dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert		No Matches Found
+Gourmet 1	小笼包	小籠包	xiǎo lóng bāo	xiǎo lóng bāo	Dumplings	steamed dumpling	steamed dumpling		No Matches Found
+Gourmet 1	拉		lā	lā	Pull	to pull / to play (a bowed instrument) / to drag / to draw / to chat	to pull / to play (a bowed instrument) / to drag / to draw / to chat		拉面 (Gourmet 1), 拉 (Gourmet 1)
+Gourmet 1	笼	籠	lóng   lǒng	lóng   lǒng	cage	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]		小笼包 (Gourmet 1), 笼 (Gourmet 1)
+Gourmet 1	粥		yù   zhōu	yù   zhōu	Gruel	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗		No Matches Found
+Gourmet 1	油条	油條	yóu tiáo	yóu tiáo	Fritters	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person		No Matches Found
+Gourmet 1	豆浆	豆漿	dòu jiāng	dòu jiāng	Milk	soy milk	soy milk		No Matches Found
+Gourmet 1	豆		dòu	dòu	beans	bean / pea / CL: 棵, 粒 / sacrificial vessel	bean / pea / CL: 棵, 粒 / sacrificial vessel		豆浆 (Gourmet 1), 豆 (Gourmet 1), 豆花 (Gourmet 2)
+Gourmet 1	浆	漿	jiāng   jiàng	jiāng   jiàng	Pulp	broth / serum / to starch  starch paste	broth / serum / to starch  starch paste		豆浆 (Gourmet 1), 浆 (Gourmet 1)
+Gourmet 1	火锅	火鍋	huǒ guō	huǒ guō	Hot Pot	hotpot	hotpot		No Matches Found
+Gourmet 1	包子		bāo zi	bāo zi	bun	steamed stuffed bun / CL: 個｜个	steamed stuffed bun / CL: 個｜个		No Matches Found
+Gourmet 1	炒饭	炒飯	chǎo fàn	chǎo fàn	Fried rice	fried rice / (slang) (Tw) to have sex	fried rice / (slang) (Tw) to have sex		No Matches Found
+Gourmet 1	锅	鍋	guō	guō	pot	pot / pan / boiler / CL: 口, 隻｜只	pot / pan / boiler / CL: 口, 隻｜只		火锅 (Gourmet 1), 锅 (Gourmet 1)
+Gourmet 1	炒		chǎo	chǎo	fry	to sauté / to stir-fry / to speculate / to hype / to fire (sb)	to sauté / to stir-fry / to speculate / to hype / to fire (sb)		炒饭 (Gourmet 1), 炒 (Gourmet 1)
+Time 4	夏		Xià   xià	Xià   xià	summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer		No Matches Found
+Time 4	冬		dōng   Dōng   dōng	dōng   Dōng   dōng	winter	winter  surname Dong  (onom.) beating a drum / rat-a-tat	winter  surname Dong  (onom.) beating a drum / rat-a-tat		No Matches Found
+Time 4	秋		Qiū   qiū   qiū	Qiū   qiū   qiū	autumn	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千		秋 (Time 4), 中秋节 (Festivals)
+Time 4	季		Jì   jì	Jì   jì	season	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields		季 (Time 4), 季节 (Time 4)
+Time 4	澳		Ào   ào	Ào   ào	Australia	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor		澳 (Time 4), 澳大利亚 (Time 4)
+Time 4	亚	亞	yà	yà	Asia	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]		亚 (Time 4), 澳大利亚 (Time 4)
+Time 4	季节	季節	jì jié	jì jié	season	time / season / period / CL: 個｜个	time / season / period / CL: 個｜个		No Matches Found
+Time 4	澳大利亚	澳大利亞	Ào dà lì yà	Ào dà lì yà	Australia	Australia	Australia		No Matches Found
+Time 4	越来越	越來越	yuè lái yuè	yuè lái yuè	More	more and more	more and more		No Matches Found
+Time 4	前天		qián tiān	qián tiān	The day before yesterday	the day before yesterday	the day before yesterday		No Matches Found
+Time 4	后天	後天	hòu tiān	hòu tiān	acquired	the day after tomorrow / acquired (not innate) / a posteriori	the day after tomorrow / acquired (not innate) / a posteriori		No Matches Found
+Time 4	堵车	堵車	dǔ chē	dǔ chē	Traffic jam	traffic jam / choking	traffic jam / choking		No Matches Found
+Time 4	大概		dà gài	dà gài	probably	roughly / probably / rough / approximate / about / general idea	roughly / probably / rough / approximate / about / general idea		No Matches Found
+Time 4	准时	準時	zhǔn shí	zhǔn shí	on time	on time / punctual / on schedule	on time / punctual / on schedule		No Matches Found
+Time 4	刚	剛	gāng	gāng	just	hard / firm / strong / just / barely / exactly	hard / firm / strong / just / barely / exactly		刚 (Time 4), 刚才 (Communication 2)
+Time 4	堵		dǔ	dǔ	Blocking	to stop up / (to feel) stifled or suffocated / wall / classifier for walls	to stop up / (to feel) stifled or suffocated / wall / classifier for walls		堵车 (Time 4), 堵 (Time 4)
+Time 4	概		gài	gài	General	general / approximate	general / approximate		大概 (Time 4), 概 (Time 4)
+Location 5	城		chéng	chéng	city	city walls / city / town / CL: 座, 道, 個｜个	city walls / city / town / CL: 座, 道, 個｜个		城 (Location 5), 城市 (Location 5), 长城 (Culture)
+Location 5	附		fù	fù	Attached	to add / to attach / to be close to / to be attached	to add / to attach / to be close to / to be attached		附 (Location 5), 附近 (Location 5)
+Location 5	园	園	Yuán   yuán	Yuán   yuán	garden	surname Yuan  land used for growing plants / site used for public recreation	surname Yuan  land used for growing plants / site used for public recreation		园 (Location 5), 公园 (Location 5), 园 (Festivals)
+Location 5	城市		chéng shì	chéng shì	city	city / town / CL: 座	city / town / CL: 座		No Matches Found
+Location 5	附近		fù jìn	fù jìn	nearby	(in the) vicinity / nearby / neighboring / next to	(in the) vicinity / nearby / neighboring / next to		No Matches Found
+Location 5	公园	公園	gōng yuán	gōng yuán	park	park (for public recreation) / CL: 個｜个, 座	park (for public recreation) / CL: 個｜个, 座		No Matches Found
+Location 5	图	圖	tú	tú	Map	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek		图 (Location 5), 图书馆 (Location 5), 地图 (Travel 4), 美图 (Internet Slang)
+Location 5	方		Fāng   fāng	Fāng   fāng	How to	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter		方 (Location 5), 地方 (Location 5), 北方 (Food 3), 南方 (Food 3), 方便 (Environment)
+Location 5	中间	中間	zhōng jiān	zhōng jiān	intermediate	between / intermediate / mid / middle	between / intermediate / mid / middle		No Matches Found
+Location 5	图书馆	圖書館	tú shū guǎn	tú shū guǎn	library	library / CL: 家, 個｜个	library / CL: 家, 個｜个		No Matches Found
+Location 5	地方		dì fāng   dì fang	dì fāng   dì fang	local	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块		No Matches Found
+Location 5	上面		shàng miàn	shàng miàn	On	on top of / above-mentioned / also pr. [shang4 mian5]	on top of / above-mentioned / also pr. [shang4 mian5]		No Matches Found
+Location 5	下面		xià miàn   xià miàn	xià miàn   xià miàn	below	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles		No Matches Found
+Location 5	咖啡馆	咖啡館	kā fēi guǎn	kā fēi guǎn	coffee shop	café / coffee shop / CL: 家	café / coffee shop / CL: 家		No Matches Found
+Shopping 4	折		shé   zhē   zhé	shé   zhē   zhé	fold	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book		折 (Shopping 4), 打折 (Shopping 4)
+Shopping 4	角		Jué   jiǎo   jué	Jué   jiǎo   jué	angle	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale		No Matches Found
+Shopping 4	花		Huā   huā	Huā   huā	flower	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)		花 (Shopping 4), 花 (Environment), 豆花 (Gourmet 2)
+Shopping 4	打折		dǎ zhé	dǎ zhé	Discount	to give a discount	to give a discount		No Matches Found
+Shopping 4	旧	舊	jiù	jiù	old	old / opposite: new 新 / former / worn (with age)	old / opposite: new 新 / former / worn (with age)		No Matches Found
+Shopping 4	皮		Pí   pí	Pí   pí	skin	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty		皮 (Shopping 4), 皮鞋 (Shopping 4)
+Shopping 4	换	換	huàn	huàn	change	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)		换 (Shopping 4), 换钱 (Travel 3)
+Shopping 4	皮鞋		pí xié	pí xié	leather shoes	leather shoes	leather shoes		No Matches Found
+Shopping 4	经过	經過	jīng guò	jīng guò	through	to pass / to go through / process / course / CL: 個｜个	to pass / to go through / process / course / CL: 個｜个		No Matches Found
+Shopping 4	退货	退貨	tuì huò	tuì huò	Returns	to return merchandise / to withdraw a product	to return merchandise / to withdraw a product		No Matches Found
+Shopping 4	退款		tuì kuǎn	tuì kuǎn	Refund	to refund / refund	to refund / refund		No Matches Found
+Shopping 4	退		tuì	tuì	Retreat	to retreat / to decline / to move back / to withdraw	to retreat / to decline / to move back / to withdraw		退货 (Shopping 4), 退款 (Shopping 4), 退 (Shopping 4), 退房 (Travel 3)
+Shopping 4	货	貨	huò	huò	goods	goods / money / commodity / CL: 個｜个	goods / money / commodity / CL: 個｜个		退货 (Shopping 4), 货 (Shopping 4), 吃货 (Internet Slang)
+Shopping 4	款		kuǎn	kuǎn	paragraph	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)		退款 (Shopping 4), 款 (Shopping 4)
+Shopping 4	袋子		dài zi	dài zi	bag	bag	bag		No Matches Found
+Daily Routine 2	惯	慣	guàn	guàn	used	accustomed to / used to / indulge / to spoil (a child)	accustomed to / used to / indulge / to spoil (a child)		惯 (Daily Routine 2), 习惯 (Daily Routine 2)
+Daily Routine 2	刷		shuā   shuà	shuā   shuà	brush	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select		刷 (Daily Routine 2), 刷牙 (Daily Routine 2), 刷 (Internet Slang)
+Daily Routine 2	习惯	習慣	xí guàn	xí guàn	habit	habit / custom / usual practice / to be used to / CL: 個｜个	habit / custom / usual practice / to be used to / CL: 個｜个		No Matches Found
+Daily Routine 2	刷牙		shuā yá	shuā yá	Brush teeth	to brush one's teeth	to brush one's teeth		No Matches Found
+Daily Routine 2	马上	馬上	mǎ shàng	mǎ shàng	immediately	at once / right away / immediately / on horseback (i.e. by military force)	at once / right away / immediately / on horseback (i.e. by military force)		No Matches Found
+Daily Routine 2	以后	以後	yǐ hòu	yǐ hòu	after	after / later / afterwards / following / later on / in the future	after / later / afterwards / following / later on / in the future		No Matches Found
+Daily Routine 2	澡		zǎo	zǎo	bath	bath	bath		澡 (Daily Routine 2), 洗澡 (Daily Routine 2)
+Daily Routine 2	总	總	zǒng	zǒng	total	always / to assemble / gather / total / overall / head / chief / general / in every case	always / to assemble / gather / total / overall / head / chief / general / in every case		总 (Daily Routine 2), 总是 (Daily Routine 2)
+Daily Routine 2	洗澡		xǐ zǎo	xǐ zǎo	Bathe	to bathe / to take a shower	to bathe / to take a shower		No Matches Found
+Daily Routine 2	一边	一邊	yī biān	yī biān	One side	one side / either side / on the one hand / on the other hand / doing while	one side / either side / on the one hand / on the other hand / doing while		No Matches Found
+Daily Routine 2	总是	總是	zǒng shì	zǒng shì	always	always	always		No Matches Found
+Daily Routine 2	讲	講	jiǎng	jiǎng	speak	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture		No Matches Found
+Daily Routine 2	故		gù	gù	Therefore	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead		故 (Daily Routine 2), 故事 (Daily Routine 2), 故宫 (Culture)
+Daily Routine 2	故事		gù shì   gù shi	gù shì   gù shi	story	old practice / CL: 個｜个  narrative / story / tale	old practice / CL: 個｜个  narrative / story / tale		No Matches Found
+Daily Routine 2	以前		yǐ qián	yǐ qián	before	before / formerly / previous / ago	before / formerly / previous / ago		No Matches Found
+Daily Routine 2	做梦	做夢	zuò mèng	zuò mèng	dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream		No Matches Found
+Daily Routine 2	梦	夢	mèng	mèng	dream	dream / CL: 場｜场, 個｜个	dream / CL: 場｜场, 個｜个		做梦 (Daily Routine 2), 梦 (Daily Routine 2)
+Food 3	除		chú	chú	except	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including		除 (Food 3), 除了 (Food 3)
+Food 3	其		qí	qí	its	his / her / its / their / that / such / it (refers to sth preceding it)	his / her / its / their / that / such / it (refers to sth preceding it)		其 (Food 3), 其他 (Food 3), 其实 (Communication 2)
+Food 3	饺	餃	jiǎo	jiǎo	dumpling	dumplings with meat filling	dumplings with meat filling		饺 (Food 3), 饺子 (Food 3)
+Food 3	北方		běi fāng	běi fāng	north	north / the northern part a country / China north of the Yellow River	north / the northern part a country / China north of the Yellow River		No Matches Found
+Food 3	除了		chú le	chú le	apart from	besides / apart from (... also...) / in addition to / except (for)	besides / apart from (... also...) / in addition to / except (for)		No Matches Found
+Food 3	其他		qí tā	qí tā	other	other / (sth or sb) else / the rest	other / (sth or sb) else / the rest		No Matches Found
+Food 3	饺子	餃子	jiǎo zi	jiǎo zi	Dumplings	dumpling / pot-sticker / CL: 個｜个, 隻｜只	dumpling / pot-sticker / CL: 個｜个, 隻｜只		No Matches Found
+Food 3	辣		là	là	hot	hot (spicy) / pungent	hot (spicy) / pungent		辣 (Food 3), 酸辣汤 (Gourmet 2)
+Food 3	极	極	jí	jí	pole	extremely / pole (geography, physics) / utmost / top	extremely / pole (geography, physics) / utmost / top		No Matches Found
+Food 3	苦		kǔ	kǔ	bitter	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly		苦 (Food 3), 辛苦 (Business 2)
+Food 3	盐	鹽	yán	yán	salt	salt / CL: 粒	salt / CL: 粒		No Matches Found
+Food 3	咸		Xián   xián   xián	Xián   xián   xián	salty	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly		No Matches Found
+Food 3	南		Nán   nán	Nán   nán	south	surname Nan  south	surname Nan  south		南 (Food 3), 南方 (Food 3), 南边 (Location 6)
+Food 3	南方		nán fāng	nán fāng	south	south / the southern part of the country / the South	south / the southern part of the country / the South		No Matches Found
+Food 3	难吃	難吃	nán chī	nán chī	Unpalatable	unpalatable	unpalatable		No Matches Found
+People 3	级	級	jí	jí	level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level		级 (People 3), 年级 (People 3)
+People 3	个子	個子	gè zi	gè zi	Stature	height / stature / build / size	height / stature / build / size		No Matches Found
+People 3	年级	年級	nián jí	nián jí	grade	grade / year (in school, college etc) / CL: 個｜个	grade / year (in school, college etc) / CL: 個｜个		No Matches Found
+People 3	小学	小學	xiǎo xué	xiǎo xué	primary school	elementary school / primary school / CL: 個｜个	elementary school / primary school / CL: 個｜个		No Matches Found
+People 3	初中		chū zhōng	chū zhōng	junior high school	junior high school / abbr. for 初級中學｜初级中学	junior high school / abbr. for 初級中學｜初级中学		No Matches Found
+People 3	初		chū	chū	First	at first / (at the) beginning / first / junior / basic	at first / (at the) beginning / first / junior / basic		初中 (People 3), 初 (People 3)
+People 3	较	較	jiào	jiào	Relatively	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]		较 (People 3), 比较 (People 3)
+People 3	年轻	年輕	nián qīng	nián qīng	young	young	young		No Matches Found
+People 3	比较	比較	bǐ jiào	bǐ jiào	Compare	to compare / to contrast / comparatively / relatively / quite / comparison	to compare / to contrast / comparatively / relatively / quite / comparison		No Matches Found
+People 3	眼镜	眼鏡	yǎn jìng	yǎn jìng	glasses	spectacles / eyeglasses / CL: 副	spectacles / eyeglasses / CL: 副		No Matches Found
+People 3	戴		Dài   dài	Dài   dài	wore	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support		No Matches Found
+People 3	镜	鏡	jìng	jìng	mirror	mirror / lens	mirror / lens		眼镜 (People 3), 镜 (People 3)
+Location 6	先		xiān	xiān	first	early / prior / former / in advance / first	early / prior / former / in advance / first		先 (Location 6), 先生 (Work)
+Location 6	然后	然後	rán hòu	rán hòu	then	after / then (afterwards) / after that / afterwards	after / then (afterwards) / after that / afterwards		No Matches Found
+Location 6	西边	西邊	xī biān	xī biān	The west	west / west side / western part / to the west of	west / west side / western part / to the west of		No Matches Found
+Location 6	东边	東邊	dōng bian	dōng bian	The east	east / east side / eastern part / to the east of	east / east side / eastern part / to the east of		No Matches Found
+Location 6	北边	北邊	běi biān	běi biān	North	north / north side / northern part / to the north of	north / north side / northern part / to the north of		No Matches Found
+Location 6	一直		yī zhí	yī zhí	Up	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along		No Matches Found
+Location 6	最后	最後	zuì hòu	zuì hòu	At last	final / last / finally / ultimate	final / last / finally / ultimate		No Matches Found
+Location 6	南边	南邊	nán bian	nán bian	South	south / south side / southern part / to the south of	south / south side / southern part / to the south of		No Matches Found
+Location 6	直		Zhí   zhí	Zhí   zhí	straight	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters		一直 (Location 6), 直 (Location 6)
+Location 6	迷路		mí lù	mí lù	get lost	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)		No Matches Found
+Location 6	地址		dì zhǐ	dì zhǐ	address	address / CL: 個｜个	address / CL: 個｜个		No Matches Found
+Location 6	周围	周圍	zhōu wéi	zhōu wéi	around	surroundings / environment / to encompass	surroundings / environment / to encompass		No Matches Found
+Location 6	迷		mí	mí	fan	to bewilder / crazy about / fan / enthusiast / lost / confused	to bewilder / crazy about / fan / enthusiast / lost / confused		迷路 (Location 6), 迷 (Location 6)
+Location 6	址		zhǐ	zhǐ	site	location / site	location / site		地址 (Location 6), 址 (Location 6)
+Location 6	围	圍	Wéi   wéi	Wéi   wéi	Enclose	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)		周围 (Location 6), 围 (Location 6)
+Daily Routine 3	般		bān   pán	bān   pán	Sort	sort / kind / class / way / manner  see 般樂｜般乐	sort / kind / class / way / manner  see 般樂｜般乐		般 (Daily Routine 3), 一般 (Daily Routine 3)
+Daily Routine 3	聊		liáo	liáo	chat	to chat / to depend upon (literary) / temporarily / just / slightly	to chat / to depend upon (literary) / temporarily / just / slightly		聊 (Daily Routine 3), 聊天 (Daily Routine 3)
+Daily Routine 3	聊天		liáo tiān	liáo tiān	to chat with	to chat / to gossip	to chat / to gossip		No Matches Found
+Daily Routine 3	一般		yī bān	yī bān	general	same / ordinary / so-so / common / general / generally / in general	same / ordinary / so-so / common / general / generally / in general		No Matches Found
+Daily Routine 3	见面	見面	jiàn miàn	jiàn miàn	meet	to meet / to see each other / CL: 次	to meet / to see each other / CL: 次		No Matches Found
+Daily Routine 3	自己		zì jǐ	zì jǐ	Own	oneself / one's own	oneself / one's own		No Matches Found
+Daily Routine 3	一个人	一個人	yī gè rén	yī gè rén	A person	by oneself (without assistance) / alone (without company)	by oneself (without assistance) / alone (without company)		No Matches Found
+Daily Routine 3	自		zì	zì	from	self / oneself / from / since / naturally / surely	self / oneself / from / since / naturally / surely		自己 (Daily Routine 3), 自 (Daily Routine 3), 自行车 (Hobbies 3), 自拍 (Internet Slang)
+Daily Routine 3	己		jǐ	jǐ	already	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa		自己 (Daily Routine 3), 己 (Daily Routine 3)
+Travel 2	证	証	zhèng   zhèng	zhèng   zhèng	certificate	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症		证 (Travel 2), 签证 (Travel 2)
+Travel 2	签	簽	qiān   qiān	qiān   qiān	sign	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag		签 (Travel 2), 签证 (Travel 2), 签名 (Business 1)
+Travel 2	护	護	hù	hù	Protect	to protect	to protect		护 (Travel 2), 护照 (Travel 2), 护 (Emergency), 救护车 (Emergency)
+Travel 2	护照	護照	hù zhào	hù zhào	passport	passport / CL: 本, 個｜个	passport / CL: 本, 個｜个		No Matches Found
+Travel 2	签证	簽證	qiān zhèng	qiān zhèng	visa	visa / certificate / to certify / CL: 個｜个	visa / certificate / to certify / CL: 個｜个		No Matches Found
+Travel 2	发现	發現	fā xiàn	fā xiàn	Find	to find / to discover	to find / to discover		No Matches Found
+Travel 2	起飞	起飛	qǐ fēi	qǐ fēi	take off	(of an aircraft) to take off	(of an aircraft) to take off		No Matches Found
+Travel 2	离开	離開	lí kāi	lí kāi	go away	to depart / to leave	to depart / to leave		No Matches Found
+Travel 2	检查	檢查	jiǎn chá	jiǎn chá	an examination	inspection / to examine / to inspect / CL: 次	inspection / to examine / to inspect / CL: 次		No Matches Found
+Travel 2	行李		xíng li	xíng li	Baggage	luggage / CL: 件	luggage / CL: 件		No Matches Found
+Travel 2	安全		ān quán	ān quán	Safety	safe / secure / safety / security	safe / secure / safety / security		No Matches Found
+Travel 2	检	檢	jiǎn	jiǎn	Check	to check / to examine / to inspect / to exercise restraint	to check / to examine / to inspect / to exercise restraint		检查 (Travel 2), 检 (Travel 2)
+Travel 2	查		Zhā   chá   zhā	Zhā   chá   zhā	check	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查		检查 (Travel 2), 查 (Travel 2)
+Travel 2	几乎	幾乎	jī hū	jī hū	almost	almost / nearly / practically	almost / nearly / practically		No Matches Found
+Travel 2	忘记	忘記	wàng jì	wàng jì	forget	to forget	to forget		No Matches Found
+Travel 2	海关	海關	hǎi guān	hǎi guān	Customs	customs (i.e. border crossing inspection) / CL: 個｜个	customs (i.e. border crossing inspection) / CL: 個｜个		No Matches Found
+Travel 2	忘		wàng	wàng	forget	to forget / to overlook / to neglect	to forget / to overlook / to neglect		忘记 (Travel 2), 忘 (Travel 2), 忘 (Work)
+Travel 2	记	記	jì	jì	Remember	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots		忘记 (Travel 2), 记 (Travel 2), 笔记 (School 2), 笔记本 (School 2), 记得 (Exam)
+Travel 2	乎		hū	hū	Down	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)		几乎 (Travel 2), 乎 (Travel 2)
+Languages 2	言		yán	yán	Speech	words / speech / to say / to talk	words / speech / to say / to talk		言 (Languages 2), 语言 (Languages 2)
+Languages 2	易		Yì   yì	Yì   yì	easy	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange		易 (Languages 2), 容易 (Languages 2)
+Languages 2	容		Róng   róng	Róng   róng	Allow	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance		容 (Languages 2), 容易 (Languages 2)
+Languages 2	种	種	zhǒng   zhòng	zhǒng   zhòng	Kind	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate		No Matches Found
+Languages 2	容易		róng yì	róng yì	easily	easy / likely / liable (to)	easy / likely / liable (to)		No Matches Found
+Languages 2	语言	語言	yǔ yán	yǔ yán	Language	language / CL: 門｜门, 種｜种	language / CL: 門｜门, 種｜种		No Matches Found
+Languages 2	更		gēng   gèng	gēng   gèng	more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more		No Matches Found
+Languages 2	努力		nǔ lì	nǔ lì	Strive	great effort / to strive / to try hard	great effort / to strive / to try hard		No Matches Found
+Languages 2	汉字	漢字	hàn zì	hàn zì	Chinese character	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự		No Matches Found
+Languages 2	努		nǔ	nǔ	Strive	to exert / to strive	to exert / to strive		努力 (Languages 2), 努 (Languages 2)
+Languages 2	提高		tí gāo	tí gāo	improve	to raise / to increase / to improve	to raise / to increase / to improve		No Matches Found
+Languages 2	水平		shuǐ píng	shuǐ píng	Level	level (of achievement etc) / standard / horizontal	level (of achievement etc) / standard / horizontal		No Matches Found
+Languages 2	后来	後來	hòu lái	hòu lái	later	afterwards / later	afterwards / later		No Matches Found
+Languages 2	提		tí	tí	mention	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid		提高 (Languages 2), 提 (Languages 2), 提醒 (Duo)
+Languages 2	平		Píng   píng	Píng   píng	level	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声		水平 (Languages 2), 平 (Languages 2)
+Personality and Feelings	看起来	看起來	kàn qǐ lai	kàn qǐ lai	Looks	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be		No Matches Found
+Personality and Feelings	奇怪		qí guài	qí guài	strange	strange / odd / to marvel / to be baffled	strange / odd / to marvel / to be baffled		No Matches Found
+Personality and Feelings	生气	生氣	shēng qì	shēng qì	pissed off	to get angry / to take offense / angry / vitality / liveliness	to get angry / to take offense / angry / vitality / liveliness		No Matches Found
+Personality and Feelings	紧张	緊張	jǐn zhāng	jǐn zhāng	tension	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵		No Matches Found
+Personality and Feelings	奇		jī   qí	jī   qí	odd	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually		奇怪 (Personality and Feelings), 奇 (Personality and Feelings)
+Personality and Feelings	怪		guài	guài	strange	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather		奇怪 (Personality and Feelings), 怪 (Personality and Feelings)
+Personality and Feelings	紧	緊	jǐn	jǐn	tight	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten		紧张 (Personality and Feelings), 紧 (Personality and Feelings)
+Personality and Feelings	难过	難過	nán guò	nán guò	Sorry	to feel sad / to feel unwell / (of life) to be difficult	to feel sad / to feel unwell / (of life) to be difficult		No Matches Found
+Personality and Feelings	哭		kū	kū	cry	to cry / to weep	to cry / to weep		No Matches Found
+Personality and Feelings	可怕		kě pà	kě pà	terrible	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly		No Matches Found
+Personality and Feelings	热情	熱情	rè qíng	rè qíng	enthusiasm	cordial / enthusiastic / passion / passionate / passionately	cordial / enthusiastic / passion / passionate / passionately		No Matches Found
+Personality and Feelings	关心	關心	guān xīn	guān xīn	care	to be concerned about / to care about	to be concerned about / to care about		No Matches Found
+Personality and Feelings	经常	經常	jīng cháng	jīng cháng	often	frequently / constantly / regularly / often / day-to-day / everyday / daily	frequently / constantly / regularly / often / day-to-day / everyday / daily		No Matches Found
+Personality and Feelings	遇到		yù dào	yù dào	Experience	to meet / to run into / to come across	to meet / to run into / to come across		No Matches Found
+Personality and Feelings	好笑		hǎo xiào	hǎo xiào	funny	laughable / funny / ridiculous	laughable / funny / ridiculous		No Matches Found
+Personality and Feelings	遇		Yù   yù	Yù   yù	Encounter	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance		遇到 (Personality and Feelings), 遇 (Personality and Feelings)
+School 2	求		qiú	qiú	begging	to seek / to look for / to request / to demand / to beseech	to seek / to look for / to request / to demand / to beseech		求 (School 2), 要求 (School 2)
+School 2	校长	校長	xiào zhǎng	xiào zhǎng	principal	(college, university) president / headmaster / CL: 個｜个, 位, 名	(college, university) president / headmaster / CL: 個｜个, 位, 名		No Matches Found
+School 2	要求		yāo qiú	yāo qiú	Claim	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点		No Matches Found
+School 2	食堂		shí táng	shí táng	Cafeteria	dining hall / CL: 個｜个, 間｜间	dining hall / CL: 個｜个, 間｜间		No Matches Found
+School 2	食		shí   sì	shí   sì	food	to eat / food / animal feed / eclipse  to feed	to eat / food / animal feed / eclipse  to feed		食堂 (School 2), 食 (School 2)
+School 2	堂		táng	táng	Hall	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture		食堂 (School 2), 堂 (School 2)
+School 2	必须	必須	bì xū	bì xū	have to	to have to / must / compulsory / necessarily	to have to / must / compulsory / necessarily		No Matches Found
+School 2	完成		wán chéng	wán chéng	carry out	to complete / to accomplish	to complete / to accomplish		No Matches Found
+School 2	作业	作業	zuò yè	zuò yè	operation	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	school assignment / homework / work / task / operation / CL: 個｜个 / to operate		No Matches Found
+School 2	高中		gāo zhōng   gāo zhòng	gāo zhōng   gāo zhòng	Senior middle school	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)		No Matches Found
+School 2	必		bì	bì	must	certainly / must / will / necessarily	certainly / must / will / necessarily		必须 (School 2), 必 (School 2)
+School 2	成		Chéng   chéng	Chéng   chéng	to make	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth		完成 (School 2), 成 (School 2), 成绩 (Exam), 成 (Exam)
+School 2	须	須	xū   xū	xū   xū	must	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel		必须 (School 2), 须 (School 2)
+School 2	业	業	Yè   yè	Yè   yè	industry	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already		作业 (School 2), 业 (School 2), 专业 (Exam)
+School 2	向		Xiàng   xiàng   xiàng	Xiàng   xiàng   xiàng	to	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向		No Matches Found
+School 2	借		jiè	jiè	borrow	to lend / to borrow / by means of / to take (an opportunity)	to lend / to borrow / by means of / to take (an opportunity)		No Matches Found
+School 2	笔记	筆記	bǐ jì	bǐ jì	notes	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本		笔记 (School 2), 笔记本 (School 2)
+School 2	铅笔	鉛筆	qiān bǐ	qiān bǐ	pencil	(lead) pencil / CL: 支, 枝, 桿｜杆	(lead) pencil / CL: 支, 枝, 桿｜杆		No Matches Found
+School 2	铅	鉛	qiān	qiān	lead	lead (chemistry)	lead (chemistry)		铅笔 (School 2), 铅 (School 2)
+School 2	清楚		qīng chu	qīng chu	clear	clear / distinct / to understand thoroughly / to be clear about	clear / distinct / to understand thoroughly / to be clear about		No Matches Found
+School 2	黑板		hēi bǎn	hēi bǎn	blackboard	blackboard / CL: 塊｜块, 個｜个	blackboard / CL: 塊｜块, 個｜个		No Matches Found
+School 2	笔记本	筆記本	bǐ jì běn	bǐ jì běn	notebook	notebook (stationery) / CL: 本 / notebook (computing)	notebook (stationery) / CL: 本 / notebook (computing)		No Matches Found
+School 2	清		Qīng   qīng	Qīng   qīng	clear	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge		清楚 (School 2), 清 (School 2)
+School 2	楚		Chǔ   chǔ	Chǔ   chǔ	Chu	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)		清楚 (School 2), 楚 (School 2)
+School 2	板		bǎn   bǎn   pàn	bǎn   bǎn   pàn	board	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)		黑板 (School 2), 板 (School 2), 老板 (Work 2), 板 (Work 2)
+School 2	体育馆	體育館	tǐ yù guǎn	tǐ yù guǎn	stadium	gym / gymnasium / stadium / CL: 個｜个	gym / gymnasium / stadium / CL: 個｜个		No Matches Found
+Future	化		huà	huà	Of	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学		化 (Future), 变化 (Future), 文化 (Hobbies 3)
+Future	算		suàn	suàn	Count	to regard as / to figure / to calculate / to compute	to regard as / to figure / to calculate / to compute		算 (Future), 打算 (Future), 预算 (Business 1)
+Future	搬		bān	bān	move	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately		No Matches Found
+Future	变	變	biàn	biàn	change	to change / to become different / to transform / to vary / rebellion	to change / to become different / to transform / to vary / rebellion		变 (Future), 变化 (Future)
+Future	打算		dǎ suàn	dǎ suàn	intend	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个		No Matches Found
+Future	变化	變化	biàn huà	biàn huà	Variety	change / variation / to change / to vary / CL: 個｜个	change / variation / to change / to vary / CL: 個｜个		No Matches Found
+Future	机会	機會	jī huì	jī huì	opportunity	opportunity / chance / occasion / CL: 個｜个	opportunity / chance / occasion / CL: 個｜个		No Matches Found
+Future	留学	留學	liú xué	liú xué	Study abroad	to study abroad	to study abroad		No Matches Found
+Future	国家	國家	guó jiā	guó jiā	country	country / nation / state / CL: 個｜个	country / nation / state / CL: 個｜个		No Matches Found
+Future	选择	選擇	xuǎn zé	xuǎn zé	select	to select / to pick / choice / option / alternative	to select / to pick / choice / option / alternative		No Matches Found
+Future	选	選	xuǎn	xuǎn	selected	to choose / to pick / to select / to elect	to choose / to pick / to select / to elect		选择 (Future), 选 (Future)
+Future	择	擇	zé	zé	Choose	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]		选择 (Future), 择 (Future)
+Future	结婚	結婚	jié hūn	jié hūn	marry	to marry / to get married / CL: 次	to marry / to get married / CL: 次		No Matches Found
+Future	愿意	願意	yuàn yì	yuàn yì	willing	to wish / to want / ready / willing (to do sth)	to wish / to want / ready / willing (to do sth)		No Matches Found
+Future	认真	認真	rèn zhēn	rèn zhēn	serious	conscientious / earnest / serious / to take seriously / to take to heart	conscientious / earnest / serious / to take seriously / to take to heart		No Matches Found
+Future	结	結	jiē   jié	jiē   jié	Knot	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)		结婚 (Future), 结 (Future), 结束 (Exam), 结 (Exam)
+Future	愿		yuàn   yuàn	yuàn   yuàn	willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing		愿意 (Future), 愿 (Future)
+Future	婚		hūn	hūn	marriage	to marry / marriage / wedding / to take a wife	to marry / marriage / wedding / to take a wife		结婚 (Future), 婚 (Future)
+Future	当然	當然	dāng rán	dāng rán	of course	only natural / as it should be / certainly / of course / without doubt	only natural / as it should be / certainly / of course / without doubt		No Matches Found
+Future	放心		fàng xīn	fàng xīn	rest assured	to feel relieved / to feel reassured / to be at ease	to feel relieved / to feel reassured / to be at ease		No Matches Found
+Future	害怕		hài pà	hài pà	Afraid	to be afraid / to be scared	to be afraid / to be scared		No Matches Found
+Future	当	噹	dāng   dāng   dàng	dāng   dāng   dàng	when	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)		当然 (Future), 当 (Future)
+Future	害		hài	hài	harm	to do harm to / to cause trouble to / harm / evil / calamity	to do harm to / to cause trouble to / harm / evil / calamity		害怕 (Future), 害 (Future)
+Future	怕		Pà   pà	Pà   pà	afraid	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps		可怕 (Personality and Feelings), 害怕 (Future), 怕 (Future)
+Future	分手		fēn shǒu	fēn shǒu	Breaking up	to part company / to split up / to break up	to part company / to split up / to break up		No Matches Found
+Environment	境		jìng	jìng	territory	border / place / condition / boundary / circumstances / territory	border / place / condition / boundary / circumstances / territory		境 (Environment), 环境 (Environment)
+Environment	环	環	Huán   huán	Huán   huán	ring	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in		环 (Environment), 环境 (Environment)
+Environment	层	層	céng	céng	Floor	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)		No Matches Found
+Environment	方便		fāng biàn	fāng biàn	Convenience	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself		No Matches Found
+Environment	环境	環境	huán jìng	huán jìng	surroundings	environment / circumstances / surroundings / CL: 個｜个 / ambient	environment / circumstances / surroundings / CL: 個｜个 / ambient		No Matches Found
+Environment	草		cǎo	cǎo	grass	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根		No Matches Found
+Environment	太阳	太陽	tài yang	tài yang	sun	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴		No Matches Found
+Environment	星星		xīng xing	xīng xing	star	star in the sky	star in the sky		No Matches Found
+Environment	阳	陽	yáng	yáng	Positive	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯		太阳 (Environment), 阳 (Environment)
+Environment	安静	安靜	ān jìng	ān jìng	be quiet	quiet / peaceful / calm	quiet / peaceful / calm		No Matches Found
+Environment	楼	樓	Lóu   lóu	Lóu   lóu	floor	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋		No Matches Found
+Environment	静	靜	jìng	jìng	Quiet	still / calm / quiet / not moving	still / calm / quiet / not moving		安静 (Environment), 静 (Environment)
+Environment	声音	聲音	shēng yīn	shēng yīn	sound	voice / sound / CL: 個｜个	voice / sound / CL: 個｜个		No Matches Found
+Environment	影响	影響	yǐng xiǎng	yǐng xiǎng	influences	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股		No Matches Found
+Environment	邻居	鄰居	lín jū	lín jū	neighbor	neighbor / next door / CL: 個｜个	neighbor / next door / CL: 個｜个		No Matches Found
+Environment	声	聲	shēng	shēng	sound	sound / voice / tone / noise / classifier for sounds	sound / voice / tone / noise / classifier for sounds		声音 (Environment), 声 (Environment)
+Environment	邻	鄰	lín	lín	adjacent	neighbor / adjacent / close to	neighbor / adjacent / close to		邻居 (Environment), 邻 (Environment), 多邻国 (Languages 3)
+Environment	响	響	xiǎng	xiǎng	ring	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises		影响 (Environment), 响 (Environment)
+Environment	居		Jū   jī   jū	Jū   jī   jū	House	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms		邻居 (Environment), 居 (Environment)
+Environment	垃圾		lā jī	lā jī	Rubbish	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]		No Matches Found
+Environment	桶		tǒng	tǒng	barrel	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只		No Matches Found
+Environment	丢	丟	diū	diū	throw	to lose / to put aside / to throw	to lose / to put aside / to throw		No Matches Found
+Environment	脏	臟	zàng   zāng	zàng   zāng	dirty	viscera / (anatomy) organ  dirty / filthy	viscera / (anatomy) organ  dirty / filthy		No Matches Found
+Environment	垃		lā	lā	garbage	see 垃圾 / Taiwan pr. [le4]	see 垃圾 / Taiwan pr. [le4]		垃圾 (Environment), 垃 (Environment)
+Environment	圾		jī	jī	Rubbish	see 垃圾 / Taiwan pr. [se4]	see 垃圾 / Taiwan pr. [se4]		垃圾 (Environment), 圾 (Environment)
+Work	先生		Xiān sheng   xiān sheng	Xiān sheng   xiān sheng	Mr	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位		No Matches Found
+Work	小姐		xiǎo jie	xiǎo jie	Young lady	young lady / miss / (slang) prostitute / CL: 個｜个, 位	young lady / miss / (slang) prostitute / CL: 個｜个, 位		No Matches Found
+Work	经理	經理	jīng lǐ	jīng lǐ	manager	manager / director / CL: 個｜个, 位, 名	manager / director / CL: 個｜个, 位, 名		No Matches Found
+Work	同事		tóng shì	tóng shì	colleague	colleague / co-worker / CL: 個｜个, 位	colleague / co-worker / CL: 個｜个, 位		No Matches Found
+Work	突然		tū rán	tū rán	suddenly	sudden / abrupt / unexpected	sudden / abrupt / unexpected		No Matches Found
+Work	重要		zhòng yào	zhòng yào	important	important / significant / major	important / significant / major		No Matches Found
+Work	会议	會議	huì yì	huì yì	meeting	meeting / conference / CL: 場｜场, 屆｜届	meeting / conference / CL: 場｜场, 屆｜届		No Matches Found
+Work	突		tū	tū	Sudden	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]		突然 (Work), 突 (Work)
+Work	重		chóng   zhòng	chóng   zhòng	weight	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to		重要 (Work), 重 (Work), 严重 (Emergency)
+Work	议	議	yì	yì	Discuss	to comment on / to discuss / to suggest	to comment on / to discuss / to suggest		会议 (Work), 议 (Work), 协议 (Business 1), 议 (Business 1)
+Work	解决	解決	jiě jué	jiě jué	solve	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch		No Matches Found
+Work	办法	辦法	bàn fǎ	bàn fǎ	Method	means / method / way (of doing sth) / CL: 條｜条, 個｜个	means / method / way (of doing sth) / CL: 條｜条, 個｜个		No Matches Found
+Work	相信		xiāng xìn	xiāng xìn	Believe	to be convinced (that sth is true) / to believe / to accept sth as true	to be convinced (that sth is true) / to believe / to accept sth as true		No Matches Found
+Work	决	決	jué	jué	Decide	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly		解决 (Work), 决 (Work), 决定 (Work 2)
+Work	解		Xiè   jiě   jiè   xiè	Xiè   jiě   jiè   xiè	solution	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)		解决 (Work), 解 (Work), 了解 (Hobbies 3)
+Culture	界		jiè	jiè	boundary	boundary / scope / extent / circles / group / kingdom (taxonomy)	boundary / scope / extent / circles / group / kingdom (taxonomy)		界 (Culture), 世界 (Culture)
+Culture	河		hé	hé	River	river / CL: 條｜条, 道	river / CL: 條｜条, 道		河 (Culture), 黄河 (Culture)
+Culture	世		Shì   shì	Shì   shì	world	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble		世 (Culture), 世界 (Culture)
+Culture	黄河	黃河	Huáng Hé	Huáng Hé	Yellow River	Yellow River or Huang He	Yellow River or Huang He		No Matches Found
+Culture	动物	動物	dòng wù	dòng wù	animal	animal / CL: 隻｜只, 群, 個｜个	animal / CL: 隻｜只, 群, 個｜个		No Matches Found
+Culture	有名		yǒu míng	yǒu míng	Famous	famous / well-known	famous / well-known		No Matches Found
+Culture	世界		shì jiè	shì jiè	world	world / CL: 個｜个	world / CL: 個｜个		No Matches Found
+Culture	长江	長江	Cháng Jiāng	Cháng Jiāng	Yangtze	Yangtze River, or Chang Jiang	Yangtze River, or Chang Jiang		No Matches Found
+Culture	江		Jiāng   jiāng	Jiāng   jiāng	River	surname Jiang  river / CL: 條｜条, 道	surname Jiang  river / CL: 條｜条, 道		长江 (Culture), 江 (Culture)
+Culture	多么	多麼	duō me	duō me	how	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent		No Matches Found
+Culture	熊猫	熊貓	xióng māo	xióng māo	panda	panda / CL: 隻｜只	panda / CL: 隻｜只		No Matches Found
+Culture	西安		Xī ān	Xī ān	Xi'an	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区		No Matches Found
+Culture	啊		ā   á   ǎ   à   a	ā   á   ǎ   à   a	what	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent		No Matches Found
+Culture	熊		Xióng   xióng	Xióng   xióng	Bear	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly		熊猫 (Culture), 熊 (Culture)
+Culture	长城	長城	Cháng chéng	Cháng chéng	Great Wall	the Great Wall	the Great Wall		No Matches Found
+Culture	故宫	故宮	Gù gōng   gù gōng	Gù gōng   gù gōng	Forbidden City	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace		No Matches Found
+Culture	宫	宮	Gōng   gōng	Gōng   gōng	palace	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale		故宫 (Culture), 宫 (Culture), 宫保鸡丁 (Gourmet 2)
+Hobbies 3	山		Shān   shān	Shān   shān	mountain	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable		山 (Hobbies 3), 爬山 (Hobbies 3)
+Hobbies 3	者		zhě	zhě	Person	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this		者 (Hobbies 3), 或者 (Hobbies 3)
+Hobbies 3	爬		pá	pá	climb	to crawl / to climb / to get up or sit up	to crawl / to climb / to get up or sit up		爬 (Hobbies 3), 爬山 (Hobbies 3)
+Hobbies 3	或		huò	huò	or	maybe / perhaps / might / possibly / or	maybe / perhaps / might / possibly / or		或 (Hobbies 3), 或者 (Hobbies 3)
+Hobbies 3	自行车	自行車	zì xíng chē	zì xíng chē	bicycle	bicycle / bike / CL: 輛｜辆	bicycle / bike / CL: 輛｜辆		No Matches Found
+Hobbies 3	或者		huò zhě	huò zhě	or	or / possibly / maybe / perhaps	or / possibly / maybe / perhaps		No Matches Found
+Hobbies 3	爬山		pá shān	pá shān	Climb	to climb a mountain / to mountaineer / hiking / mountaineering	to climb a mountain / to mountaineer / hiking / mountaineering		No Matches Found
+Hobbies 3	功夫		gōng fu	gōng fu	effort	skill / art / kung fu / labor / effort	skill / art / kung fu / labor / effort		No Matches Found
+Hobbies 3	功		gōng	gōng	Gong	meritorious deed or service / achievement / result / service / accomplishment / work (physics)	meritorious deed or service / achievement / result / service / accomplishment / work (physics)		功夫 (Hobbies 3), 功 (Hobbies 3)
+Hobbies 3	文化		wén huà	wén huà	culture	culture / civilization / cultural / CL: 個｜个, 種｜种	culture / civilization / cultural / CL: 個｜个, 種｜种		No Matches Found
+Hobbies 3	历史	歷史	lì shǐ	lì shǐ	history	history / CL: 門｜门, 段	history / CL: 門｜门, 段		No Matches Found
+Hobbies 3	兴趣	興趣	xìng qù	xìng qù	interest	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个		兴趣 (Hobbies 3), 感兴趣 (Hobbies 3)
+Hobbies 3	感兴趣	感興趣	gǎn xìng qù	gǎn xìng qù	Interested	to be interested	to be interested		No Matches Found
+Hobbies 3	历	曆	lì   lì	lì   lì	calendar	calendar  to experience / to undergo / to pass through / all / each / every / history	calendar  to experience / to undergo / to pass through / all / each / every / history		历史 (Hobbies 3), 历 (Hobbies 3)
+Hobbies 3	趣		qù	qù	interest	interesting / to interest	interesting / to interest		兴趣 (Hobbies 3), 感兴趣 (Hobbies 3), 趣 (Hobbies 3)
+Hobbies 3	史		Shǐ   shǐ	Shǐ   shǐ	history	surname Shi  history / annals / title of an official historian in ancient China	surname Shi  history / annals / title of an official historian in ancient China		历史 (Hobbies 3), 史 (Hobbies 3)
+Hobbies 3	为了	為了	wèi le	wèi le	in order to	in order to / for the purpose of / so as to	in order to / for the purpose of / so as to		No Matches Found
+Hobbies 3	特别	特別	tè bié	tè bié	particular	especially / special / particular / unusual	especially / special / particular / unusual		No Matches Found
+Hobbies 3	了解		liǎo jiě   liǎo jiě	liǎo jiě   liǎo jiě	To understanding	to understand / to realize / to find out  to understand / to realize / to find out	to understand / to realize / to find out  to understand / to realize / to find out		No Matches Found
+Hobbies 3	麻将	麻將	má jiàng	má jiàng	Mahjong	mahjong / CL: 副	mahjong / CL: 副		No Matches Found
+Hobbies 3	特		tè	tè	special	special / unique / distinguished / especially / unusual / very	special / unique / distinguished / especially / unusual / very		特别 (Hobbies 3), 特 (Hobbies 3)
+Hobbies 3	麻		Má   má	Má   má	hemp	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb		麻将 (Hobbies 3), 麻 (Hobbies 3), 麻烦 (Work 2)
+Hobbies 3	将	將	jiāng   jiàng   qiāng	jiāng   jiàng   qiāng	will	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request		麻将 (Hobbies 3), 将 (Hobbies 3)
+Health 3	顾	顧	Gù   gù	Gù   gù	Attend	surname Gu  to look after / to take into consideration / to attend to	surname Gu  to look after / to take into consideration / to attend to		顾 (Health 3), 照顾 (Health 3)
+Health 3	死		sǐ	sǐ	dead	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	to die / impassable / uncrossable / inflexible / rigid / extremely / damned		No Matches Found
+Health 3	闷	悶	mēn   mèn	mēn   mèn	stuffy	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed		No Matches Found
+Health 3	腿		tuǐ   tuǐ	tuǐ   tuǐ	leg	leg / CL: 條｜条  hip bone / old variant of 腿	leg / CL: 條｜条  hip bone / old variant of 腿		No Matches Found
+Health 3	照顾	照顧	zhào gu	zhào gu	Look after	to take care of / to show consideration / to attend to / to look after	to take care of / to show consideration / to attend to / to look after		No Matches Found
+Health 3	公斤		gōng jīn	gōng jīn	kg	kilogram (kg)	kilogram (kg)		No Matches Found
+Health 3	着急	著急	zháo jí	zháo jí	Worry	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]		No Matches Found
+Health 3	瘦		shòu	shòu	thin	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive		No Matches Found
+Health 3	斤		jīn	jīn	jin	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g		公斤 (Health 3), 斤 (Health 3)
+Health 3	急		jí	jí	anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious		着急 (Health 3), 急 (Health 3)
+Health 3	咳嗽		ké sou	ké sou	cough	to cough / CL: 陣｜阵	to cough / CL: 陣｜阵		No Matches Found
+Health 3	抽烟	抽煙	chōu yān	chōu yān	smokes	to smoke (a cigarette, tobacco)	to smoke (a cigarette, tobacco)		No Matches Found
+Health 3	咳		hāi   ké	hāi   ké	cough	sound of sighing  cough	sound of sighing  cough		咳嗽 (Health 3), 咳 (Health 3)
+Health 3	嗽		sòu	sòu	cough	cough	cough		咳嗽 (Health 3), 嗽 (Health 3)
+Health 3	抽		chōu	chōu	Draw	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash		抽烟 (Health 3), 抽 (Health 3)
+Health 3	烟	煙	yān	yān	smoke	cigarette or pipe tobacco / CL: 根 / smoke / mist / vapour / CL: 縷｜缕 / tobacco plant / (of the eyes) to be irritated by smoke	cigarette or pipe tobacco / CL: 根 / smoke / mist / vapour / CL: 縷｜缕 / tobacco plant / (of the eyes) to be irritated by smoke		抽烟 (Health 3), 烟 (Health 3)
+Travel 3	际	際	jì	jì	The occasion	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)		际 (Travel 3), 国际 (Travel 3)
+Travel 3	柜		jǔ   guì	jǔ   guì	cabinet	Salix multinervis  cupboard / cabinet / wardrobe	Salix multinervis  cupboard / cabinet / wardrobe		柜 (Travel 3), 柜台 (Travel 3)
+Travel 3	转	轉	zhuǎi   zhuǎn   zhuàn	zhuǎi   zhuǎn   zhuàn	turn	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions		转 (Travel 3), 转机 (Travel 3), 转发 (Internet Slang)
+Travel 3	转机	轉機	zhuǎn jī	zhuǎn jī	Connection	(to take) a turn for the better / to change planes	(to take) a turn for the better / to change planes		No Matches Found
+Travel 3	柜台	櫃檯	guì tái	guì tái	counter	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)		No Matches Found
+Travel 3	国际	國際	guó jì	guó jì	International	international	international		No Matches Found
+Travel 3	换钱	換錢	huàn qián	huàn qián	Change money	to change money / to sell	to change money / to sell		No Matches Found
+Travel 3	银行	銀行	yín háng	yín háng	bank	bank / CL: 家, 個｜个	bank / CL: 家, 個｜个		No Matches Found
+Travel 3	充电	充電	chōng diàn	chōng diàn	Charging	to recharge batteries / fig. to rest and recuperate	to recharge batteries / fig. to rest and recuperate		No Matches Found
+Travel 3	国内	國內	guó nèi	guó nèi	domestic	domestic / internal (to a country) / civil	domestic / internal (to a country) / civil		No Matches Found
+Travel 3	银	銀	yín	yín	silver	silver / silver-colored / relating to money or currency	silver / silver-colored / relating to money or currency		银行 (Travel 3), 银 (Travel 3)
+Travel 3	充		chōng	chōng	Charge	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full		充电 (Travel 3), 充 (Travel 3), 充值 (Travel 3)
+Travel 3	内	內	nèi	nèi	Inside	inside / inner / internal / within / interior	inside / inner / internal / within / interior		国内 (Travel 3), 内 (Travel 3)
+Travel 3	充值		chōng zhí	chōng zhí	Recharge	to recharge (money onto a card)	to recharge (money onto a card)		No Matches Found
+Travel 3	漫游	漫遊	màn yóu	màn yóu	roaming	to travel around / to roam / (mobile telephony) roaming	to travel around / to roam / (mobile telephony) roaming		No Matches Found
+Travel 3	电话卡	電話卡	diàn huà kǎ	diàn huà kǎ	phone card	telephone card	telephone card		No Matches Found
+Travel 3	值		zhí	zhí	value	value / (to be) worth / to happen to / to be on duty	value / (to be) worth / to happen to / to be on duty		充值 (Travel 3), 值 (Travel 3)
+Travel 3	订房	訂房	dìng fáng	dìng fáng	Booking	to reserve a room	to reserve a room		No Matches Found
+Travel 3	退房		tuì fáng	tuì fáng	check out	to check out of a hotel room	to check out of a hotel room		No Matches Found
+Travel 3	取消		qǔ xiāo	qǔ xiāo	cancel	to cancel / cancellation	to cancel / cancellation		No Matches Found
+Travel 3	导游	導遊	dǎo yóu	dǎo yóu	Tourist guide	tour guide / guidebook / to conduct a tour	tour guide / guidebook / to conduct a tour		No Matches Found
+Travel 3	取		qǔ	qǔ	take	to take / to get / to choose / to fetch	to take / to get / to choose / to fetch		取消 (Travel 3), 取 (Travel 3)
+Travel 3	导	導	dǎo	dǎo	guide	to transmit / to lead / to guide / to conduct / to direct	to transmit / to lead / to guide / to conduct / to direct		导游 (Travel 3), 导 (Travel 3)
+Travel 3	消		xiāo	xiāo	Eliminate	to disappear / to vanish / to eliminate / to spend (time) / have to / need	to disappear / to vanish / to eliminate / to spend (time) / have to / need		取消 (Travel 3), 消 (Travel 3)
+Languages 3	答		dā   dá	dā   dá	answer	to answer / to agree  reply / answer / return / respond / echo	to answer / to agree  reply / answer / return / respond / echo		答 (Languages 3), 回答 (Languages 3)
+Languages 3	句		jù	jù	sentence	sentence / clause / phrase / classifier for phrases or lines of verse	sentence / clause / phrase / classifier for phrases or lines of verse		句 (Languages 3), 句子 (Languages 3)
+Languages 3	简	簡	jiǎn	jiǎn	simple	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)		简 (Languages 3), 简单 (Languages 3)
+Languages 3	简单	簡單	jiǎn dān	jiǎn dān	simple	simple / not complicated	simple / not complicated		No Matches Found
+Languages 3	句子		jù zi	jù zi	sentence	sentence / CL: 個｜个	sentence / CL: 個｜个		No Matches Found
+Languages 3	回答		huí dá	huí dá	Reply	to reply / to answer / the answer / CL: 個｜个	to reply / to answer / the answer / CL: 個｜个		No Matches Found
+Languages 3	词典	詞典	cí diǎn	cí diǎn	dictionary	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本		No Matches Found
+Languages 3	应用	應用	yìng yòng	yìng yòng	application	to use / to apply / application / applicable	to use / to apply / application / applicable		No Matches Found
+Languages 3	语法	語法	yǔ fǎ	yǔ fǎ	grammar	grammar	grammar		No Matches Found
+Languages 3	流利		liú lì	liú lì	fluent	fluent	fluent		No Matches Found
+Languages 3	词	詞	cí	cí	word	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首		词典 (Languages 3), 词 (Languages 3)
+Languages 3	流		liú	liú	flow	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade		流利 (Languages 3), 流 (Languages 3)
+Languages 3	典		diǎn	diǎn	Code	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn		词典 (Languages 3), 典 (Languages 3)
+Languages 3	下载	下載	xià zǎi	xià zǎi	download	to download / also pr. [xia4 zai4]	to download / also pr. [xia4 zai4]		No Matches Found
+Languages 3	多邻国		duō lín guó	duō lín guó	Duolingo	duolingo	duolingo		No Matches Found
+Languages 3	翻译	翻譯	fān yì	fān yì	translation	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名		No Matches Found
+Languages 3	翻		fān	fān	turn	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross		翻译 (Languages 3), 翻 (Languages 3)
+Languages 3	载	載	zǎi   zài	zǎi   zài	Load	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously		下载 (Languages 3), 载 (Languages 3)
+Languages 3	译	譯	yì	yì	Translate	to translate / to interpret	to translate / to interpret		翻译 (Languages 3), 译 (Languages 3)
+House	把		bǎ   bà	bǎ   bà	The	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle		No Matches Found
+House	灯	燈	dēng	dēng	light	lamp / light / lantern / CL: 盞｜盏	lamp / light / lantern / CL: 盞｜盏		灯 (House), 红绿灯 (Travel 4)
+House	空调	空調	kōng tiáo	kōng tiáo	air conditioning	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台		No Matches Found
+House	画	畫	huà	huà	painting	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划		No Matches Found
+House	厨房	廚房	chú fáng	chú fáng	kitchen	kitchen / CL: 間｜间	kitchen / CL: 間｜间		No Matches Found
+House	客厅	客廳	kè tīng	kè tīng	living room	drawing room (room for arriving guests) / living room / CL: 間｜间	drawing room (room for arriving guests) / living room / CL: 間｜间		No Matches Found
+House	厨	廚	chú	chú	Kitchen	kitchen	kitchen		厨房 (House), 厨 (House)
+House	厅	廳	tīng	tīng	hall	(reception) hall / living room / office / provincial government department	(reception) hall / living room / office / provincial government department		客厅 (House), 厅 (House)
+House	客人		kè rén	kè rén	The guests	visitor / guest / customer / client / CL: 位	visitor / guest / customer / client / CL: 位		No Matches Found
+House	打扫	打掃	dǎ sǎo	dǎ sǎo	clean	to clean / to sweep	to clean / to sweep		No Matches Found
+House	干净	乾淨	gān jìng	gān jìng	clean	clean / neat	clean / neat		No Matches Found
+House	扫	掃	sǎo   sào	sǎo   sào	sweep	to sweep  broom	to sweep  broom		打扫 (House), 扫 (House)
+House	净	淨	jìng	jìng	net	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role		干净 (House), 净 (House)
+House	电梯	電梯	diàn tī	diàn tī	elevator	elevator / escalator / CL: 臺｜台, 部	elevator / escalator / CL: 臺｜台, 部		No Matches Found
+House	坏	壞	huài	huài	Bad	bad / spoiled / broken / to break down / (suffix) to the utmost	bad / spoiled / broken / to break down / (suffix) to the utmost		No Matches Found
+House	被		bèi	bèi	Is	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with		No Matches Found
+House	厕所	廁所	cè suǒ	cè suǒ	WC	toilet / lavatory / CL: 間｜间, 處｜处	toilet / lavatory / CL: 間｜间, 處｜处		No Matches Found
+House	厕	廁	cè   sì	cè   sì	toilet	restroom / toilet / lavatory  see 茅廁｜茅厕	restroom / toilet / lavatory  see 茅廁｜茅厕		厕所 (House), 厕 (House)
+House	梯		tī	tī	ladder	ladder / stairs	ladder / stairs		电梯 (House), 梯 (House)
+Exam	寒		hán	hán	cold	cold / poor / to tremble	cold / poor / to tremble		寒 (Exam), 寒假 (Exam)
+Exam	暑		shǔ	shǔ	Heat	heat / hot weather / summer heat	heat / hot weather / summer heat		暑 (Exam), 暑假 (Exam)
+Exam	复	復	fù   fù	fù   fù	complex	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate		复 (Exam), 复习 (Exam), 回复 (Business 1)
+Exam	记得	記得	jì de	jì de	remember	to remember	to remember		No Matches Found
+Exam	复习	復習	fù xí	fù xí	review	to review / revision / CL: 次	to review / revision / CL: 次		No Matches Found
+Exam	数学	數學	shù xué	shù xué	mathematics	mathematics / mathematical	mathematics / mathematical		No Matches Found
+Exam	放假		fàng jià	fàng jià	holiday	to have a holiday or vacation	to have a holiday or vacation		No Matches Found
+Exam	暑假		shǔ jià	shǔ jià	summer vacation	summer vacation / CL: 個｜个	summer vacation / CL: 個｜个		No Matches Found
+Exam	寒假		hán jià	hán jià	winter vacation	winter vacation	winter vacation		No Matches Found
+Exam	终于	終於	zhōng yú	zhōng yú	at last	at last / in the end / finally / eventually	at last / in the end / finally / eventually		No Matches Found
+Exam	结束	結束	jié shù	jié shù	End	termination / to finish / to end / to conclude / to close	termination / to finish / to end / to conclude / to close		No Matches Found
+Exam	放松	放鬆	fàng sōng	fàng sōng	Relax	to loosen / to relax	to loosen / to relax		No Matches Found
+Exam	大学	大學	Dà xué   dà xué	Dà xué   dà xué	the University	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所		No Matches Found
+Exam	终	終	zhōng	zhōng	end	end / finish	end / finish		终于 (Exam), 终 (Exam)
+Exam	于		Yú   yú   yú	Yú   yú   yú	to	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of		终于 (Exam), 于 (Exam), 关于 (Communication 2)
+Exam	束		Shù   shù	Shù   shù	bundle	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control		结束 (Exam), 束 (Exam)
+Exam	成绩	成績	chéng jì	chéng jì	Achievement	achievement / performance records / grades / CL: 項｜项, 個｜个	achievement / performance records / grades / CL: 項｜项, 個｜个		No Matches Found
+Exam	担心	擔心	dān xīn	dān xīn	worry	anxious / worried / uneasy / to worry / to be anxious	anxious / worried / uneasy / to worry / to be anxious		No Matches Found
+Exam	专业	專業	zhuān yè	zhuān yè	profession	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional		No Matches Found
+Exam	担	擔	dān   dàn	dān   dàn	Dan	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole		担心 (Exam), 担 (Exam)
+Exam	专	專	zhuān	zhuān	Special	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized		专业 (Exam), 专 (Exam)
+Exam	绩	績	jì	jì	Merit	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]		成绩 (Exam), 绩 (Exam)
+Travel 4	景		Jǐng   jǐng	Jǐng   jǐng	view	surname Jing  bright / circumstance / scenery	surname Jing  bright / circumstance / scenery		景 (Travel 4), 风景 (Travel 4)
+Travel 4	街		jiē	jiē	street	street / CL: 條｜条	street / CL: 條｜条		街 (Travel 4), 街道 (Travel 4)
+Travel 4	地图	地圖	dì tú	dì tú	map	map / CL: 張｜张, 本	map / CL: 張｜张, 本		No Matches Found
+Travel 4	街道		jiē dào	jiē dào	street	street / CL: 條｜条 / subdistrict / residential district	street / CL: 條｜条 / subdistrict / residential district		No Matches Found
+Travel 4	红绿灯	紅綠燈	hóng lǜ dēng	hóng lǜ dēng	traffic light	traffic light / traffic signal	traffic light / traffic signal		No Matches Found
+Travel 4	风景	風景	fēng jǐng	fēng jǐng	landscape	scenery / landscape / CL: 個｜个	scenery / landscape / CL: 個｜个		No Matches Found
+Travel 4	司机	司機	sī jī	sī jī	driver	chauffeur / driver / CL: 個｜个	chauffeur / driver / CL: 個｜个		No Matches Found
+Travel 4	接		jiē	jiē	Meet	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb		No Matches Found
+Travel 4	免费	免費	miǎn fèi	miǎn fèi	free	free (of charge)	free (of charge)		No Matches Found
+Travel 4	打车	打車	dǎ chē	dǎ chē	A taxi	to take a taxi (in town) / to hitch a lift	to take a taxi (in town) / to hitch a lift		No Matches Found
+Travel 4	观光	觀光	guān guāng	guān guāng	go sightseeing	to tour / sightseeing / tourism	to tour / sightseeing / tourism		No Matches Found
+Travel 4	免		miǎn	miǎn	Avoid	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited		免费 (Travel 4), 免 (Travel 4), 免 (Business 2)
+Travel 4	观	觀	Guàn   guān   guàn	Guàn   guān   guàn	Watch	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform		观光 (Travel 4), 观 (Travel 4), 参观 (Travel 4)
+Travel 4	光		guāng	guāng	Light	light / ray / CL: 道 / bright / only / merely / to use up	light / ray / CL: 道 / bright / only / merely / to use up		观光 (Travel 4), 光 (Travel 4)
+Travel 4	小心		xiǎo xīn	xiǎo xīn	Be careful	to be careful / to take care	to be careful / to take care		No Matches Found
+Travel 4	时差	時差	shí chā	shí chā	jet lag	time difference / time lag / jet lag	time difference / time lag / jet lag		No Matches Found
+Travel 4	马路	馬路	mǎ lù	mǎ lù	road	street / road / CL: 條｜条	street / road / CL: 條｜条		No Matches Found
+Travel 4	参观	參觀	cān guān	cān guān	Visit	to look around / to tour / to visit	to look around / to tour / to visit		No Matches Found
+Travel 4	博物馆	博物館	bó wù guǎn	bó wù guǎn	museum	museum	museum		No Matches Found
+Travel 4	博		bó	bó	Rich	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble		博物馆 (Travel 4), 博 (Travel 4), 微博 (Internet Slang)
+Travel 4	安排		ān pái	ān pái	arrangement	to arrange / to plan / to set up / arrangements / plans	to arrange / to plan / to set up / arrangements / plans		No Matches Found
+Travel 4	活动	活動	huó dòng	huó dòng	activity	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个		No Matches Found
+Travel 4	表演		biǎo yǎn	biǎo yǎn	Performance	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场		No Matches Found
+Travel 4	海边	海邊	hǎi biān	hǎi biān	seaside	coast / seaside / seashore / beach	coast / seaside / seashore / beach		No Matches Found
+Travel 4	活		huó	huó	live	to live / alive / living / work / workmanship	to live / alive / living / work / workmanship		活动 (Travel 4), 活 (Travel 4)
+Travel 4	演		yǎn	yǎn	play	to develop / to evolve / to practice / to perform / to play / to act	to develop / to evolve / to practice / to perform / to play / to act		表演 (Travel 4), 演 (Travel 4)
+Communication 2	邮	郵	yóu	yóu	mail	post (office) / mail	post (office) / mail		邮 (Communication 2), 电子邮件 (Communication 2)
+Communication 2	刚才	剛才	gāng cái   gāng cái	gāng cái   gāng cái	Just now	just now / a moment ago  (just) a moment ago	just now / a moment ago  (just) a moment ago		No Matches Found
+Communication 2	电子邮件	電子郵件	diàn zǐ yóu jiàn	diàn zǐ yóu jiàn	e-mail	email / CL: 封, 份	email / CL: 封, 份		No Matches Found
+Communication 2	主要		zhǔ yào	zhǔ yào	main	main / principal / major / primary	main / principal / major / primary		No Matches Found
+Communication 2	短信		duǎn xìn	duǎn xìn	SMS	text message / SMS	text message / SMS		No Matches Found
+Communication 2	关于	關於	guān yú	guān yú	on	pertaining to / concerning / with regard to / about / a matter of	pertaining to / concerning / with regard to / about / a matter of		No Matches Found
+Communication 2	主		zhǔ	zhǔ	the Lord	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)		主要 (Communication 2), 主 (Communication 2)
+Communication 2	登录	登錄	dēng lù	dēng lù	log in	to register / to log in	to register / to log in		No Matches Found
+Communication 2	密码	密碼	mì mǎ	mì mǎ	password	secret code / ciphertext / password / PIN	secret code / ciphertext / password / PIN		No Matches Found
+Communication 2	信号	信號	xìn hào	xìn hào	signal	signal	signal		No Matches Found
+Communication 2	登		dēng	dēng	Ascend	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)		登录 (Communication 2), 登 (Communication 2)
+Communication 2	密		Mì   mì	Mì   mì	dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense		密码 (Communication 2), 密 (Communication 2)
+Communication 2	录	錄	Lù   lù	Lù   lù	record	surname Lu  diary / record / to hit / to copy	surname Lu  diary / record / to hit / to copy		登录 (Communication 2), 录 (Communication 2)
+Communication 2	段		Duàn   duàn	Duàn   duàn	segment	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc		No Matches Found
+Communication 2	其实	其實	qí shí	qí shí	in fact	actually / in fact / really	actually / in fact / really		No Matches Found
+Communication 2	过去	過去	guò qù   guò qu	guò qù   guò qu	past	(in the) past / former / previous / to go over / to pass by  (verb suffix)	(in the) past / former / previous / to go over / to pass by  (verb suffix)		No Matches Found
+Communication 2	谈	談	Tán   tán	Tán   tán	talk	surname Tan  to speak / to talk / to converse / to chat / to discuss	surname Tan  to speak / to talk / to converse / to chat / to discuss		No Matches Found
+Communication 2	实	實	shí	shí	real	real / true / honest / really / solid / fruit / seed / definitely	real / true / honest / really / solid / fruit / seed / definitely		其实 (Communication 2), 实 (Communication 2)
+Work 2	同意		tóng yì	tóng yì	agree	to agree / to consent / to approve	to agree / to consent / to approve		No Matches Found
+Work 2	决定	決定	jué dìng	jué dìng	Decide	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly		No Matches Found
+Work 2	根据	根據	gēn jù	gēn jù	according to	according to / based on / basis / foundation / CL: 個｜个	according to / based on / basis / foundation / CL: 個｜个		No Matches Found
+Work 2	升职	升職	shēng zhí	shēng zhí	Promotion	to get promoted (at work etc) / promotion	to get promoted (at work etc) / promotion		No Matches Found
+Work 2	根		gēn	gēn	root	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)		根据 (Work 2), 根 (Work 2)
+Work 2	据		jū   jù	jū   jù	according to	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy		根据 (Work 2), 据 (Work 2), 据 (Business 1), 收据 (Business 1)
+Work 2	升		shēng	shēng	Rise	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗		升职 (Work 2), 升 (Work 2)
+Work 2	职	職	zhí	zhí	Office	office / duty	office / duty		升职 (Work 2), 职 (Work 2)
+Work 2	满意	滿意	mǎn yì	mǎn yì	satisfaction	satisfied / pleased / to one's satisfaction	satisfied / pleased / to one's satisfaction		No Matches Found
+Work 2	认为	認為	rèn wéi	rèn wéi	think	to believe / to think / to consider / to feel	to believe / to think / to consider / to feel		No Matches Found
+Work 2	出差		chū chāi	chū chāi	On a business trip	to go on an official or business trip	to go on an official or business trip		No Matches Found
+Work 2	表现	表現	biǎo xiàn	biǎo xiàn	which performed	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior		No Matches Found
+Work 2	满	滿	Mǎn   mǎn	Mǎn   mǎn	full	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented		满意 (Work 2), 满 (Work 2)
+Work 2	老板	老闆	Lǎo bǎn   lǎo bǎn	Lǎo bǎn   lǎo bǎn	boss	Robam (brand)  boss / business proprietor / CL: 個｜个	Robam (brand)  boss / business proprietor / CL: 個｜个		No Matches Found
+Work 2	麻烦	麻煩	má fan	má fan	trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble		No Matches Found
+Work 2	开会	開會	kāi huì	kāi huì	Meetings	to hold a meeting / to attend a meeting	to hold a meeting / to attend a meeting		No Matches Found
+Work 2	面试	面試	miàn shì	miàn shì	Interview	to be interviewed (as a candidate) / interview	to be interviewed (as a candidate) / interview		No Matches Found
+Work 2	烦	煩	fán	fán	bother	to feel vexed / to bother / to trouble / superfluous and confusing / edgy	to feel vexed / to bother / to trouble / superfluous and confusing / edgy		麻烦 (Work 2), 烦 (Work 2)
+Festivals	饼	餅	bǐng	bǐng	cake	round flat cake / cookie / cake / pastry / CL: 張｜张	round flat cake / cookie / cake / pastry / CL: 張｜张		饼 (Festivals), 月饼 (Festivals)
+Festivals	月亮		yuè liang	yuè liang	moon	the moon	the moon		No Matches Found
+Festivals	月饼	月餅	yuè bǐng	yuè bǐng	moon cake	mooncake (esp. for the Mid-Autumn Festival)	mooncake (esp. for the Mid-Autumn Festival)		No Matches Found
+Festivals	中秋节	中秋節	Zhōng qiū jié	Zhōng qiū jié	Mid-Autumn Festival	the Mid-Autumn Festival on 15th of 8th lunar month	the Mid-Autumn Festival on 15th of 8th lunar month		No Matches Found
+Festivals	圆	圓	yuán	yuán	circle	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify		圆 (Festivals), 汤圆 (Festivals)
+Festivals	恭喜		gōng xǐ	gōng xǐ	Congratulation	congratulations / greetings	congratulations / greetings		No Matches Found
+Festivals	红包	紅包	hóng bāo	hóng bāo	Red envelope	money wrapped in red as a gift / bonus payment / kickback / bribe	money wrapped in red as a gift / bonus payment / kickback / bribe		No Matches Found
+Festivals	汤圆	湯圓	tāng yuán	tāng yuán	Dumpling	boiled balls of glutinous rice flour, eaten during the Lantern Festival	boiled balls of glutinous rice flour, eaten during the Lantern Festival		No Matches Found
+Festivals	聚会	聚會	jù huì	jù huì	get together	party / gathering / to meet / to get together	party / gathering / to meet / to get together		No Matches Found
+Festivals	发财	發財	fā cái	fā cái	Make a fortune	to get rich	to get rich		No Matches Found
+Festivals	恭		gōng	gōng	Respectful	respectful	respectful		恭喜 (Festivals), 恭 (Festivals)
+Festivals	聚		jù	jù	Gather	to congregate / to assemble / to mass / to gather together / to amass / to polymerize	to congregate / to assemble / to mass / to gather together / to amass / to polymerize		聚会 (Festivals), 聚 (Festivals)
+Festivals	财	財	cái	cái	fiscal	money / wealth / riches / property / valuables	money / wealth / riches / property / valuables		发财 (Festivals), 财 (Festivals)
+Festivals	端午节	端午節	Duān wǔ jié	Duān wǔ jié	Dragon boat festival	Dragon Boat Festival (5th day of the 5th lunar month)	Dragon Boat Festival (5th day of the 5th lunar month)		No Matches Found
+Festivals	粽子		zòng zi	zòng zi	Zongzi	glutinous rice and choice of filling wrapped in leaves and boiled	glutinous rice and choice of filling wrapped in leaves and boiled		No Matches Found
+Festivals	划		huá   huá   huà	huá   huá   huà	Draw	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character		No Matches Found
+Festivals	龙舟	龍舟	lóng zhōu	lóng zhōu	Dragon Boat	dragon boat / imperial boat	dragon boat / imperial boat		No Matches Found
+Festivals	端		duān	duān	end	end / extremity / item / port / to hold sth level with both hands / to carry / regular	end / extremity / item / port / to hold sth level with both hands / to carry / regular		端午节 (Festivals), 端 (Festivals)
+Festivals	粽		zòng	zòng	Dumplings	rice dumplings wrapped in leaves	rice dumplings wrapped in leaves		粽子 (Festivals), 粽 (Festivals)
+Festivals	龙	龍	Lóng   lóng	Lóng   lóng	Dragon	surname Long  dragon / CL: 條｜条 / imperial	surname Long  dragon / CL: 條｜条 / imperial		龙舟 (Festivals), 龙 (Festivals)
+Festivals	舟		zhōu	zhōu	boat	boat	boat		龙舟 (Festivals), 舟 (Festivals)
+Gourmet 2	珠		zhū	zhū	Pearl	bead / pearl / CL: 粒, 顆｜颗	bead / pearl / CL: 粒, 顆｜颗		珠 (Gourmet 2), 珍珠奶茶 (Gourmet 2)
+Gourmet 2	汤	湯	Tāng   shāng   tāng	Tāng   shāng   tāng	soup	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled		汤圆 (Festivals), 汤 (Gourmet 2), 酸辣汤 (Gourmet 2)
+Gourmet 2	酸		suān	suān	acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid		酸 (Gourmet 2), 酸辣汤 (Gourmet 2)
+Gourmet 2	珍		zhēn	zhēn	Treasure	precious thing / treasure / culinary delicacy / rare / valuable / to value highly	precious thing / treasure / culinary delicacy / rare / valuable / to value highly		珍 (Gourmet 2), 珍珠奶茶 (Gourmet 2)
+Gourmet 2	珍珠奶茶		zhēn zhū nǎi chá	zhēn zhū nǎi chá	Pearl milk tea	pearl milk tea / tapioca milk tea / bubble milk tea	pearl milk tea / tapioca milk tea / bubble milk tea		No Matches Found
+Gourmet 2	酸辣汤	酸辣湯	suān là tāng	suān là tāng	Hot and sour soup	hot and sour soup / sour and spicy soup	hot and sour soup / sour and spicy soup		No Matches Found
+Gourmet 2	北京烤鸭	北京烤鴨	Běi jīng kǎo yā	Běi jīng kǎo yā	Peking duck	Peking Duck	Peking Duck		No Matches Found
+Gourmet 2	春卷	春捲	chūn juǎn	chūn juǎn	Spring Rolls	egg roll / spring roll	egg roll / spring roll		No Matches Found
+Gourmet 2	豆花		dòu huā	dòu huā	Curd	jellied tofu / soft bean curd	jellied tofu / soft bean curd		No Matches Found
+Gourmet 2	烤		kǎo	kǎo	grilled	to roast / to bake / to broil	to roast / to bake / to broil		北京烤鸭 (Gourmet 2), 烤 (Gourmet 2)
+Gourmet 2	鸭	鴨	yā	yā	duck	duck / CL: 隻｜只 / (slang) male prostitute	duck / CL: 隻｜只 / (slang) male prostitute		北京烤鸭 (Gourmet 2), 鸭 (Gourmet 2)
+Gourmet 2	卷		juǎn   juàn   juǎn	juǎn   juàn   juǎn	volume	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll		春卷 (Gourmet 2), 卷 (Gourmet 2)
+Gourmet 2	宫保鸡丁	宮保雞丁	gōng bǎo jī dīng	gōng bǎo jī dīng	Kung Pao Chicken	Kung Pao Chicken / spicy diced chicken	Kung Pao Chicken / spicy diced chicken		No Matches Found
+Gourmet 2	卤肉饭		lǔ ròu fàn	lǔ ròu fàn	Braised pork on rice	Braised pork on rice	Braised pork on rice		No Matches Found
+Gourmet 2	馒头	饅頭	mán tou	mán tou	steamed bread	steamed roll / steamed bun / steamed bread / CL: 個｜个	steamed roll / steamed bun / steamed bread / CL: 個｜个		No Matches Found
+Gourmet 2	保		Bǎo   bǎo	Bǎo   bǎo	Insurance	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure		宫保鸡丁 (Gourmet 2), 保 (Gourmet 2), 保险 (Business 2), 保持 (Business 2)
+Gourmet 2	卤	滷	lǔ   lǔ	lǔ   lǔ	halogen	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid		卤肉饭 (Gourmet 2), 卤 (Gourmet 2)
+Gourmet 2	馒	饅	mán	mán	steamed bread	steamed bread	steamed bread		馒头 (Gourmet 2), 馒 (Gourmet 2)
+Gourmet 2	丁		Dīng   dīng	Dīng   dīng	Ding	surname Ding  fourth of the ten Heavenly Stems 十天干 / fourth in order / letter 'D' or roman 'IV' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 195° / butyl / cubes (of food)	surname Ding  fourth of the ten Heavenly Stems 十天干 / fourth in order / letter 'D' or roman 'IV' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 195° / butyl / cubes (of food)		宫保鸡丁 (Gourmet 2), 丁 (Gourmet 2)
+Internet Slang	豪		háo	háo	Howe	grand / heroic	grand / heroic		豪 (Internet Slang), 土豪 (Internet Slang)
+Internet Slang	宅		zhái	zhái	House	residence / (coll.) to stay in at home / to hang around at home	residence / (coll.) to stay in at home / to hang around at home		宅 (Internet Slang), 宅男 (Internet Slang)
+Internet Slang	土		Tǔ   tǔ	Tǔ   tǔ	soil	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音		土 (Internet Slang), 土豪 (Internet Slang)
+Internet Slang	土豪		tǔ háo	tǔ háo	Local tycoon	local tyrant / local strong man / (slang) nouveau riche	local tyrant / local strong man / (slang) nouveau riche		No Matches Found
+Internet Slang	吃货	吃貨	chī huò	chī huò	Food goods	chowhound / foodie / a good-for-nothing	chowhound / foodie / a good-for-nothing		No Matches Found
+Internet Slang	宅男		zhái nán	zhái nán	Takuotoko	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')		No Matches Found
+Internet Slang	菜鸟	菜鳥	cài niǎo	cài niǎo	Rookie	(coll.) sb new to a particular subject / rookie / beginner / newbie	(coll.) sb new to a particular subject / rookie / beginner / newbie		No Matches Found
+Internet Slang	美图		měi tú	měi tú	Mito				No Matches Found
+Internet Slang	萌		méng	méng	Sprout	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)		No Matches Found
+Internet Slang	自拍		zì pāi	zì pāi	Selfie	to take a picture or video of oneself	to take a picture or video of oneself		No Matches Found
+Internet Slang	囧		jiǒng	jiǒng	Oops	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated		No Matches Found
+Internet Slang	美眉		měi méi	měi méi	Meimei	(coll.) pretty girl	(coll.) pretty girl		No Matches Found
+Internet Slang	高富帅	高富帥	gāo fù shuài	gāo fù shuài	Tall, rich and handsome	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)		No Matches Found
+Internet Slang	眉		méi	méi	eyebrow	eyebrow / upper margin	eyebrow / upper margin		美眉 (Internet Slang), 眉 (Internet Slang)
+Internet Slang	富		Fù   fù	Fù   fù	rich	surname Fu  rich / abundant / wealthy	surname Fu  rich / abundant / wealthy		高富帅 (Internet Slang), 富 (Internet Slang)
+Internet Slang	微博		wēi bó	wēi bó	BiHiroshi	micro-blogging / microblog	micro-blogging / microblog		No Matches Found
+Internet Slang	微信		Wēi xìn	Wēi xìn	Micro letter	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)		No Matches Found
+Internet Slang	朋友圈		Péng you quān	Péng you quān	Circle of friends	Moments (social networking function of smartphone app WeChat 微信)	Moments (social networking function of smartphone app WeChat 微信)		No Matches Found
+Internet Slang	微		Wēi   wēi	Wēi   wēi	micro-	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]		微博 (Internet Slang), 微信 (Internet Slang), 微 (Internet Slang)
+Internet Slang	圈		juān   juàn   quān	juān   juàn   quān	ring	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle		朋友圈 (Internet Slang), 圈 (Internet Slang)
+Internet Slang	关注	關注	guān zhù	guān zhù	attention	to pay attention to / to follow sth closely / concern / interest / attention	to pay attention to / to follow sth closely / concern / interest / attention		No Matches Found
+Internet Slang	赞	贊	zàn	zàn	awesome	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)		No Matches Found
+Internet Slang	转发	轉發	zhuǎn fā	zhuǎn fā	Forwarded	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)		No Matches Found
+Internet Slang	好友		hǎo yǒu	hǎo yǒu	Friends	close friend / pal / (social networking website) friend / CL: 個｜个	close friend / pal / (social networking website) friend / CL: 個｜个		No Matches Found
+Internet Slang	粉丝	粉絲	fěn sī	fěn sī	Fans	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth		No Matches Found
+Internet Slang	分享		fēn xiǎng	fēn xiǎng	share it	to share (let others have some of sth good)	to share (let others have some of sth good)		No Matches Found
+Internet Slang	评论	評論	píng lùn	píng lùn	comment	to comment on / to discuss / comment / commentary / CL: 篇	to comment on / to discuss / comment / commentary / CL: 篇		No Matches Found
+Internet Slang	粉		fěn	fěn	powder	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink		粉丝 (Internet Slang), 粉 (Internet Slang)
+Internet Slang	丝	絲	sī	sī	wire	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc		粉丝 (Internet Slang), 丝 (Internet Slang)
+Internet Slang	享		xiǎng	xiǎng	enjoy	to enjoy / to benefit / to have the use of	to enjoy / to benefit / to have the use of		分享 (Internet Slang), 享 (Internet Slang)
+Internet Slang	评	評	píng	píng	Review	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)		评论 (Internet Slang), 评 (Internet Slang)
+Internet Slang	论	論	Lún   lùn	Lún   lùn	s	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)		评论 (Internet Slang), 论 (Internet Slang)
+Business 1	销	銷	xiāo	xiāo	pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin		销 (Business 1), 报销 (Business 1)
+Business 1	收据	收據	shōu jù	shōu jù	receipt	receipt / CL: 張｜张	receipt / CL: 張｜张		No Matches Found
+Business 1	报销	報銷	bào xiāo	bào xiāo	Submit an expense account	to submit an expense account / to apply for reimbursement / to write off / to wipe out	to submit an expense account / to apply for reimbursement / to write off / to wipe out		No Matches Found
+Business 1	费用	費用	fèi yòng	fèi yòng	cost	cost / expenditure / expense / CL: 筆｜笔, 個｜个	cost / expenditure / expense / CL: 筆｜笔, 個｜个		No Matches Found
+Business 1	尽快	儘快	jǐn kuài   jìn kuài	jǐn kuài   jìn kuài	ASAP	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快		No Matches Found
+Business 1	回复	回復	huí fù	huí fù	Reply	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)		No Matches Found
+Business 1	报告	報告	bào gào	bào gào	report	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通		No Matches Found
+Business 1	协议	協議	xié yì	xié yì	protocol	agreement / pact / protocol / CL: 項｜项	agreement / pact / protocol / CL: 項｜项		No Matches Found
+Business 1	尽	儘	jǐn   jìn	jǐn   jìn	Exhausted	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely		尽快 (Business 1), 尽 (Business 1)
+Business 1	协	協	xié	xié	Assist	to cooperate / to harmonize / to help / to assist / to join	to cooperate / to harmonize / to help / to assist / to join		协议 (Business 1), 协 (Business 1)
+Business 1	合同		hé tong	hé tong	contract	(business) contract / CL: 個｜个	(business) contract / CL: 個｜个		No Matches Found
+Business 1	项目	項目	xiàng mù	xiàng mù	project	item / project / (sports) event / CL: 個｜个	item / project / (sports) event / CL: 個｜个		No Matches Found
+Business 1	签名	簽名	qiān míng	qiān míng	signature	to sign (one's name with a pen etc) / to autograph / signature	to sign (one's name with a pen etc) / to autograph / signature		No Matches Found
+Business 1	汇报	匯報	huì bào   huì bào	huì bào   huì bào	report	to report / to give an account of / to collect information and report back  to report / to give an account of / report	to report / to give an account of / to collect information and report back  to report / to give an account of / report		No Matches Found
+Business 1	合		gě   hé	gě   hé	Close	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒		合同 (Business 1), 合 (Business 1), 合作 (Business 2)
+Business 1	项	項	Xiàng   xiàng	Xiàng   xiàng	item	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc		项目 (Business 1), 项 (Business 1)
+Business 1	汇	匯	huì   huì	huì   huì	exchange	to remit / to converge (of rivers) / to exchange  class / collection	to remit / to converge (of rivers) / to exchange  class / collection		汇报 (Business 1), 汇 (Business 1)
+Business 1	广告	廣告	guǎng gào	guǎng gào	ad	to advertise / a commercial / advertisement / CL: 項｜项	to advertise / a commercial / advertisement / CL: 項｜项		No Matches Found
+Business 1	预算	預算	yù suàn	yù suàn	budget	budget	budget		No Matches Found
+Business 1	资本	資本	zī běn	zī běn	capital	capital (economics)	capital (economics)		No Matches Found
+Business 1	低		dī	dī	low	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	low / beneath / to lower (one's head) / to let droop / to hang down / to incline		No Matches Found
+Business 1	广	廣	Guǎng   guǎng	Guǎng   guǎng	wide	surname Guang  wide / numerous / to spread	surname Guang  wide / numerous / to spread		广告 (Business 1), 广 (Business 1)
+Business 1	资	資	zī	zī	Capital	resources / capital / to provide / to supply / to support / money / expense	resources / capital / to provide / to supply / to support / money / expense		资本 (Business 1), 资 (Business 1), 投资 (Business 2), 工资 (Work 3)
+Business 2	险	險	xiǎn	xiǎn	risk	danger / dangerous / rugged	danger / dangerous / rugged		险 (Business 2), 保险 (Business 2), 风险 (Business 2)
+Business 2	投		tóu	tóu	cast	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of		投 (Business 2), 投资 (Business 2)
+Business 2	保险	保險	bǎo xiǎn	bǎo xiǎn	Insurance	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	insurance / to insure / safe / secure / be sure / be bound to / CL: 份		No Matches Found
+Business 2	风险	風險	fēng xiǎn	fēng xiǎn	risk	risk / hazard	risk / hazard		No Matches Found
+Business 2	投资	投資	tóu zī	tóu zī	investment	investment / to invest	investment / to invest		No Matches Found
+Business 2	律师	律師	lǜ shī	lǜ shī	lawyer	lawyer	lawyer		No Matches Found
+Business 2	版权	版權	bǎn quán	bǎn quán	copyright	copyright	copyright		No Matches Found
+Business 2	咨询	咨詢	zī xún	zī xún	advisory	to consult / to seek advice / consultation / (sales) inquiry (formal)	to consult / to seek advice / consultation / (sales) inquiry (formal)		No Matches Found
+Business 2	律		Lǜ   lǜ	Lǜ   lǜ	law	surname Lü  law	surname Lü  law		律师 (Business 2), 律 (Business 2)
+Business 2	版		bǎn	bǎn	Version	a register / block of printing / edition / version / page	a register / block of printing / edition / version / page		版权 (Business 2), 版 (Business 2)
+Business 2	咨		zī	zī	Advisory	to consult	to consult		咨询 (Business 2), 咨 (Business 2)
+Business 2	权	權	Quán   quán	Quán   quán	right	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary		版权 (Business 2), 权 (Business 2)
+Business 2	询	詢	xún	xún	Query	to ask about / to inquire about	to ask about / to inquire about		咨询 (Business 2), 询 (Business 2)
+Business 2	保持		bǎo chí	bǎo chí	maintain	to keep / to maintain / to hold / to preserve	to keep / to maintain / to hold / to preserve		No Matches Found
+Business 2	联系	聯繫	lián xì	lián xì	contact	connection / contact / relation / to get in touch with / to integrate / to link / to touch	connection / contact / relation / to get in touch with / to integrate / to link / to touch		No Matches Found
+Business 2	联	聯	lián	lián	United	to ally / to unite / to join / (poetry) antithetical couplet	to ally / to unite / to join / (poetry) antithetical couplet		联系 (Business 2), 联 (Business 2)
+Business 2	持		chí	chí	hold	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control		保持 (Business 2), 持 (Business 2)
+Business 2	合作		hé zuò	hé zuò	Cooperation	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个		No Matches Found
+Business 2	愉快		yú kuài	yú kuài	happy	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted		No Matches Found
+Business 2	辛苦		xīn kǔ	xīn kǔ	hard	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)		No Matches Found
+Business 2	感谢	感謝	gǎn xiè	gǎn xiè	thank	(express) thanks / gratitude / grateful / thankful / thanks	(express) thanks / gratitude / grateful / thankful / thanks		No Matches Found
+Business 2	愉		yú	yú	Discovery	pleased	pleased		愉快 (Business 2), 愉 (Business 2)
+Business 2	辛		Xīn   xīn	Xīn   xīn	Xin	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa		辛苦 (Business 2), 辛 (Business 2)
+Emergency	伤	傷	shāng	shāng	hurt	to injure / injury / wound	to injure / injury / wound		伤 (Emergency), 受伤 (Emergency)
+Emergency	受		shòu	shòu	Suffer	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)		受 (Emergency), 受伤 (Emergency)
+Emergency	救		jiù	jiù	save	to save / to assist / to rescue	to save / to assist / to rescue		救 (Emergency), 救护车 (Emergency), 救命 (Emergency)
+Emergency	警		jǐng	jǐng	police	to alert / to warn / police	to alert / to warn / police		警 (Emergency), 报警 (Emergency), 警察 (Emergency)
+Emergency	报警	報警	bào jǐng	bào jǐng	Call the police	to sound an alarm / to report sth to the police	to sound an alarm / to report sth to the police		No Matches Found
+Emergency	救护车	救護車	jiù hù chē	jiù hù chē	ambulance	ambulance / CL: 輛｜辆	ambulance / CL: 輛｜辆		No Matches Found
+Emergency	受伤	受傷	shòu shāng	shòu shāng	Injured	to sustain injuries / wounded (in an accident etc) / harmed	to sustain injuries / wounded (in an accident etc) / harmed		No Matches Found
+Emergency	救命		jiù mìng	jiù mìng	Help	to save sb's life / (interj.) Help! / Save me!	to save sb's life / (interj.) Help! / Save me!		No Matches Found
+Emergency	发生	發生	fā shēng	fā shēng	occur	to happen / to occur / to take place / to break out	to happen / to occur / to take place / to break out		No Matches Found
+Emergency	意外		yì wài	yì wài	accident	unexpected / accident / mishap / CL: 個｜个	unexpected / accident / mishap / CL: 個｜个		No Matches Found
+Emergency	严重	嚴重	yán zhòng	yán zhòng	serious	grave / serious / severe / critical	grave / serious / severe / critical		No Matches Found
+Emergency	严	嚴	Yán   yán	Yán   yán	strict	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father		严重 (Emergency), 严 (Emergency)
+Emergency	命		mìng	mìng	Life	life / fate / order or command / to assign a name, title etc	life / fate / order or command / to assign a name, title etc		救命 (Emergency), 命 (Emergency)
+Emergency	偷		tōu	tōu	steal	to steal / to pilfer / to snatch / thief / stealthily	to steal / to pilfer / to snatch / thief / stealthily		No Matches Found
+Emergency	警察		jǐng chá	jǐng chá	Policemen	police / police officer / CL: 個｜个	police / police officer / CL: 個｜个		No Matches Found
+Emergency	察		Chá   chá	Chá   chá	Observe	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident		警察 (Emergency), 察 (Emergency)
+Work 3	奖	獎	jiǎng	jiǎng	prize	prize / award / encouragement / CL: 個｜个	prize / award / encouragement / CL: 個｜个		奖 (Work 3), 奖金 (Work 3)
+Work 3	工资	工資	gōng zī	gōng zī	wage	wages / pay / CL: 個｜个, 份, 月	wages / pay / CL: 個｜个, 份, 月		No Matches Found
+Work 3	加班		jiā bān	jiā bān	Overtime	to work overtime	to work overtime		No Matches Found
+Work 3	奖金	獎金	jiǎng jīn	jiǎng jīn	bonus	premium / award money / bonus	premium / award money / bonus		No Matches Found
+Work 3	生意		shēng yì   shēng yi	shēng yì   shēng yi	business	life force / vitality  business / CL: 筆｜笔	life force / vitality  business / CL: 筆｜笔		No Matches Found
+Work 3	压力	壓力	yā lì	yā lì	pressure	pressure	pressure		No Matches Found
+Work 3	责任	責任	zé rèn	zé rèn	responsibility	responsibility / blame / duty / CL: 個｜个	responsibility / blame / duty / CL: 個｜个		No Matches Found
+Work 3	商量		shāng liang	shāng liang	discuss	to consult / to talk over / to discuss	to consult / to talk over / to discuss		No Matches Found
+Work 3	意见	意見	yì jiàn	yì jiàn	opinion	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条		No Matches Found
+Work 3	压	壓	yā   yà	yā   yà	Press	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿		压力 (Work 3), 压 (Work 3)
+Work 3	责	責	zé	zé	responsibility	duty / responsibility / to reproach / to blame	duty / responsibility / to reproach / to blame		责任 (Work 3), 责 (Work 3)
+Work 3	任		Rén   rèn	Rén   rèn	Any	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)		责任 (Work 3), 任 (Work 3)
+Work 3	误会	誤會	wù huì	wù huì	misunderstanding	to misunderstand / to mistake / misunderstanding / CL: 個｜个	to misunderstand / to mistake / misunderstanding / CL: 個｜个		No Matches Found
+Work 3	抱歉		bào qiàn	bào qiàn	Sorry	to be sorry / to feel apologetic / sorry!	to be sorry / to feel apologetic / sorry!		No Matches Found
+Work 3	原谅	原諒	yuán liàng	yuán liàng	forgive	to excuse / to forgive / to pardon	to excuse / to forgive / to pardon		No Matches Found
+Work 3	误	誤	wù	wù	error	mistake / error / to miss / to harm / to delay / to neglect / mistakenly	mistake / error / to miss / to harm / to delay / to neglect / mistakenly		误会 (Work 3), 误 (Work 3)
+Work 3	抱		bào	bào	hold	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish		抱歉 (Work 3), 抱 (Work 3)
+Work 3	原		Yuán   yuán	Yuán   yuán	original	Hara (Japanese surname)  former / original / primary / raw / level / cause / source	Hara (Japanese surname)  former / original / primary / raw / level / cause / source		原谅 (Work 3), 原 (Work 3)
+Work 3	歉		qiàn	qiàn	apologize	to apologize / to regret / deficient	to apologize / to regret / deficient		抱歉 (Work 3), 歉 (Work 3)
+Work 3	谅	諒	liàng	liàng	Forgive	to show understanding / to excuse / to presume / to expect	to show understanding / to excuse / to presume / to expect		原谅 (Work 3), 谅 (Work 3)
+Weather 2	干燥	乾燥	gān zào	gān zào	dry	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid		No Matches Found
+Weather 2	暖和		nuǎn huo	nuǎn huo	warm	warm / nice and warm	warm / nice and warm		No Matches Found
+Weather 2	凉快	涼快	liáng kuai	liáng kuai	Cool off	nice and cold / pleasantly cool	nice and cold / pleasantly cool		No Matches Found
+Weather 2	燥		zào	zào	dry	dry / parched / impatient	dry / parched / impatient		干燥 (Weather 2), 燥 (Weather 2)
+Weather 2	暖		nuǎn	nuǎn	warm	warm / to warm	warm / to warm		暖和 (Weather 2), 暖 (Weather 2)
+Weather 2	凉	涼	Liáng   liáng   liàng	Liáng   liáng   liàng	cool	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down		凉快 (Weather 2), 凉 (Weather 2)
+Weather 2	温度	溫度	wēn dù	wēn dù	temperature	temperature / CL: 個｜个	temperature / CL: 個｜个		No Matches Found
+Weather 2	大约	大約	dà yuē	dà yuē	about	approximately / probably	approximately / probably		No Matches Found
+Weather 2	温	溫	Wēn   wēn	Wēn   wēn	temperature	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟		温度 (Weather 2), 温 (Weather 2)
+Duo	鹰	鷹	yīng	yīng	eagle	eagle / falcon / hawk	eagle / falcon / hawk		鹰 (Duo), 猫头鹰 (Duo)
+Duo	羽		yǔ	yǔ	feather	feather / 5th note in pentatonic scale	feather / 5th note in pentatonic scale		羽 (Duo), 羽毛 (Duo)
+Duo	橙		chéng	chéng	Orange	orange tree / orange (color)	orange tree / orange (color)		No Matches Found
+Duo	猫头鹰	貓頭鷹	māo tóu yīng	māo tóu yīng	owl	owl	owl		No Matches Found
+Duo	羽毛		yǔ máo	yǔ máo	feather	feather / plumage / plume	feather / plumage / plume		No Matches Found
+Duo	多儿		duō er	duō er	And more children				No Matches Found
+Duo	鼓励	鼓勵	gǔ lì	gǔ lì	encourage	to encourage	to encourage		No Matches Found
+Duo	提醒		tí xǐng	tí xǐng	remind	to remind / to call attention to / to warn of	to remind / to call attention to / to warn of		No Matches Found
+Duo	懒	懶	lǎn	lǎn	lazy	lazy	lazy		No Matches Found
+Duo	放弃	放棄	fàng qì	fàng qì	give up	to renounce / to abandon / to give up	to renounce / to abandon / to give up		No Matches Found
+Duo	鼓		gǔ	gǔ	drum	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell		鼓励 (Duo), 鼓 (Duo)
+Duo	励	勵	Lì   lì	Lì   lì	Encourage	surname Li  to encourage / to urge	surname Li  to encourage / to urge		鼓励 (Duo), 励 (Duo)
+Duo	醒		xǐng	xǐng	wake	to wake up / to be awake / to become aware / to sober up / to come to	to wake up / to be awake / to become aware / to sober up / to come to		提醒 (Duo), 醒 (Duo)
+Duo	弃	棄	qì	qì	abandoned	to abandon / to relinquish / to discard / to throw away	to abandon / to relinquish / to discard / to throw away		放弃 (Duo), 弃 (Duo)

--- a/words.tsv
+++ b/words.tsv
@@ -1,48 +1,48 @@
 Lesson	Simplified Chinese	Traditional Chinese	Primary pinyin	CC-CEDICT pinyin	Google_Translate_Definition	Primary English definition	CC-CEDICT English definition	Labels	Alternate Occurences
 Greeting 1	你		nǐ		you	you			你 (Greeting 1), 你们 (Occupation)
 Greeting 1	好		hǎo   hào		it is good	good			好 (Greeting 1), 好久不见 (Greeting 4), 爱好 (Hobbies 2), 好 (Hobbies 2), 不好意思 (Invitiation 1), 好吃 (Dining 3), 好喝 (Dining 3), 好看 (Shopping 2), 好在 (Sports 2), 好笑 (Personality and Feelings), 好友 (Internet Slang)
-Greeting 1	再见	再見	zài jiàn		Goodbye	see you again later			No Matches Found
+Greeting 1	再见	再見	zài jiàn		Goodbye	see you again later			
 Greeting 1	再		zài		again	again			再见 (Greeting 1), 再 (Greeting 1), 再 (Phrases 2)
 Greeting 1	见	見	jiàn		see	to see			再见 (Greeting 1), 见 (Greeting 1), 见 (Greeting 4), 好久不见 (Greeting 4), 见 (Location 4), 见面 (Daily Routine 3), 意见 (Work 3)
-Numbers	三		sān		three	3			No Matches Found
+Numbers	三		sān		three	3			
 Numbers	一		yī		One	1			一 (Numbers), 一会儿 (Greeting 4), 一点儿 (Telephone), 一共 (Payment), 一下 (Restaurant), 一点儿 (Languages), 一起 (Invitiation 1), 一定 (Health 2), 一样 (Family 3), 一边 (Daily Routine 2), 一直 (Location 6), 一般 (Daily Routine 3), 一个人 (Daily Routine 3)
-Numbers	七		qī		Seven	7			No Matches Found
-Numbers	八		bā		Eight	8			No Matches Found
-Numbers	十		shí		ten	10			No Matches Found
-Numbers	零		líng		zero	zero			No Matches Found
-Numbers	元		Yuán		yuan	Chinese yuan currency unit			No Matches Found
-Numbers	五		wǔ		Fives	5			No Matches Found
-Numbers	九		jiǔ		nine	9			No Matches Found
-Numbers	百		bǎi		hundred	100			No Matches Found
-Numbers	二		èr		two	2			No Matches Found
-Numbers	四		sì		four	4			No Matches Found
-Numbers	六		liù		six	6			No Matches Found
-Name	叫		jiào		call	to be called			No Matches Found
+Numbers	七		qī		Seven	7			
+Numbers	八		bā		Eight	8			
+Numbers	十		shí		ten	10			
+Numbers	零		líng		zero	zero			
+Numbers	元		Yuán		yuan	Chinese yuan currency unit			
+Numbers	五		wǔ		Fives	5			
+Numbers	九		jiǔ		nine	9			
+Numbers	百		bǎi		hundred	100			
+Numbers	二		èr		two	2			
+Numbers	四		sì		four	4			
+Numbers	六		liù		six	6			
+Name	叫		jiào		call	to be called			
 Name	我		wǒ		I	I			我 (Name), 我们 (Occupation)
 Name	张	張	Zhāng		Zhang	surname Zhang			张 (Name), 张 (Existence), 紧张 (Personality and Feelings)
 Name	李		Lǐ		Plum	surname Li			李 (Name), 李 (Name), 行李 (Travel 2)
-Name	华	華	Huá		China	given name Huá			No Matches Found
+Name	华	華	Huá		China	given name Huá			
 Name	明		míng		Bright			Meaning off-topic	明 (Name), 明天 (Time 1), 明 (Time 1), 明白 (Telephone), 明年 (Time 2), 明星 (Entertainment), 聪明 (People 2)
-Name	名字		míng zi		first name	name			No Matches Found
+Name	名字		míng zi		first name	name			
 Name	什么	什麼	shén me		what	what?			什么 (Name), 为什么 (Hobbies 2)
 Name	名		míng		name			Meaning off-topic	名字 (Name), 名 (Name), 有名 (Culture), 签名 (Business 1)
 Name	字		zì		word	letter			名字 (Name), 字 (Name), 字 (Languages), 汉字 (Languages 2)
 Name	什		shén   shí		Assorted			Meaning off-topic	什么 (Name), 什 (Name), 为什么 (Hobbies 2)
 Name	么	麼	má   ma   me		What			Meaning off-topic	什么 (Name), 么 (Name), 怎么样 (Greeting 3), 怎么 (Location 3), 为什么 (Hobbies 2), 怎么办 (Travel), 多么 (Culture)
-Name	姓		xìng		surname	Family name			No Matches Found
-Name	王		Wáng		king	surname Wang			No Matches Found
-Name	呢		ne		It	question particle			No Matches Found
-Greeting 2	很		hěn		very	very			No Matches Found
-Greeting 2	高兴	高興	gāo xìng		happy	happy			No Matches Found
+Name	姓		xìng		surname	Family name			
+Name	王		Wáng		king	surname Wang			
+Name	呢		ne		It	question particle			
+Greeting 2	很		hěn		very	very			
+Greeting 2	高兴	高興	gāo xìng		happy	happy			
 Greeting 2	高		gāo		high	tall			高兴 (Greeting 2), 高 (Greeting 2), 高 (People 1), 提高 (Languages 2), 高中 (School 2), 高富帅 (Internet Slang)
 Greeting 2	兴	興	xìng		Interest			Meaning off-topic	高兴 (Greeting 2), 兴 (Greeting 2), 兴趣 (Hobbies 3), 感兴趣 (Hobbies 3)
-Greeting 2	认识	認識	rèn shi		understanding	to know			No Matches Found
-Greeting 2	也		yě		and also	too			No Matches Found
+Greeting 2	认识	認識	rèn shi		understanding	to know			
+Greeting 2	也		yě		and also	too			
 Greeting 2	认	認	rèn		recognize			Meaning off-topic	认识 (Greeting 2), 认 (Greeting 2), 认真 (Future), 认为 (Work 2)
 Greeting 2	识	識	shí   zhì		knowledge			Meaning off-topic	认识 (Greeting 2), 识 (Greeting 2)
 Food 1	吃		chī	chī	eat	to eat	to eat / to consume / to eat at (a cafeteria etc) / to eradicate / to destroy / to absorb / to suffer / to stammer (Taiwan pr. for this sense is [ji2])		吃 (Food 1), 好吃 (Dining 3), 难吃 (Food 3), 吃货 (Internet Slang)
 Food 1	饭	飯	fàn	fàn	rice	food	food / cuisine / cooked rice / meal / CL: 碗, 頓｜顿		饭 (Food 1), 饭馆 (Location 2), 早饭 (Daily Routine 1), 午饭 (Daily Routine 1), 晚饭 (Daily Routine 1), 米饭 (Dining 1), 炒饭 (Gourmet 1), 卤肉饭 (Gourmet 2)
-Food 1	鱼	魚	yú	Yú   yú	fish	fish	surname Yu  fish / CL: 條｜条, 尾		No Matches Found
+Food 1	鱼	魚	yú	Yú   yú	fish	fish	surname Yu  fish / CL: 條｜条, 尾		
 Food 1	面		miàn	miàn   miàn	surface	noodles	face / side / surface / aspect / top / classifier for flat surfaces such as drums, mirrors, flags etc  flour / noodles / (of food) soft (not crunchy) / (slang) (of a person) ineffectual / spineless		面 (Food 1), 前面 (Location 3), 后面 (Location 3), 面包 (Supermarket), 面条 (Dining 1), 外面 (Weather), 里面 (Weather), 拉面 (Gourmet 1), 上面 (Location 5), 下面 (Location 5), 见面 (Daily Routine 3), 面试 (Work 2)
 Food 1	喝		hē	hē   hè	drink	to drink	to drink / My goodness!  to shout loudly		喝 (Food 1), 好喝 (Dining 3)
 Food 1	水		shuǐ	Shuǐ   shuǐ	water	water	surname Shui  water / river / liquid / beverage / additional charges or income / (of clothes) classifier for number of washes		水 (Food 1), 水果 (Supermarket), 水平 (Languages 2)
@@ -50,52 +50,52 @@ Food 1	茶		chá	chá	tea	tea	tea / tea plant / CL: 杯, 壺｜壶		茶 (Food 1)
 Food 1	不		bù	bù	Do not	not	(negative prefix) / not / no		不 (Food 1), 不客气 (Phrases 1), 对不起 (Phrases 1), 好久不见 (Greeting 4), 不错 (Greeting 4), 不要 (Health 1), 不准 (Transportation), 不好意思 (Invitiation 1), 不但 (People 2)
 Occupation	是		shì	shì	Yes	to be	is / are / am / yes / to be		是 (Occupation), 还是 (Dining 1), 但是 (Shopping 3), 总是 (Daily Routine 2)
 Occupation	他		tā	tā	he	he	he or him / (used for either sex when the sex is unknown or unimportant) / (used before sb's name for emphasis) / (used as a meaningless mock object) / other / another		他 (Occupation), 他们 (Occupation), 其他 (Food 3)
-Occupation	学生	學生	xué sheng	xué sheng	student	student	student / schoolchild		No Matches Found
+Occupation	学生	學生	xué sheng	xué sheng	student	student	student / schoolchild		
 Occupation	学	學	xué	xué	learn	to learn	to learn / to study / to imitate / science / -ology		学生 (Occupation), 学 (Occupation), 学校 (Location 3), 上学 (Daily Routine 1), 放学 (Daily Routine 1), 学习 (Hobbies 2), 同学 (School), 科学 (School), 小学 (People 3), 学 (Languages 2), 留学 (Future), 数学 (Exam), 大学 (Exam)
 Occupation	生		shēng	shēng	Raw		to be born / to give birth / life / to grow / raw / uncooked / student	Meaning off-topic	学生 (Occupation), 生 (Occupation), 医生 (Occupation), 生病 (Health 2), 生日 (Invitation 2), 生气 (Personality and Feelings), 先生 (Work), 发生 (Emergency), 生意 (Work 3)
-Occupation	吗	嗎	mǎ	mǎ   ma	It	question particle for 'yes-no' questions	see 嗎啡｜吗啡, morphine  (question particle for 'yes-no' questions)		No Matches Found
+Occupation	吗	嗎	mǎ	mǎ   ma	It	question particle for 'yes-no' questions	see 嗎啡｜吗啡, morphine  (question particle for 'yes-no' questions)		
 Occupation	她		tā	tā	she was	she	she		她 (Occupation), 她们 (Occupation)
-Occupation	你们	你們	nǐ men	nǐ men	you guys	you (plural)	you (plural)		No Matches Found
-Occupation	我们	我們	wǒ men	wǒ men	we	we	we / us / ourselves / our		No Matches Found
-Occupation	他们	他們	tā men	tā men	they	they	they		No Matches Found
+Occupation	你们	你們	nǐ men	nǐ men	you guys	you (plural)	you (plural)		
+Occupation	我们	我們	wǒ men	wǒ men	we	we	we / us / ourselves / our		
+Occupation	他们	他們	tā men	tā men	they	they	they		
 Occupation	们	們	men	men	They	plural marker for pronouns	plural marker for pronouns, and nouns referring to individuals		你们 (Occupation), 我们 (Occupation), 他们 (Occupation), 们 (Occupation), 她们 (Occupation)
-Occupation	老师	老師	lǎo shī	lǎo shī	teacher	teacher	teacher / CL: 個｜个, 位		No Matches Found
-Occupation	医生	醫生	yī shēng	yī shēng	Doctors	doctor	doctor / CL: 個｜个, 位, 名		No Matches Found
-Occupation	她们	她們	tā men	tā men	they	they (females)	they / them (for females)		No Matches Found
+Occupation	老师	老師	lǎo shī	lǎo shī	teacher	teacher	teacher / CL: 個｜个, 位		
+Occupation	医生	醫生	yī shēng	yī shēng	Doctors	doctor	doctor / CL: 個｜个, 位, 名		
+Occupation	她们	她們	tā men	tā men	they	they (females)	they / them (for females)		
 Occupation	老		lǎo	lǎo	old		prefix used before the surname of a person or a numeral indicating the order of birth of the children in a family or to indicate affection or familiarity / old (of people) / venerable (person) / experienced / of long standing / always / all the time / of the past / very / outdated / (of meat etc) tough	Meaning off-topic	老师 (Occupation), 老 (Occupation), 老 (People 3), 老板 (Work 2)
 Occupation	师	師	Shī   shī	Shī   shī	division		surname Shi  teacher / master / expert / model / army division / (old) troops / to dispatch troops	Meaning off-topic	老师 (Occupation), 师 (Occupation), 律师 (Business 2)
 Occupation	医	醫	yī	yī	medical		medical / medicine / doctor / to cure / to treat	Meaning off-topic	医生 (Occupation), 医 (Occupation), 医院 (Location 2)
-Contact	的		de	de   dī   dí   dì	of	of	of / ~'s (possessive particle) / (used after an attribute) / (used to form a nominal expression) / (used at the end of a declarative sentence for emphasis)  see 的士  really and truly  aim / clear		No Matches Found
+Contact	的		de	de   dī   dí   dì	of	of	of / ~'s (possessive particle) / (used after an attribute) / (used to form a nominal expression) / (used at the end of a declarative sentence for emphasis)  see 的士  really and truly  aim / clear		
 Contact	电话	電話	diàn huà	diàn huà	phone	telephone	telephone / CL: 部 / phone call / CL: 通 / phone number		电话 (Contact), 电话卡 (Travel 3)
 Contact	电	電	diàn	diàn	Electricity	electricity	electric / electricity / electrical		电话 (Contact), 电 (Contact), 电脑 (Hobbies 1), 电视 (Entertainment), 电影 (Entertainment), 充电 (Travel 3), 电话卡 (Travel 3), 电梯 (House), 电子邮件 (Communication 2)
 Contact	话	話	huà	huà	words	language	dialect / language / spoken words / speech / talk / words / conversation / what sb said / CL: 種｜种, 席, 句, 口, 番		电话 (Contact), 话 (Contact), 说话 (People 2), 话 (People 2), 电话卡 (Travel 3)
-Contact	号码	號碼	hào mǎ	hào mǎ	number	number	number / CL: 堆, 個｜个		No Matches Found
-Contact	多少		duō shǎo	duō shǎo   duō shao	How many	how many	number / amount / somewhat  how much / how many / which (number) / as much as		No Matches Found
+Contact	号码	號碼	hào mǎ	hào mǎ	number	number	number / CL: 堆, 個｜个		
+Contact	多少		duō shǎo	duō shǎo   duō shao	How many	how many	number / amount / somewhat  how much / how many / which (number) / as much as		
 Contact	多		duō	duō	many	many	many / much / often / a lot of / numerous / more / in excess / how (to what extent) / multi- / Taiwan pr. [duo2] when it means 'how'		多少 (Contact), 多 (Contact), 多 (Invitation 2), 多么 (Culture), 多邻国 (Languages 3), 多儿 (Duo)
 Contact	少		shǎo	shǎo   shào	less	few	few / less / to lack / to be missing / to stop (doing sth) / seldom  young		多少 (Contact), 少 (Contact), 少 (Dining 3)
 Contact	号	號	háo   hào	háo   hào	number		roar / cry / CL: 個｜个  ordinal number / day of a month / mark / sign / business establishment / size / ship suffix / horn (wind instrument) / bugle call / assumed name / to take a pulse / classifier used to indicate number of people	Meaning off-topic	号码 (Contact), 号 (Contact), 号 (Time 1), 信号 (Communication 2)
 Contact	码	碼	mǎ	mǎ	code		weight / number / code / to pile / to stack / classifier for length or distance (yard), happenings etc	Meaning off-topic	号码 (Contact), 码 (Contact), 密码 (Communication 2), 码 (Communication 2)
-Nation	中国	中國	Zhōng guó	Zhōng guó	China	China	China		No Matches Found
+Nation	中国	中國	Zhōng guó	Zhōng guó	China	China	China		
 Nation	人		rén	rén	people	person	man / person / people / CL: 個｜个, 位		人 (Nation), 家人 (Family 1), 别人 (People 2), 一个人 (Daily Routine 3), 客人 (House)
 Nation	中		zhōng	Zhōng   zhōng   zhòng	in	middle	China / Chinese / surname Zhong  within / among / in / middle / center / while (doing sth) / during / (dialect) OK / all right  to hit (the mark) / to be hit by / to suffer / to win (a prize, a lottery)		中国 (Nation), 中 (Nation), 中午 (Time 2), 中文 (Hobbies 2), 中间 (Location 5), 初中 (People 3), 高中 (School 2), 中秋节 (Festivals)
 Nation	国	國	guó	Guó   guó	country	country	surname Guo  country / nation / state / national / CL: 個｜个		中国 (Nation), 国 (Nation), 英国 (Nation), 美国 (Nation), 国 (Nation), 韩国 (Entertainment), 德国 (Dining 2), 法国 (Celebration), 国家 (Future), 国际 (Travel 3), 国内 (Travel 3), 多邻国 (Languages 3)
 Nation	哪		nǎ	nǎ   na   něi	where	how / which	how / which  (particle equivalent to 啊 after noun ending in -n)  which? (interrogative, followed by classifier or numeral-classifier)		哪 (Nation), 哪儿 (Location 1), 哪里 (Location 3)
-Nation	英国	英國	Yīng guó	Yīng guó	United Kingdom	United Kingdom	United Kingdom 聯合王國｜联合王国 / United Kingdom of Great Britain and Northern Ireland / abbr. for England 英格蘭｜英格兰		No Matches Found
-Nation	美国	美國	Měi guó	Měi guó	United States	USA	United States / USA / US		No Matches Found
+Nation	英国	英國	Yīng guó	Yīng guó	United Kingdom	United Kingdom	United Kingdom 聯合王國｜联合王国 / United Kingdom of Great Britain and Northern Ireland / abbr. for England 英格蘭｜英格兰		
+Nation	美国	美國	Měi guó	Měi guó	United States	USA	United States / USA / US		
 Nation	英		Yīng   yīng	Yīng   yīng	English	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom	United Kingdom / British / England / English / abbr. for 英國｜英国  hero / outstanding / excellent / (literary) flower / blossom		英国 (Nation), 英 (Nation), 英语 (Phrases 2), 英文 (Restaurant), 英 (Restaurant)
 Nation	美		Měi   měi	Měi   měi	nice	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself	the Americas / abbr. for 美洲 / USA / abbr. for 美國｜美国  beautiful / very satisfactory / good / to beautify / to be pleased with oneself		美国 (Nation), 美 (Nation), 美术 (School), 美图 (Internet Slang), 美眉 (Internet Slang)
-Nation	都		Dū   dōu   dū	Dū   dōu   dū	All	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis		No Matches Found
+Nation	都		Dū   dōu   dū	Dū   dōu   dū	All	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis	surname Du  all / both / entirely / (used for emphasis) even / already / (not) at all  capital city / metropolis		
 Nation	对	對	duì	duì	Correct	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple	right / correct / couple / pair / towards / at / for / to face / opposite / to treat (sb a certain way) / to match together / to adjust / to fit / to suit / to answer / to reply / classifier: couple		对 (Nation), 对不起 (Phrases 1), 派对 (Invitation 2), 对 (Hobbies 3)
-Nation	加拿大		Jiā ná dà	Jiā ná dà	Canada	Canada / Canadian	Canada / Canadian		No Matches Found
+Nation	加拿大		Jiā ná dà	Jiā ná dà	Canada	Canada / Canadian	Canada / Canadian		
 Nation	加		Jiā   jiā	Jiā   jiā	plus	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)	abbr. for Canada 加拿大 / surname Jia  to add / plus / (used after an adverb such as 不, 大, 稍 etc, and before a disyllabic verb, to indicate that the action of the verb is applied to sth or sb previously mentioned) / to apply (restrictions etc) to (sb) / to give (support, consideration etc) to (sth)		加拿大 (Nation), 加 (Nation), 参加 (Sports 2), 加油 (Sports 2), 加 (Internet Slang), 加班 (Work 3)
 Nation	拿		ná	ná	take	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)	to hold / to seize / to catch / to apprehend / to take / (used in the same way as 把: to mark the following noun as a direct object)		加拿大 (Nation), 拿 (Nation), 拿 (Travel 4)
 Nation	大		dà   dài	dà   dài	Big	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫	big / huge / large / major / great / wide / deep / older (than) / oldest / eldest / greatly / very much / (dialect) father / father's elder or younger brother  see 大夫		加拿大 (Nation), 大 (Nation), 大家 (Invitation 2), 意大利 (Shopping 2), 大 (Shopping 2), 澳大利亚 (Time 4), 大概 (Time 4), 大学 (Exam), 大约 (Weather 2)
 Greeting 3	忙		máng	máng	busy	busy / hurriedly / to hurry / to rush	busy / hurriedly / to hurry / to rush		忙 (Greeting 3), 帮忙 (Shopping 1)
-Greeting 3	早上		zǎo shang	zǎo shang	morning	early morning / CL: 個｜个	early morning / CL: 個｜个		No Matches Found
+Greeting 3	早上		zǎo shang	zǎo shang	morning	early morning / CL: 個｜个	early morning / CL: 個｜个		
 Greeting 3	早		zǎo	zǎo	early	early / morning / Good morning! / long ago / prematurely	early / morning / Good morning! / long ago / prematurely		早上 (Greeting 3), 早 (Greeting 3), 早安 (Greeting 4), 早饭 (Daily Routine 1), 早 (Time 3)
 Greeting 3	上		shǎng   shàng	shǎng   shàng	on	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)	see 上聲｜上声  on top / upon / above / upper / previous / first (of multiple parts) / to climb / to get onto / to go up / to attend (class or university)		早上 (Greeting 3), 上 (Greeting 3), 上午 (Time 2), 晚上 (Time 2), 上 (Time 2), 上学 (Daily Routine 1), 上班 (Daily Routine 1), 上网 (Entertainment), 上 (Location 4), 上海 (Dining 1), 上 (Travel), 上 (School), 上面 (Location 5), 马上 (Daily Routine 2), 上 (Environment)
-Greeting 3	怎么样	怎麼樣	zěn me yàng	zěn me yàng	how about it	how? / how about? / how was it? / how are things?	how? / how about? / how was it? / how are things?		No Matches Found
-Greeting 3	今天		jīn tiān	jīn tiān	Nowadays	today / at the present / now	today / at the present / now		No Matches Found
+Greeting 3	怎么样	怎麼樣	zěn me yàng	zěn me yàng	how about it	how? / how about? / how was it? / how are things?	how? / how about? / how was it? / how are things?		
+Greeting 3	今天		jīn tiān	jīn tiān	Nowadays	today / at the present / now	today / at the present / now		
 Greeting 3	怎		zěn	zěn	How	how	how		怎么样 (Greeting 3), 怎 (Greeting 3), 怎么 (Location 3), 怎么办 (Travel)
 Greeting 3	样	樣	yàng	yàng	kind	manner / pattern / way / appearance / shape / classifier: kind, type	manner / pattern / way / appearance / shape / classifier: kind, type		怎么样 (Greeting 3), 样 (Greeting 3), 一样 (Family 3)
 Greeting 3	今		jīn	jīn	now	today / modern / present / current / this / now	today / modern / present / current / this / now		今天 (Greeting 3), 今 (Greeting 3), 今年 (Time 2)
@@ -105,75 +105,75 @@ Location 1	北京		Běi jīng	Běi jīng	Beijing	Beijing, capital of People's Re
 Location 1	在		zài	zài	in	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)	(located) at / (to be) in / to exist / in the middle of doing sth / (indicating an action in progress)		在 (Location 1), 现在 (Time 1), 在 (Hobbies 1), 正在 (Invitation 2), 好在 (Sports 2)
 Location 1	北		běi	běi	north	north / to be defeated (classical)	north / to be defeated (classical)		北京 (Location 1), 北 (Location 1), 北方 (Food 3), 北边 (Location 6), 北京烤鸭 (Gourmet 2)
 Location 1	京		Jīng   jīng	Jīng   jīng	Beijing	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)	abbr. for Beijing / surname Jing / Jing ethnic minority  capital city of a country / big / algebraic term for a large number (old) / artificial mound (old)		北京 (Location 1), 京 (Location 1), 北京烤鸭 (Gourmet 2)
-Location 1	哪儿	哪兒	nǎr	nǎr	where	where? / wherever / anywhere	where? / wherever / anywhere		No Matches Found
-Location 1	纽约	紐約	Niǔ yuē	Niǔ yuē	new York	New York	New York		No Matches Found
-Location 1	香港		Xiāng gǎng	Xiāng gǎng	Hong Kong	Hong Kong	Hong Kong		No Matches Found
+Location 1	哪儿	哪兒	nǎr	nǎr	where	where? / wherever / anywhere	where? / wherever / anywhere		
+Location 1	纽约	紐約	Niǔ yuē	Niǔ yuē	new York	New York	New York		
+Location 1	香港		Xiāng gǎng	Xiāng gǎng	Hong Kong	Hong Kong	Hong Kong		
 Location 1	儿	兒	ér   r	ér   r	child	child / son  non-syllabic diminutive suffix / retroflex final	child / son  non-syllabic diminutive suffix / retroflex final		哪儿 (Location 1), 儿 (Location 1), 一会儿 (Greeting 4), 这儿 (Location 2), 那儿 (Location 2), 女儿 (Family 2), 儿子 (Family 2), 儿 (Family 2), 一点儿 (Telephone), 有点儿 (Health 1), 一点儿 (Languages), 多儿 (Duo)
 Location 1	纽	紐	niǔ	niǔ	Button	to turn / to wrench / button / nu (Greek letter Νν)	to turn / to wrench / button / nu (Greek letter Νν)		纽约 (Location 1), 纽 (Location 1)
 Location 1	约	約	yāo   yuē	yāo   yuē	approximately	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise	to weigh in a balance or on a scale  to make an appointment / to invite / approximately / pact / treaty / to economize / to restrict / to reduce (a fraction) / concise		纽约 (Location 1), 约 (Location 1), 约会 (Invitiation 1), 大约 (Weather 2)
 Location 1	香		xiāng	xiāng	Fragrant	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根	fragrant / sweet smelling / aromatic / savory or appetizing / (to eat) with relish / (of sleep) sound / perfume or spice / joss or incense stick / CL: 根		香港 (Location 1), 香 (Location 1), 香蕉 (Dining 2), 香 (Dining 2)
 Location 1	港		Gǎng   gǎng	Gǎng   gǎng	port	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个	Hong Kong, abbr. for 香港 / surname Gang  harbor / port / CL: 個｜个		香港 (Location 1), 港 (Location 1)
-Location 1	住		zhù	zhù	live	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)		No Matches Found
-Location 1	伦敦	倫敦	Lún dūn	Lún dūn	London	London, capital of United Kingdom	London, capital of United Kingdom		No Matches Found
-Location 1	台湾	臺灣	Tái wān	Tái wān	Taiwan	Taiwan	Taiwan		No Matches Found
+Location 1	住		zhù	zhù	live	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)	to live / to dwell / to stay / to reside / to stop / (suffix indicating firmness, steadiness, or coming to a halt)		
+Location 1	伦敦	倫敦	Lún dūn	Lún dūn	London	London, capital of United Kingdom	London, capital of United Kingdom		
+Location 1	台湾	臺灣	Tái wān	Tái wān	Taiwan	Taiwan	Taiwan		
 Location 1	伦	倫	lún	lún	Lun	human relationship / order / coherence	human relationship / order / coherence		伦敦 (Location 1), 伦 (Location 1)
 Location 1	敦		dūn	dūn	London	kindhearted / place name	kindhearted / place name		伦敦 (Location 1), 敦 (Location 1)
 Location 1	台		Tái   tái   tái   Tái   tái   tái	Tái   tái   tái   Tái   tái   tái	station	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon	Taiwan (abbr.) / surname Tai  (classical) you (in letters) / variant of 臺｜台  desk / table / counter  Taiwan (abbr.)  platform / stage / terrace / stand / support / station / broadcasting station / classifier for vehicles or machines  typhoon		台湾 (Location 1), 台 (Location 1), 柜台 (Travel 3)
 Location 1	湾	灣	wān	wān	Bay	bay / gulf / to cast anchor / to moor (a boat)	bay / gulf / to cast anchor / to moor (a boat)		台湾 (Location 1), 湾 (Location 1)
-Phrases 1	谢谢	謝謝	xiè xie	xiè xie	Thank you	to thank / thanks / thank you	to thank / thanks / thank you		No Matches Found
-Phrases 1	不客气	不客氣	bù kè qi	bù kè qi	You're welcome	you're welcome / don't mention it / impolite / rude / blunt	you're welcome / don't mention it / impolite / rude / blunt		No Matches Found
+Phrases 1	谢谢	謝謝	xiè xie	xiè xie	Thank you	to thank / thanks / thank you	to thank / thanks / thank you		
+Phrases 1	不客气	不客氣	bù kè qi	bù kè qi	You're welcome	you're welcome / don't mention it / impolite / rude / blunt	you're welcome / don't mention it / impolite / rude / blunt		
 Phrases 1	谢	謝	Xiè   xiè	Xiè   xiè	thank	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline	surname Xie  to thank / to apologize / to wither (of flowers, leaves etc) / to decline		谢谢 (Phrases 1), 谢 (Phrases 1), 感谢 (Business 2)
 Phrases 1	客		kè	kè	customer	customer / visitor / guest	customer / visitor / guest		不客气 (Phrases 1), 客 (Phrases 1), 客厅 (House), 客人 (House)
 Phrases 1	气	氣	qì	qì	gas	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi	gas / air / smell / weather / to make angry / to annoy / to get angry / vital energy / qi		不客气 (Phrases 1), 气 (Phrases 1), 天气 (Weather), 生气 (Personality and Feelings)
-Phrases 1	对不起	對不起	duì bu qǐ	duì bu qǐ	I am sorry	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)		No Matches Found
-Phrases 1	没关系	沒關係	méi guān xi	méi guān xi	It's ok	it doesn't matter	it doesn't matter		No Matches Found
+Phrases 1	对不起	對不起	duì bu qǐ	duì bu qǐ	I am sorry	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)	unworthy / to let down / I'm sorry / excuse me / pardon me / if you please / sorry? (please repeat)		
+Phrases 1	没关系	沒關係	méi guān xi	méi guān xi	It's ok	it doesn't matter	it doesn't matter		
 Phrases 1	起		qǐ	qǐ	Start	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group	to rise / to raise / to get up / to set out / to start / to appear / to launch / to initiate (action) / to draft / to establish / to get (from a depot or counter) / verb suffix, to start / starting from (a time, place, price etc) / classifier for occurrences or unpredictable events: case, instance / classifier for groups: batch, group		对不起 (Phrases 1), 起 (Phrases 1), 起床 (Daily Routine 1), 起 (Daily Routine 1), 一起 (Invitiation 1), 起飞 (Travel 2), 看起来 (Personality and Feelings)
 Phrases 1	没	沒	méi   mò	méi   mò	No	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate	(negative prefix for verbs) / have not / not  drowned / to end / to die / to inundate		没关系 (Phrases 1), 没 (Phrases 1), 没 (Family 1)
 Phrases 1	关	關	Guān   guān	Guān   guān	turn off	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve	surname Guan  mountain pass / to close / to shut / to turn off / to concern / to involve		没关系 (Phrases 1), 关 (Phrases 1), 关 (Shopping 1), 关系 (Family 3), 海关 (Travel 2), 关心 (Personality and Feelings), 关于 (Communication 2), 关注 (Internet Slang)
 Phrases 1	系	係	xì   xì   jì   xì	xì   xì   jì   xì	system	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry	to connect / to relate to / to tie up / to bind / to be (literary)  system / department / faculty  to tie / to fasten / to button up  to connect / to arrest / to worry		没关系 (Phrases 1), 系 (Phrases 1), 关系 (Family 3), 联系 (Business 2)
-Family 1	爸爸		bà ba	bà ba	father	(informal) father / CL: 個｜个, 位	(informal) father / CL: 個｜个, 位		No Matches Found
-Family 1	妈妈	媽媽	mā ma	mā ma	mom	mama / mommy / mother / CL: 個｜个, 位	mama / mommy / mother / CL: 個｜个, 位		No Matches Found
+Family 1	爸爸		bà ba	bà ba	father	(informal) father / CL: 個｜个, 位	(informal) father / CL: 個｜个, 位		
+Family 1	妈妈	媽媽	mā ma	mā ma	mom	mama / mommy / mother / CL: 個｜个, 位	mama / mommy / mother / CL: 個｜个, 位		
 Family 1	爱	愛	ài	ài	Love	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)	to love / to be fond of / to like / affection / to be inclined (to do sth) / to tend to (happen)		爱 (Family 1), 可爱 (People 1), 爱好 (Hobbies 2)
-Family 1	家人		jiā rén	jiā rén	family	household / (one's) family	household / (one's) family		No Matches Found
+Family 1	家人		jiā rén	jiā rén	family	household / (one's) family	household / (one's) family		
 Family 1	爸		bà	bà	dad	father / dad / pa / papa	father / dad / pa / papa		爸爸 (Family 1), 爸 (Family 1)
 Family 1	妈	媽	mā	mā	mom	ma / mom / mother	ma / mom / mother		妈妈 (Family 1), 妈 (Family 1)
-Family 1	谁	誰	shéi	shéi	Who	who / also pr. [shui2]	who / also pr. [shui2]		No Matches Found
+Family 1	谁	誰	shéi	shéi	Who	who / also pr. [shui2]	who / also pr. [shui2]		
 Family 1	那		Nā   Nuó   nà   nuó	Nā   Nuó   nà   nuó	that	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪	surname Na  surname Nuo  that / those / then (in that case) / commonly pr. [nei4] before a classifier, esp. in Beijing  (archaic) many / beautiful / how / old variant of 挪		那 (Family 1), 那儿 (Location 2), 那里 (Location 3)
 Family 1	个	個	gè	gè	More	individual / this / that / size / classifier for people or objects in general	individual / this / that / size / classifier for people or objects in general		个 (Family 1), 个子 (People 3), 一个人 (Daily Routine 3)
 Family 1	这	這	zhè	zhè	This	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)	this / these / (commonly pr. [zhei4] before a classifier, esp. in Beijing)		这 (Family 1), 这儿 (Location 2), 这里 (Location 3)
-Family 1	哥哥		gē ge	gē ge	brother	older brother / CL: 個｜个, 位	older brother / CL: 個｜个, 位		No Matches Found
-Family 1	姐姐		jiě jie	jiě jie	sister	older sister / CL: 個｜个	older sister / CL: 個｜个		No Matches Found
+Family 1	哥哥		gē ge	gē ge	brother	older brother / CL: 個｜个, 位	older brother / CL: 個｜个, 位		
+Family 1	姐姐		jiě jie	jiě jie	sister	older sister / CL: 個｜个	older sister / CL: 個｜个		
 Family 1	有		yǒu	yǒu	Have	to have / there is / there are / to exist / to be	to have / there is / there are / to exist / to be		有 (Family 1), 有点儿 (Health 1), 有名 (Culture)
 Family 1	哥		gē	gē	brother	elder brother	elder brother		哥哥 (Family 1), 哥 (Family 1)
 Family 1	姐		jiě	jiě	sister	older sister	older sister		姐姐 (Family 1), 姐 (Family 1), 兄弟姐妹 (Family 3), 小姐 (Work)
-Family 1	弟弟		dì di	dì di	Little brother	younger brother / CL: 個｜个, 位	younger brother / CL: 個｜个, 位		No Matches Found
+Family 1	弟弟		dì di	dì di	Little brother	younger brother / CL: 個｜个, 位	younger brother / CL: 個｜个, 位		
 Family 1	和		Hé   hé   hè   hú   huó   huò	Hé   hé   hè   hú   huó   huò	with	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs	surname He / Japanese (food, clothes etc)  and / together with / with / sum / union / peace / harmony / Taiwan pr. [han4] when it means 'and' or 'with'  to compose a poem in reply (to sb's poem) using the same rhyme sequence / to join in the singing / to chime in with others  to complete a set in mahjong or playing cards  to combine a powdery substance (flour, plaster etc) with water / Taiwan pr. [huo4]  to mix (ingredients) together / to blend / classifier for rinses of clothes / classifier for boilings of medicinal herbs		和 (Family 1), 暖和 (Weather 2), 和 (Weather 2)
-Family 1	妹妹		mèi mei	mèi mei	younger sister	younger sister / young woman / CL: 個｜个	younger sister / young woman / CL: 個｜个		No Matches Found
+Family 1	妹妹		mèi mei	mèi mei	younger sister	younger sister / young woman / CL: 個｜个	younger sister / young woman / CL: 個｜个		
 Family 1	弟		dì	dì	Younger brother	younger brother / junior male / I (modest word in letter)	younger brother / junior male / I (modest word in letter)		弟弟 (Family 1), 弟 (Family 1), 兄弟姐妹 (Family 3)
 Family 1	妹		mèi	mèi	sister	younger sister	younger sister		妹妹 (Family 1), 妹 (Family 1), 兄弟姐妹 (Family 3)
-Phrases 2	请问	請問	qǐng wèn	qǐng wèn	Excuse me	Excuse me, may I ask...?	Excuse me, may I ask...?		No Matches Found
-Phrases 2	知道		zhī dào	zhī dào	know	to know / to become aware of / also pr. [zhi1 dao5]	to know / to become aware of / also pr. [zhi1 dao5]		No Matches Found
+Phrases 2	请问	請問	qǐng wèn	qǐng wèn	Excuse me	Excuse me, may I ask...?	Excuse me, may I ask...?		
+Phrases 2	知道		zhī dào	zhī dào	know	to know / to become aware of / also pr. [zhi1 dao5]	to know / to become aware of / also pr. [zhi1 dao5]		
 Phrases 2	问	問	wèn	wèn	ask	to ask	to ask		请问 (Phrases 2), 问 (Phrases 2), 问题 (School)
 Phrases 2	请	請	qǐng	qǐng	please	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request	to ask / to invite / please (do sth) / to treat (to a meal etc) / to request		请问 (Phrases 2), 请 (Phrases 2), 请 (Phrases 2), 请 (Invitiation 1), 请假 (Health 2), 请 (Dining 3)
 Phrases 2	知		zhī	zhī	know	to know / to be aware	to know / to be aware		知道 (Phrases 2), 知 (Phrases 2)
 Phrases 2	道		dào	dào	Road	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)	road / path / CL: 條｜条, 股 / principle / truth / morality / reason / skill / method / Dao (of Daoism) / to say / to speak / to talk / classifier for long thin things (rivers, cracks etc), barriers (walls, doors etc), questions (in an exam etc), commands, courses in a meal, steps in a process / (old) administrative division (similar to province in Tang times)		知道 (Phrases 2), 道 (Phrases 2), 味道 (Dining 3), 街道 (Travel 4)
 Phrases 2	说	說	shuì   shuō	shuì   shuō	Say	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)	to persuade  to speak / to say / to explain / to scold / to tell off / a theory (typically the last character in a compound, as in 日心說｜日心说 heliocentric theory)		说 (Phrases 2), 说话 (People 2)
-Phrases 2	英语	英語	Yīng yǔ	Yīng yǔ	English	English (language)	English (language)		No Matches Found
-Phrases 2	汉语	漢語	Hàn yǔ	Hàn yǔ	Chinese	Chinese language / CL: 門｜门	Chinese language / CL: 門｜门		No Matches Found
+Phrases 2	英语	英語	Yīng yǔ	Yīng yǔ	English	English (language)	English (language)		
+Phrases 2	汉语	漢語	Hàn yǔ	Hàn yǔ	Chinese	Chinese language / CL: 門｜门	Chinese language / CL: 門｜门		
 Phrases 2	汉	漢	Hàn   hàn	Hàn   hàn	Chinese	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man	Han ethnic group / Chinese (language) / the Han dynasty (206 BC-220 AD)  man		汉语 (Phrases 2), 汉 (Phrases 2), 汉字 (Languages 2)
 Phrases 2	语	語	yǔ   yù	yǔ   yù	language	dialect / language / speech  to tell to	dialect / language / speech  to tell to		英语 (Phrases 2), 汉语 (Phrases 2), 语 (Phrases 2), 西班牙语 (Hobbies 2), 语言 (Languages 2), 语法 (Languages 3)
-Phrases 2	帮助	幫助	bāng zhù	bāng zhù	help	assistance / aid / to help / to assist	assistance / aid / to help / to assist		No Matches Found
-Phrases 2	次		cì	cì	Secondary	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time		No Matches Found
+Phrases 2	帮助	幫助	bāng zhù	bāng zhù	help	assistance / aid / to help / to assist	assistance / aid / to help / to assist		
+Phrases 2	次		cì	cì	Secondary	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time	next in sequence / second / the second (day, time etc) / secondary / vice- / sub- / infra- / inferior quality / substandard / order / sequence / hypo- (chemistry) / classifier for enumerated events: time		
 Phrases 2	帮	幫	bāng	bāng	help	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society	to help / to assist / to support / for sb (i.e. as a help) / hired (as worker) / side (of pail, boat etc) / outer layer / upper (of a shoe) / group / gang / clique / party / secret society		帮助 (Phrases 2), 帮 (Phrases 2), 帮 (Supermarket), 帮忙 (Shopping 1)
 Phrases 2	助		zhù	zhù	help	to help / to assist	to help / to assist		帮助 (Phrases 2), 助 (Phrases 2)
-Greeting 4	早安		zǎo ān	zǎo ān	good Morning	Good morning!	Good morning!		No Matches Found
-Greeting 4	晚安		wǎn ān	wǎn ān	good night	Good night! / Good evening!	Good night! / Good evening!		No Matches Found
-Greeting 4	一会儿	一會兒	yī huìr	yī huìr	Awhile	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]		No Matches Found
+Greeting 4	早安		zǎo ān	zǎo ān	good Morning	Good morning!	Good morning!		
+Greeting 4	晚安		wǎn ān	wǎn ān	good night	Good night! / Good evening!	Good night! / Good evening!		
+Greeting 4	一会儿	一會兒	yī huìr	yī huìr	Awhile	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]	a moment / a while / in a moment / now...now... / also pr. [yi1 hui3 r5]		
 Greeting 4	会	會	huì   kuài	huì   kuài	meeting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting	can / to be possible / to be able to / will / to be likely to / to be sure to / to assemble / to meet / to gather / to see / union / group / association / CL: 個｜个 / a moment (Taiwan pr. for this sense is [hui3])  to balance an account / accountancy / accounting		一会儿 (Greeting 4), 会 (Greeting 4), 会 (Time 2), 会 (Hobbies 1), 约会 (Invitiation 1), 机会 (Future), 会议 (Work), 开会 (Work 2), 聚会 (Festivals), 误会 (Work 3)
 Greeting 4	安		Ān   ān	Ān   ān	Secure	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere	surname An  content / calm / still / quiet / safe / secure / in good health / to find a place for / to install / to fix / to fit / to bring (a charge against sb) / to pacify / to harbor (good intentions) / security / safety / peace / ampere		早安 (Greeting 4), 晚安 (Greeting 4), 安 (Greeting 4), 安全 (Travel 2), 安静 (Environment), 西安 (Culture), 安排 (Travel 4)
-Greeting 4	最近		zuì jìn	zuì jìn	Recently	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)		No Matches Found
-Greeting 4	好久不见	好久不見	hǎo jiǔ bu jiàn	hǎo jiǔ bu jiàn	long time no see	long time no see	long time no see		No Matches Found
-Greeting 4	不错	不錯	bù cuò	bù cuò	Pretty good	correct / right / not bad / pretty good	correct / right / not bad / pretty good		No Matches Found
+Greeting 4	最近		zuì jìn	zuì jìn	Recently	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)	recent / recently / these days / latest / soon / nearest (of locations) / shortest (of routes)		
+Greeting 4	好久不见	好久不見	hǎo jiǔ bu jiàn	hǎo jiǔ bu jiàn	long time no see	long time no see	long time no see		
+Greeting 4	不错	不錯	bù cuò	bù cuò	Pretty good	correct / right / not bad / pretty good	correct / right / not bad / pretty good		
 Greeting 4	最		zuì	zuì	most	most / the most / -est (superlative suffix)	most / the most / -est (superlative suffix)		最近 (Greeting 4), 最 (Greeting 4), 最 (Hobbies 1), 最后 (Location 6)
 Greeting 4	近		jìn	jìn	near	near / close to / approximately	near / close to / approximately		最近 (Greeting 4), 近 (Greeting 4), 近 (Travel), 附近 (Location 5)
 Greeting 4	久		jiǔ	jiǔ	Long	(long) time / (long) duration of time	(long) time / (long) duration of time		好久不见 (Greeting 4), 久 (Greeting 4), 久 (Languages 2)
@@ -181,101 +181,101 @@ Greeting 4	错	錯	Cuò   cuò	Cuò   cuò	wrong	surname Cuo  mistake / wrong / 
 Drink	要		yāo   yào	yāo   yào	To	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if	to demand / to request / to coerce  important / vital / to want / to ask for / will / going to (as future auxiliary) / may / must / (used in a comparison) must be / probably / if		要 (Drink), 不要 (Health 1), 需要 (Shopping 1), 要求 (School 2), 重要 (Work), 主要 (Communication 2)
 Drink	热	熱	rè	rè	heat	to warm up / to heat up / hot (of weather) / heat / fervent	to warm up / to heat up / hot (of weather) / heat / fervent		热 (Drink), 热情 (Personality and Feelings)
 Drink	冰		bīng	bīng	ice	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine	ice / CL: 塊｜块 / to chill sth / (of an object or substance) to feel cold / (of a person) cold / unfriendly / (slang) methamphetamine		冰 (Drink), 冰箱 (Location 4)
-Drink	牛奶		niú nǎi	niú nǎi	milk	cow's milk / CL: 瓶, 杯	cow's milk / CL: 瓶, 杯		No Matches Found
+Drink	牛奶		niú nǎi	niú nǎi	milk	cow's milk / CL: 瓶, 杯	cow's milk / CL: 瓶, 杯		
 Drink	咖啡		kā fēi	kā fēi	coffee	coffee (loanword) / CL: 杯	coffee (loanword) / CL: 杯		咖啡 (Drink), 咖啡馆 (Location 5)
 Drink	牛		Niú   niú	Niú   niú	Cattle	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome	surname Niu  ox / cow / bull / CL: 條｜条, 頭｜头 / (slang) awesome		牛奶 (Drink), 牛 (Drink), 牛肉 (Dining 1)
 Drink	奶		nǎi   nǎi	nǎi   nǎi	milk	breast / milk / to breastfeed  mother / variant of 奶	breast / milk / to breastfeed  mother / variant of 奶		牛奶 (Drink), 奶 (Drink), 奶奶 (Family 3), 珍珠奶茶 (Gourmet 2)
 Drink	咖		kā	kā	coffee	coffee / class / grade	coffee / class / grade		咖啡 (Drink), 咖 (Drink), 咖啡馆 (Location 5)
 Drink	啡		fēi	fēi	coffee	(phonetic component)	(phonetic component)		咖啡 (Drink), 啡 (Drink), 咖啡馆 (Location 5)
-Location 2	洗手间	洗手間	xǐ shǒu jiān	xǐ shǒu jiān	Toilets	toilet / lavatory / washroom	toilet / lavatory / washroom		No Matches Found
-Location 2	医院	醫院	yī yuàn	yī yuàn	hospital	hospital / CL: 所, 家, 座	hospital / CL: 所, 家, 座		No Matches Found
+Location 2	洗手间	洗手間	xǐ shǒu jiān	xǐ shǒu jiān	Toilets	toilet / lavatory / washroom	toilet / lavatory / washroom		
+Location 2	医院	醫院	yī yuàn	yī yuàn	hospital	hospital / CL: 所, 家, 座	hospital / CL: 所, 家, 座		
 Location 2	洗		xǐ	xǐ	wash	to wash / to bathe / to develop (photo)	to wash / to bathe / to develop (photo)		洗手间 (Location 2), 洗 (Location 2), 洗 (Shopping 3), 洗澡 (Daily Routine 2)
 Location 2	手		shǒu	shǒu	hand	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只	hand / (formal) to hold / person engaged in certain types of work / person skilled in certain types of work / personal(ly) / convenient / classifier for skill / CL: 雙｜双, 隻｜只		洗手间 (Location 2), 手 (Location 2), 手机 (Entertainment), 手 (Body Parts), 手表 (Shopping 3), 分手 (Future)
 Location 2	间	間	jiān   jiàn	jiān   jiàn	between	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent	between / among / within a definite time or space / room / section of a room or lateral space between two pairs of pillars / classifier for rooms  gap / to separate / to thin out (seedlings) / to sow discontent		洗手间 (Location 2), 间 (Location 2), 房间 (Location 4), 间 (Location 4), 时间 (Invitiation 1), 中间 (Location 5)
 Location 2	院		yuàn	yuàn	hospital	courtyard / institution / CL: 個｜个	courtyard / institution / CL: 個｜个		医院 (Location 2), 院 (Location 2)
-Location 2	这儿	這兒	zhèr	zhèr	here	here	here		No Matches Found
-Location 2	那儿	那兒	nàr	nàr	there	there	there		No Matches Found
-Location 2	饭馆	飯館	fàn guǎn	fàn guǎn	restaurant	restaurant / CL: 家	restaurant / CL: 家		No Matches Found
+Location 2	这儿	這兒	zhèr	zhèr	here	here	here		
+Location 2	那儿	那兒	nàr	nàr	there	there	there		
+Location 2	饭馆	飯館	fàn guǎn	fàn guǎn	restaurant	restaurant / CL: 家	restaurant / CL: 家		
 Location 2	馆	館	guǎn	guǎn	House	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家	building / shop / term for certain service establishments / embassy or consulate / schoolroom (old) / CL: 家		饭馆 (Location 2), 馆 (Location 2), 馆 (Location 5), 图书馆 (Location 5), 咖啡馆 (Location 5), 体育馆 (School 2), 博物馆 (Travel 4)
 Time 1	年		Nián   nián   nián	Nián   nián   nián	year	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年	surname Nian  year / CL: 個｜个  grain / harvest (old) / variant of 年		年 (Time 1), 今年 (Time 2), 去年 (Time 2), 明年 (Time 2), 新年 (Celebration), 年级 (People 3), 年轻 (People 3)
 Time 1	月		yuè	yuè	month	moon / month / monthly / CL: 個｜个, 輪｜轮	moon / month / monthly / CL: 個｜个, 輪｜轮		月 (Time 1), 月亮 (Festivals), 月饼 (Festivals)
 Time 1	几		jī   jī   jǐ	jī   jī   jǐ	a few	small table  almost  how much / how many / several / a few	small table  almost  how much / how many / several / a few		几 (Time 1), 几乎 (Travel 2), 几 (Travel 2)
-Time 1	〇		líng	líng	〇	zero	zero		No Matches Found
-Time 1	星期		xīng qī	xīng qī	week	week / CL: 個｜个 / day of the week / Sunday	week / CL: 個｜个 / day of the week / Sunday		No Matches Found
-Time 1	明天		míng tiān	míng tiān	tomorrow	tomorrow	tomorrow		No Matches Found
+Time 1	〇		líng	líng	〇	zero	zero		
+Time 1	星期		xīng qī	xīng qī	week	week / CL: 個｜个 / day of the week / Sunday	week / CL: 個｜个 / day of the week / Sunday		
+Time 1	明天		míng tiān	míng tiān	tomorrow	tomorrow	tomorrow		
 Time 1	日		Rì   rì	Rì   rì	day	abbr. for 日本, Japan  sun / day / date, day of the month	abbr. for 日本, Japan  sun / day / date, day of the month		日 (Time 1), 日本 (Dining 1), 生日 (Invitation 2), 节日 (Celebration)
 Time 1	星		xīng	xīng	star	star / heavenly body / satellite / small amount	star / heavenly body / satellite / small amount		星期 (Time 1), 星 (Time 1), 明星 (Entertainment), 星星 (Environment)
 Time 1	期		qī	qī	period	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]	a period of time / phase / stage / classifier for issues of a periodical, courses of study / time / term / period / to hope / Taiwan pr. [qi2]		星期 (Time 1), 期 (Time 1)
 Time 1	点	點	diǎn	diǎn	point	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items	point / dot / drop / speck / o'clock / point (in space or time) / to draw a dot / to check on a list / to choose / to order (food in a restaurant) / to touch briefly / to hint / to light / to ignite / to pour a liquid drop by drop / (old) one fifth of a two-hour watch 更 / dot stroke in Chinese characters / classifier for items		点 (Time 1), 一点儿 (Telephone), 点菜 (Restaurant), 有点儿 (Health 1), 一点儿 (Languages), 甜点 (Dining 3), 点心 (Gourmet 1), 点 (Internet Slang)
-Time 1	现在	現在	xiàn zài	xiàn zài	just now	now / at present / at the moment / modern / current / nowadays	now / at present / at the moment / modern / current / nowadays		No Matches Found
-Time 1	半		bàn	bàn	half	half / semi- / incomplete / (after a number) and a half	half / semi- / incomplete / (after a number) and a half		No Matches Found
+Time 1	现在	現在	xiàn zài	xiàn zài	just now	now / at present / at the moment / modern / current / nowadays	now / at present / at the moment / modern / current / nowadays		
+Time 1	半		bàn	bàn	half	half / semi- / incomplete / (after a number) and a half	half / semi- / incomplete / (after a number) and a half		
 Time 1	现	現	xiàn	xiàn	Present	to appear / present / now / existing / current	to appear / present / now / existing / current		现在 (Time 1), 现 (Time 1), 现金 (Payment), 发现 (Travel 2), 表现 (Work 2)
-Family 2	孩子		hái zi	hái zi	child	child	child		No Matches Found
-Family 2	两	兩	liǎng	liǎng	Two	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)		No Matches Found
+Family 2	孩子		hái zi	hái zi	child	child	child		
+Family 2	两	兩	liǎng	liǎng	Two	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)	two / both / some / a few / tael, unit of weight equal to 50 grams (modern) or 1⁄16 of a catty 斤 (old)		
 Family 2	孩		hái	hái	child	child	child		孩子 (Family 2), 孩 (Family 2)
 Family 2	子		zǐ   zi	zǐ   zi	child	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)	son / child / seed / egg / small thing / 1st earthly branch: 11 p.m.-1 a.m., midnight, 11th solar month (7th December to 5th January), year of the Rat / Viscount, fourth of five orders of nobility 五等爵位 / ancient Chinese compass point: 0° (north)  (noun suffix)		孩子 (Family 2), 子 (Family 2), 儿子 (Family 2), 妻子 (Family 2), 桌子 (Location 4), 椅子 (Location 4), 杯子 (Dining 2), 盘子 (Dining 2), 筷子 (Dining 2), 勺子 (Dining 2), 瓶子 (Existence), 肚子 (Health 2), 裙子 (Shopping 2), 鞋子 (Shopping 2), 裤子 (Shopping 2), 鼻子 (Body Parts), 帽子 (Shopping 3), 包子 (Gourmet 1), 袋子 (Shopping 4), 饺子 (Food 3), 个子 (People 3), 句子 (Languages 3), 电子邮件 (Communication 2), 粽子 (Festivals)
-Family 2	女儿	女兒	nǚ ér	nǚ ér	daughter	daughter	daughter		No Matches Found
-Family 2	儿子	兒子	ér zi	ér zi	son	son	son		No Matches Found
-Family 2	岁	歲	suì	suì	year old	classifier for years (of age) / year / year (of crop harvests)	classifier for years (of age) / year / year (of crop harvests)		No Matches Found
+Family 2	女儿	女兒	nǚ ér	nǚ ér	daughter	daughter	daughter		
+Family 2	儿子	兒子	ér zi	ér zi	son	son	son		
+Family 2	岁	歲	suì	suì	year old	classifier for years (of age) / year / year (of crop harvests)	classifier for years (of age) / year / year (of crop harvests)		
 Family 2	女		nǚ	nǚ	Female	female / woman / daughter	female / woman / daughter		女儿 (Family 2), 女 (Family 2), 女 (People 1)
-Family 2	妻子		qī zǐ   qī zi	qī zǐ   qī zi	wife	wife and children  wife / CL: 個｜个	wife and children  wife / CL: 個｜个		No Matches Found
-Family 2	丈夫		zhàng fu	zhàng fu	husband	husband / CL: 個｜个	husband / CL: 個｜个		No Matches Found
+Family 2	妻子		qī zǐ   qī zi	qī zǐ   qī zi	wife	wife and children  wife / CL: 個｜个	wife and children  wife / CL: 個｜个		
+Family 2	丈夫		zhàng fu	zhàng fu	husband	husband / CL: 個｜个	husband / CL: 個｜个		
 Family 2	妻		qī   qì	qī   qì	wife	wife  to marry off (a daughter)	wife  to marry off (a daughter)		妻子 (Family 2), 妻 (Family 2)
 Family 2	丈		zhàng	zhàng	length	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male	measure of length, ten Chinese feet (3.3 m) / to measure / husband / polite appellation for an older male		丈夫 (Family 2), 丈 (Family 2)
 Family 2	夫		fū   fú	fū   fú	husband	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)	husband / man / manual worker / conscripted laborer (old)  (classical) this, that / he, she, they / (exclamatory final particle) / (initial particle, introduces an opinion)		丈夫 (Family 2), 夫 (Family 2), 功夫 (Hobbies 3)
 Family 2	猫	貓	māo	māo	Cat	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem	cat / CL: 隻｜只 / (dialect) to hide oneself / (coll.) modem		猫 (Family 2), 熊猫 (Culture), 猫头鹰 (Duo)
-Family 2	它		tā	tā	it	it	it		No Matches Found
-Family 2	狗		gǒu	gǒu	dog	dog / CL: 隻｜只, 條｜条	dog / CL: 隻｜只, 條｜条		No Matches Found
-Telephone	喂		wéi   wèi   wèi	wéi   wèi   wèi	Hey	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed		No Matches Found
-Telephone	慢		màn	màn	slow	slow	slow		No Matches Found
+Family 2	它		tā	tā	it	it	it		
+Family 2	狗		gǒu	gǒu	dog	dog / CL: 隻｜只, 條｜条	dog / CL: 隻｜只, 條｜条		
+Telephone	喂		wéi   wèi   wèi	wéi   wèi   wèi	Hey	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed	hello (when answering the phone)  hey / to feed (an animal, baby, invalid etc)  to feed		
+Telephone	慢		màn	màn	slow	slow	slow		
 Telephone	一点儿		yī diǎnr	yī diǎnr	a little	erhua variant of 一點｜一点	erhua variant of 一點｜一点		一点儿 (Telephone), 一点儿 (Languages)
 Telephone	快		kuài	kuài	fast	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant	rapid / quick / speed / rate / soon / almost / to make haste / clever / sharp (of knives or wits) / forthright / plainspoken / gratified / pleased / pleasant		快 (Telephone), 快乐 (Celebration), 尽快 (Business 1), 愉快 (Business 2), 凉快 (Weather 2)
 Telephone	得		dé   de   děi	dé   de   děi	Get	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to	to obtain / to get / to gain / to catch (a disease) / proper / suitable / proud / contented / to allow / to permit / ready / finished  structural particle: used after a verb (or adjective as main verb), linking it to following phrase indicating effect, degree, possibility etc  to have to / must / ought to / to need to		得 (Telephone), 得 (Health 1), 觉得 (Health 1), 得 (Travel), 记得 (Exam)
-Telephone	明白		míng bai	míng bai	understand	clear / obvious / unequivocal / to understand / to realize	clear / obvious / unequivocal / to understand / to realize		No Matches Found
+Telephone	明白		míng bai	míng bai	understand	clear / obvious / unequivocal / to understand / to realize	clear / obvious / unequivocal / to understand / to realize		
 Telephone	白		Bái   bái	Bái   bái	White	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera	surname Bai  white / snowy / pure / bright / empty / blank / plain / clear / to make clear / in vain / gratuitous / free of charge / reactionary / anti-communist / funeral / to stare coldly / to write wrong character / to state / to explain / vernacular / spoken lines in opera		明白 (Telephone), 白 (Telephone), 白 (Shopping 3), 白酒 (Celebration)
-People 1	漂亮		piào liang	piào liang	Pretty	pretty / beautiful	pretty / beautiful		No Matches Found
+People 1	漂亮		piào liang	piào liang	Pretty	pretty / beautiful	pretty / beautiful		
 People 1	漂		piāo   piǎo   piào	piāo   piǎo   piào	drift	to float / to drift  to bleach  elegant / polished	to float / to drift  to bleach  elegant / polished		漂亮 (People 1), 漂 (People 1)
 People 1	亮		liàng	liàng	bright	bright / clear / resonant / to shine / to show / to reveal	bright / clear / resonant / to shine / to show / to reveal		漂亮 (People 1), 亮 (People 1), 月亮 (Festivals)
 People 1	朋友		péng you	péng you	friend	friend / CL: 個｜个, 位	friend / CL: 個｜个, 位		朋友 (People 1), 朋友圈 (Internet Slang)
 People 1	男		nán	nán	male	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个	male / Baron, lowest of five orders of nobility 五等爵位 / CL: 個｜个		男 (People 1), 宅男 (Internet Slang)
-People 1	矮		ǎi	ǎi	short	low / short (in length)	low / short (in length)		No Matches Found
+People 1	矮		ǎi	ǎi	short	low / short (in length)	low / short (in length)		
 People 1	朋		péng	péng	Friend	friend	friend		朋友 (People 1), 朋 (People 1), 朋友圈 (Internet Slang)
 People 1	友		yǒu	yǒu	Friendly	friend	friend		朋友 (People 1), 友 (People 1), 朋友圈 (Internet Slang), 好友 (Internet Slang)
-People 1	可爱	可愛	kě ài	kě ài	lovely	adorable / cute / lovely	adorable / cute / lovely		No Matches Found
-People 1	非常		fēi cháng	fēi cháng	very much	very / very much / unusual / extraordinary	very / very much / unusual / extraordinary		No Matches Found
+People 1	可爱	可愛	kě ài	kě ài	lovely	adorable / cute / lovely	adorable / cute / lovely		
+People 1	非常		fēi cháng	fēi cháng	very much	very / very much / unusual / extraordinary	very / very much / unusual / extraordinary		
 People 1	可		kě   kè	kě   kè	can	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗	can / may / able to / to approve / to permit / to suit / (particle used for emphasis) certainly / very  see 可汗		可爱 (People 1), 可 (People 1), 可以 (Transportation), 可能 (Weather), 可怕 (Personality and Feelings)
 People 1	非		Fēi   fēi	Fēi   fēi	non-	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must	abbr. for 非洲, Africa  to not be / not / wrong / incorrect / non- / un- / in- / to reproach or blame / (colloquial) to insist on / simply must		非常 (People 1), 非 (People 1)
 People 1	常		Cháng   cháng	Cháng   cháng	often	surname Chang  always / ever / often / frequently / common / general / constant	surname Chang  always / ever / often / frequently / common / general / constant		非常 (People 1), 常 (People 1), 经常 (Personality and Feelings)
-Time 2	上午		shàng wǔ	shàng wǔ	morning	morning / CL: 個｜个	morning / CL: 個｜个		No Matches Found
+Time 2	上午		shàng wǔ	shàng wǔ	morning	morning / CL: 個｜个	morning / CL: 個｜个		
 Time 2	分		fēn   fèn	fēn   fèn	Minute	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component	to divide / to separate / to distribute / to allocate / to distinguish (good and bad) / part or subdivision / fraction / one tenth (of certain units) / unit of length equivalent to 0.33 cm / minute (unit of time) / minute (angular measurement unit) / a point (in sports or games) / 0.01 yuan (unit of money)  part / share / ingredient / component		分 (Time 2), 分 (Payment), 分钟 (Time 3), 分手 (Future), 分享 (Internet Slang)
-Time 2	下午		xià wǔ	xià wǔ	in the afternoon	afternoon / CL: 個｜个 / p.m.	afternoon / CL: 個｜个 / p.m.		No Matches Found
-Time 2	晚上		wǎn shang	wǎn shang	at night	evening / night / CL: 個｜个 / in the evening	evening / night / CL: 個｜个 / in the evening		No Matches Found
+Time 2	下午		xià wǔ	xià wǔ	in the afternoon	afternoon / CL: 個｜个 / p.m.	afternoon / CL: 個｜个 / p.m.		
+Time 2	晚上		wǎn shang	wǎn shang	at night	evening / night / CL: 個｜个 / in the evening	evening / night / CL: 個｜个 / in the evening		
 Time 2	午		wǔ	wǔ	Noon	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)	7th earthly branch: 11 a.m.-1 p.m., noon, 5th solar month (6th June-6th July), year of the Horse / ancient Chinese compass point: 180° (south)		上午 (Time 2), 下午 (Time 2), 午 (Time 2), 中午 (Time 2), 午饭 (Daily Routine 1), 端午节 (Festivals)
 Time 2	晚		wǎn	wǎn	late	evening / night / late	evening / night / late		晚安 (Greeting 4), 晚上 (Time 2), 晚 (Time 2), 晚饭 (Daily Routine 1), 晚 (Time 3)
 Time 2	下		xià	xià	under	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action	down / downwards / below / lower / later / next (week etc) / second (of two parts) / to decline / to go down / to arrive at (a decision, conclusion etc) / measure word to show the frequency of an action		下午 (Time 2), 下 (Time 2), 下 (Time 2), 下班 (Daily Routine 1), 下 (Location 4), 一下 (Restaurant), 下 (Transportation), 下 (Weather), 下课 (School), 下面 (Location 5), 下 (Environment), 下载 (Languages 3)
-Time 2	每		měi	měi	each	each / every	each / every		No Matches Found
-Time 2	中午		zhōng wǔ	zhōng wǔ	noon	noon / midday / CL: 個｜个	noon / midday / CL: 個｜个		No Matches Found
-Time 2	周末	週末	zhōu mò	zhōu mò	weekend	weekend	weekend		No Matches Found
+Time 2	每		měi	měi	each	each / every	each / every		
+Time 2	中午		zhōng wǔ	zhōng wǔ	noon	noon / midday / CL: 個｜个	noon / midday / CL: 個｜个		
+Time 2	周末	週末	zhōu mò	zhōu mò	weekend	weekend	weekend		
 Time 2	周		Zhōu   zhōu   zhōu	Zhōu   zhōu   zhōu	week	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周	surname Zhou / Zhou Dynasty (1046-256 BC)  to make a circuit / to circle / circle / circumference / lap / cycle / complete / all / all over / thorough / to help financially  week / weekly / variant of 周		周末 (Time 2), 周 (Time 2), 周围 (Location 6)
 Time 2	末		mò	mò	end	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man	tip / end / final stage / latter part / inessential detail / powder / dust / opera role of old man		周末 (Time 2), 末 (Time 2)
-Time 2	昨天		zuó tiān	zuó tiān	yesterday	yesterday	yesterday		No Matches Found
+Time 2	昨天		zuó tiān	zuó tiān	yesterday	yesterday	yesterday		
 Time 2	了		le   liǎo   liǎo	le   liǎo   liǎo	The	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly	(modal particle intensifying preceding clause) / (completed action marker)  to finish / to achieve / variant of 瞭｜了 / to understand clearly  (of eyes) bright / clear-sighted / to understand clearly		了 (Time 2), 了 (Payment), 了 (Health 2), 除了 (Food 3), 为了 (Hobbies 3), 了解 (Hobbies 3), 了 (Hobbies 3)
 Time 2	做		zuò	zuò	do	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance	to do / to make / to produce / to write / to compose / to act as / to engage in / to hold (a party) / to be / to become / to function (in some capacity) / to serve as / to be used for / to form (a bond or relationship) / to pretend / to feign / to act a part / to put on appearance		做 (Time 2), 做 (Daily Routine 1), 做梦 (Daily Routine 2)
 Time 2	昨		zuó	zuó	Yesterday	yesterday	yesterday		昨天 (Time 2), 昨 (Time 2)
-Time 2	今年		jīn nián	jīn nián	this year	this year	this year		No Matches Found
-Time 2	去年		qù nián	qù nián	last year	last year	last year		No Matches Found
-Time 2	明年		míng nián	míng nián	next year	next year	next year		No Matches Found
+Time 2	今年		jīn nián	jīn nián	this year	this year	this year		
+Time 2	去年		qù nián	qù nián	last year	last year	last year		
+Time 2	明年		míng nián	míng nián	next year	next year	next year		
 Time 2	去		qù	qù	go with	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)	to go / to go to (a place) / (of a time etc) last / just passed / to send / to remove / to get rid of / to reduce / to be apart from in space or time / to die (euphemism) / to play (a part) / (when used either before or after a verb) to go in order to do sth / (after a verb of motion indicates movement away from the speaker) / (used after certain verbs to indicate detachment or separation)		去年 (Time 2), 去 (Time 2), 去 (Hobbies 2), 出去 (Invitiation 1), 去 (Environment), 过去 (Communication 2)
-Location 3	旁边	旁邊	páng biān	páng biān	next to	lateral / side / to the side / beside	lateral / side / to the side / beside		No Matches Found
-Location 3	左边	左邊	zuǒ bian	zuǒ bian	left	left / the left side / to the left of	left / the left side / to the left of		No Matches Found
-Location 3	右边	右邊	yòu bian	yòu bian	right	right side / right, to the right	right side / right, to the right		No Matches Found
+Location 3	旁边	旁邊	páng biān	páng biān	next to	lateral / side / to the side / beside	lateral / side / to the side / beside		
+Location 3	左边	左邊	zuǒ bian	zuǒ bian	left	left / the left side / to the left of	left / the left side / to the left of		
+Location 3	右边	右邊	yòu bian	yòu bian	right	right side / right, to the right	right side / right, to the right		
 Location 3	旁		páng	páng	Beside	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic	beside / one side / other / side / self / the right-hand side of split Chinese character, often the phonetic		旁边 (Location 3), 旁 (Location 3)
 Location 3	左		Zuǒ   zuǒ	Zuǒ   zuǒ	left	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐	surname Zuo  left / the Left (politics) / east / unorthodox / queer / wrong / differing / opposite / variant of 佐		左边 (Location 3), 左 (Location 3), 左 (Location 6)
 Location 3	右		yòu	yòu	right	right (-hand) / the Right (politics) / west (old)	right (-hand) / the Right (politics) / west (old)		右边 (Location 3), 右 (Location 3), 右 (Location 6)
 Location 3	边	邊	biān   bian	biān   bian	side	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality	side / edge / margin / border / boundary / CL: 個｜个 / simultaneously  suffix of a noun of locality		旁边 (Location 3), 左边 (Location 3), 右边 (Location 3), 边 (Location 3), 一边 (Daily Routine 2), 西边 (Location 6), 东边 (Location 6), 北边 (Location 6), 南边 (Location 6), 海边 (Travel 4)
-Location 3	前面		qián miàn	qián miàn	front	ahead / in front / preceding / above / also pr. [qian2 mian5]	ahead / in front / preceding / above / also pr. [qian2 mian5]		No Matches Found
-Location 3	后面	後面	hòu miàn	hòu miàn	Behind	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	rear / back / behind / later / afterwards / also pr. [hou4 mian5]		No Matches Found
-Location 3	学校	學校	xué xiào	xué xiào	school	school / CL: 所	school / CL: 所		No Matches Found
+Location 3	前面		qián miàn	qián miàn	front	ahead / in front / preceding / above / also pr. [qian2 mian5]	ahead / in front / preceding / above / also pr. [qian2 mian5]		
+Location 3	后面	後面	hòu miàn	hòu miàn	Behind	rear / back / behind / later / afterwards / also pr. [hou4 mian5]	rear / back / behind / later / afterwards / also pr. [hou4 mian5]		
+Location 3	学校	學校	xué xiào	xué xiào	school	school / CL: 所	school / CL: 所		
 Location 3	前		qián	qián	before	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly	front / forward / ahead / first / top (followed by a number) / future / ago / before / BC (e.g. 前293年) / former / formerly		前面 (Location 3), 前 (Location 3), 前 (Time 4), 前天 (Time 4), 以前 (Daily Routine 2), 前 (Location 6)
 Location 3	后		Hòu   hòu   hòu	Hòu   hòu   hòu	Rear	surname Hou  empress / queen  back / behind / rear / afterwards / after / later	surname Hou  empress / queen  back / behind / rear / afterwards / after / later		后面 (Location 3), 后 (Location 3), 后 (Time 4), 后天 (Time 4), 以后 (Daily Routine 2), 然后 (Location 6), 最后 (Location 6), 后 (Location 6), 后来 (Languages 2)
 Location 3	校		jiào   xiào	jiào   xiào	school	to proofread / to check / to compare  school / military officer / CL: 所	to proofread / to check / to compare  school / military officer / CL: 所		学校 (Location 3), 校 (Location 3), 校长 (School 2)
@@ -283,170 +283,170 @@ Location 3	走		zǒu	zǒu	go	to walk / to go / to run / to move (of vehicle) / t
 Location 3	到		dào	dào	To	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)	to (a place) / until (a time) / up to / to go / to arrive / (verb complement denoting completion or result of an action)		到 (Location 3), 迟到 (Travel), 遇到 (Personality and Feelings)
 Location 3	路		Lù   lù	Lù   lù	road	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind	surname Lu  road / CL: 條｜条 / journey / route / line (bus etc) / sort / kind		路 (Location 3), 路 (Travel), 走路 (Travel), 迷路 (Location 6), 马路 (Travel 4)
 Location 3	怎么	怎麼	zěn me	zěn me	how	how? / what? / why?	how? / what? / why?		怎么样 (Greeting 3), 怎么 (Location 3), 怎么办 (Travel)
-Location 3	哪里	哪裏	nǎ lǐ   nǎ lǐ	nǎ lǐ   nǎ lǐ	where	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment		No Matches Found
-Location 3	这里	這裡	zhè lǐ	zhè lǐ	Here	here	here		No Matches Found
-Location 3	那里	那裏	nà li   nà li	nà li   nà li	There	there / that place / also written 那裡｜那里  there / that place	there / that place / also written 那裡｜那里  there / that place		No Matches Found
-Location 3	往		wǎng	wǎng	to	to go (in a direction) / to / towards / (of a train) bound for / past / previous	to go (in a direction) / to / towards / (of a train) bound for / past / previous		No Matches Found
+Location 3	哪里	哪裏	nǎ lǐ   nǎ lǐ	nǎ lǐ   nǎ lǐ	where	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment	where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment / also written 哪裡｜哪里  where? / somewhere / anywhere / wherever / nowhere (negative answer to question) / humble expression denying compliment		
+Location 3	这里	這裡	zhè lǐ	zhè lǐ	Here	here	here		
+Location 3	那里	那裏	nà li   nà li	nà li   nà li	There	there / that place / also written 那裡｜那里  there / that place	there / that place / also written 那裡｜那里  there / that place		
+Location 3	往		wǎng	wǎng	to	to go (in a direction) / to / towards / (of a train) bound for / past / previous	to go (in a direction) / to / towards / (of a train) bound for / past / previous		
 Location 3	里	裡	lǐ   Lǐ   lǐ	lǐ   Lǐ   lǐ	in	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels	lining / interior / inside / internal / also written 裏｜里  Li (surname)  li, ancient measure of length, approx. 500 m / neighborhood / ancient administrative unit of 25 families / (Tw) borough, administrative unit between the township 鎮｜镇 and neighborhood 鄰｜邻 levels		哪里 (Location 3), 这里 (Location 3), 那里 (Location 3), 里 (Location 3), 里 (Location 4), 里面 (Weather)
-Hobbies 1	喜欢	喜歡	xǐ huan	xǐ huan	like	to like / to be fond of	to like / to be fond of		No Matches Found
+Hobbies 1	喜欢	喜歡	xǐ huan	xǐ huan	like	to like / to be fond of	to like / to be fond of		
 Hobbies 1	看		kān   kàn	kān   kàn	Look	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)	to look after / to take care of / to watch / to guard  to see / to look at / to read / to watch / to visit / to call on / to consider / to regard as / to look after / to treat (an illness) / to depend on / to feel (that) / (after verb) to give it a try / Watch out! (for a danger)		看 (Hobbies 1), 好看 (Shopping 2), 看起来 (Personality and Feelings)
 Hobbies 1	书	書	Shū   shū	Shū   shū	book	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write	abbr. for 書經｜书经  book / letter / document / CL: 本, 冊｜册, 部 / to write		书 (Hobbies 1), 图书馆 (Location 5)
 Hobbies 1	喜		xǐ	xǐ	like	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad	to be fond of / to like / to enjoy / to be happy / to feel pleased / happiness / delight / glad		喜欢 (Hobbies 1), 喜 (Hobbies 1), 恭喜 (Festivals)
 Hobbies 1	欢	歡	huān   huān   huān	huān   huān   huān	Joyous	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢	joyous / happy / pleased  hubbub / clamor / variant of 歡｜欢  a breed of horse / variant of 歡｜欢		喜欢 (Hobbies 1), 欢 (Hobbies 1), 欢迎 (Shopping 1)
-Hobbies 1	玩		wán	wán	play	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment		No Matches Found
-Hobbies 1	电脑	電腦	diàn nǎo	diàn nǎo	computer	computer / CL: 臺｜台	computer / CL: 臺｜台		No Matches Found
-Hobbies 1	游戏	遊戲	yóu xì	yóu xì	game	game / CL: 場｜场 / to play	game / CL: 場｜场 / to play		No Matches Found
+Hobbies 1	玩		wán	wán	play	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment	to play / to have fun / to trifle with / toy / sth used for amusement / curio or antique (Taiwan pr. [wan4]) / to keep sth for entertainment		
+Hobbies 1	电脑	電腦	diàn nǎo	diàn nǎo	computer	computer / CL: 臺｜台	computer / CL: 臺｜台		
+Hobbies 1	游戏	遊戲	yóu xì	yóu xì	game	game / CL: 場｜场 / to play	game / CL: 場｜场 / to play		
 Hobbies 1	脑	腦	nǎo	nǎo	brain	brain / mind / head / essence	brain / mind / head / essence		电脑 (Hobbies 1), 脑 (Hobbies 1)
 Hobbies 1	游		Yóu   yóu   yóu	Yóu   yóu   yóu	tour	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel	surname You  to swim / variant of 遊｜游  to walk / to tour / to roam / to travel		游戏 (Hobbies 1), 游 (Hobbies 1), 旅游 (Hobbies 2), 游 (Sports 1), 游泳 (Sports 1), 漫游 (Travel 3), 导游 (Travel 3)
 Hobbies 1	戏	戲	xì	xì	play	trick / drama / play / show / CL: 出, 場｜场, 臺｜台	trick / drama / play / show / CL: 出, 場｜场, 臺｜台		游戏 (Hobbies 1), 戏 (Hobbies 1)
-Hobbies 1	听		yǐn   tīng   tìng	yǐn   tīng   tìng	listen	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow		No Matches Found
-Hobbies 1	音乐	音樂	yīn yuè	yīn yuè	music	music / CL: 張｜张, 曲, 段	music / CL: 張｜张, 曲, 段		No Matches Found
-Hobbies 1	歌		gē	gē	song	song / CL: 支, 首 / to sing	song / CL: 支, 首 / to sing		No Matches Found
+Hobbies 1	听		yǐn   tīng   tìng	yǐn   tīng   tìng	listen	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow	smile (archaic)  to listen / to hear / to obey / a can (loanword from English 'tin') / classifier for canned beverages  (literary pronunciation, still advocated in Taiwan) to rule / to sentence / to allow		
+Hobbies 1	音乐	音樂	yīn yuè	yīn yuè	music	music / CL: 張｜张, 曲, 段	music / CL: 張｜张, 曲, 段		
+Hobbies 1	歌		gē	gē	song	song / CL: 支, 首 / to sing	song / CL: 支, 首 / to sing		
 Hobbies 1	音		yīn	yīn	sound	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)	sound / noise / note (of musical scale) / tone / news / syllable / reading (phonetic value of a character)		音乐 (Hobbies 1), 音 (Hobbies 1), 声音 (Environment)
 Hobbies 1	乐	樂	Lè   Yuè   lè   yuè	Lè   Yuè   lè   yuè	fun	surname Le  surname Yue  happy / cheerful / to laugh  music	surname Le  surname Yue  happy / cheerful / to laugh  music		音乐 (Hobbies 1), 乐 (Hobbies 1), 乐 (Celebration), 快乐 (Celebration)
-Hobbies 1	跳舞		tiào wǔ	tiào wǔ	dancing	to dance	to dance		No Matches Found
-Hobbies 1	唱		chàng	chàng	sing	to sing / to call loudly / to chant	to sing / to call loudly / to chant		No Matches Found
+Hobbies 1	跳舞		tiào wǔ	tiào wǔ	dancing	to dance	to dance		
+Hobbies 1	唱		chàng	chàng	sing	to sing / to call loudly / to chant	to sing / to call loudly / to chant		
 Hobbies 1	跳		tiào	tiào	jump	to jump / to hop / to skip over / to bounce / to palpitate	to jump / to hop / to skip over / to bounce / to palpitate		跳舞 (Hobbies 1), 跳 (Hobbies 1)
 Hobbies 1	舞		wǔ	wǔ	dance	to dance / to wield / to brandish	to dance / to wield / to brandish		跳舞 (Hobbies 1), 舞 (Hobbies 1)
-Daily Routine 1	起床		qǐ chuáng	qǐ chuáng	get up	to get out of bed / to get up	to get out of bed / to get up		No Matches Found
-Daily Routine 1	上学	上學	shàng xué	shàng xué	go to school	to go to school / to attend school	to go to school / to attend school		No Matches Found
-Daily Routine 1	上班		shàng bān	shàng bān	Go to work	to go to work / to be on duty / to start work / to go to the office	to go to work / to be on duty / to start work / to go to the office		No Matches Found
-Daily Routine 1	早饭	早飯	zǎo fàn	zǎo fàn	breakfast	breakfast / CL: 份, 頓｜顿, 次, 餐	breakfast / CL: 份, 頓｜顿, 次, 餐		No Matches Found
+Daily Routine 1	起床		qǐ chuáng	qǐ chuáng	get up	to get out of bed / to get up	to get out of bed / to get up		
+Daily Routine 1	上学	上學	shàng xué	shàng xué	go to school	to go to school / to attend school	to go to school / to attend school		
+Daily Routine 1	上班		shàng bān	shàng bān	Go to work	to go to work / to be on duty / to start work / to go to the office	to go to work / to be on duty / to start work / to go to the office		
+Daily Routine 1	早饭	早飯	zǎo fàn	zǎo fàn	breakfast	breakfast / CL: 份, 頓｜顿, 次, 餐	breakfast / CL: 份, 頓｜顿, 次, 餐		
 Daily Routine 1	床		chuáng	chuáng	bed	bed / couch / classifier for beds / CL: 張｜张	bed / couch / classifier for beds / CL: 張｜张		起床 (Daily Routine 1), 床 (Daily Routine 1)
 Daily Routine 1	班		Bān   bān	Bān   bān	class	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups	surname Ban  team / class / squad / work shift / ranking / CL: 個｜个 / classifier for groups		上班 (Daily Routine 1), 班 (Daily Routine 1), 下班 (Daily Routine 1), 西班牙 (Hobbies 2), 班 (Hobbies 2), 西班牙语 (Hobbies 2), 班 (School 2), 加班 (Work 3)
 Daily Routine 1	从	從	Cóng   cóng   zòng	Cóng   cóng   zòng	From	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin	surname Cong  from / through / via / to follow / to obey / to engage in (an activity) / never (in negative sentence) / (Taiwan pr. [zong4]) retainer / assistant / accomplice / related by common paternal grandfather or earlier ancestor  second cousin		从 (Daily Routine 1), 从来 (Weather)
-Daily Routine 1	睡觉	睡覺	shuì jiào	shuì jiào	go to bed	to go to bed / to sleep	to go to bed / to sleep		No Matches Found
-Daily Routine 1	午饭	午飯	wǔ fàn	wǔ fàn	lunch	lunch / CL: 份, 頓｜顿, 次, 餐	lunch / CL: 份, 頓｜顿, 次, 餐		No Matches Found
+Daily Routine 1	睡觉	睡覺	shuì jiào	shuì jiào	go to bed	to go to bed / to sleep	to go to bed / to sleep		
+Daily Routine 1	午饭	午飯	wǔ fàn	wǔ fàn	lunch	lunch / CL: 份, 頓｜顿, 次, 餐	lunch / CL: 份, 頓｜顿, 次, 餐		
 Daily Routine 1	睡		shuì	shuì	sleep	to sleep / to lie down	to sleep / to lie down		睡觉 (Daily Routine 1), 睡 (Daily Routine 1)
 Daily Routine 1	觉	覺	jiào   jué	jiào   jué	feel	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware	a nap / a sleep / CL: 場｜场  to feel / to find that / thinking / awake / aware		睡觉 (Daily Routine 1), 觉 (Daily Routine 1), 觉 (Health 1), 觉得 (Health 1)
-Daily Routine 1	放学	放學	fàng xué	fàng xué	School	to dismiss students at the end of the school day	to dismiss students at the end of the school day		No Matches Found
-Daily Routine 1	下班		xià bān	xià bān	Commute	to finish work / to get off work	to finish work / to get off work		No Matches Found
+Daily Routine 1	放学	放學	fàng xué	fàng xué	School	to dismiss students at the end of the school day	to dismiss students at the end of the school day		
+Daily Routine 1	下班		xià bān	xià bān	Commute	to finish work / to get off work	to finish work / to get off work		
 Daily Routine 1	回		huí   huí	huí   huí	Times	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve	to circle / to go back / to turn around / to answer / to return / to revolve / Hui ethnic group (Chinese Muslims) / time / classifier for acts of a play / section or chapter (of a classic book)  to curve / to return / to revolve		回 (Daily Routine 1), 回答 (Languages 3), 回 (Communication 2), 回复 (Business 1)
-Daily Routine 1	晚饭	晚飯	wǎn fàn	wǎn fàn	dinner	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐		No Matches Found
+Daily Routine 1	晚饭	晚飯	wǎn fàn	wǎn fàn	dinner	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐	evening meal / dinner / supper / CL: 份, 頓｜顿, 次, 餐		
 Daily Routine 1	放		fàng	fàng	put	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)	to put / to place / to release / to free / to let go / to let out / to set off (fireworks)		放学 (Daily Routine 1), 放 (Daily Routine 1), 放心 (Future), 放 (House), 放假 (Exam), 放松 (Exam), 放弃 (Duo)
 Payment	钱	錢	Qián   qián	Qián   qián	money	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两	surname Qian  coin / money / CL: 筆｜笔 / unit of weight, one tenth of a tael 兩｜两		钱 (Payment), 换钱 (Travel 3)
 Payment	块	塊	kuài	kuài	Piece	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units	lump (of earth) / chunk / piece / classifier for pieces of cloth, cake, soap etc / (coll.) classifier for money and currency units		块 (Payment), 块 (Dining 2)
 Payment	只		zhǐ   zhǐ   zhī	zhǐ   zhǐ   zhī	only	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc	only / merely / just / but  grain that has begun to ripen / variant of 衹｜只  classifier for birds and certain animals, one of a pair, some utensils, vessels etc		只 (Payment), 只 (Existence)
 Payment	买	買	mǎi	mǎi	buy	to buy / to purchase	to buy / to purchase		买 (Payment), 买单 (Restaurant)
-Payment	一共		yī gòng	yī gòng	Altogether	altogether	altogether		No Matches Found
+Payment	一共		yī gòng	yī gòng	Altogether	altogether	altogether		
 Payment	毛		Máo   máo	Máo   máo	hair	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)	surname Mao  hair / feather / down / wool / mildew / mold / coarse or semifinished / young / raw / careless / unthinking / nervous / scared / (of currency) to devalue or depreciate / classifier for Chinese fractional monetary unit ( = 角 , = one-tenth of a yuan or 10 fen 分)		毛 (Payment), 毛 (Duo), 羽毛 (Duo)
 Payment	共		gòng	gòng	Altogether	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party	common / general / to share / together / total / altogether / abbr. for 共產黨｜共产党, Communist party		一共 (Payment), 共 (Payment), 公共 (Transportation)
-Payment	信用卡		xìn yòng kǎ	xìn yòng kǎ	credit card	credit card	credit card		No Matches Found
+Payment	信用卡		xìn yòng kǎ	xìn yòng kǎ	credit card	credit card	credit card		
 Payment	收		shōu	shōu	Receive	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)	to receive / to accept / to collect / to put away / to restrain / to stop / in care of (used on address line after name)		收 (Payment), 收据 (Business 1)
-Payment	千		qiān   qiān	qiān   qiān	thousand	thousand  see 鞦韆｜秋千	thousand  see 鞦韆｜秋千		No Matches Found
+Payment	千		qiān   qiān	qiān   qiān	thousand	thousand  see 鞦韆｜秋千	thousand  see 鞦韆｜秋千		
 Payment	信		xìn	xìn	letter	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random	letter / mail / CL: 封 / to trust / to believe / to profess faith in / truthful / confidence / trust / at will / at random		信用卡 (Payment), 信 (Payment), 信心 (Sports 2), 信 (Sports 2), 相信 (Work), 短信 (Communication 2), 信号 (Communication 2), 微信 (Internet Slang)
 Payment	用		yòng	yòng	use	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore	to use / to employ / to have to / to eat or drink / expense or outlay / usefulness / hence / therefore		信用卡 (Payment), 用 (Payment), 用 (Entertainment), 应用 (Languages 3), 费用 (Business 1)
 Payment	卡		kǎ   qiǎ	kǎ   qiǎ	card	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]	to stop / to block / card / CL: 張｜张, 片 / calorie / cassette / (computing) (coll.) slow  to block / to be stuck / to be wedged / customs station / a clip / a fastener / a checkpost / Taiwan pr. [ka3]		信用卡 (Payment), 卡 (Payment), 电话卡 (Travel 3)
 Payment	贵	貴	guì	guì	expensive	expensive / noble / precious / (honorific) your	expensive / noble / precious / (honorific) your		贵 (Payment), 贵 (Business 2)
-Payment	便宜		biàn yí   pián yi	biàn yí   pián yi	Inexpensive	convenient  cheap / inexpensive / small advantages / to let sb off lightly	convenient  cheap / inexpensive / small advantages / to let sb off lightly		No Matches Found
-Payment	现金	現金	xiàn jīn	xiàn jīn	cash	cash	cash		No Matches Found
+Payment	便宜		biàn yí   pián yi	biàn yí   pián yi	Inexpensive	convenient  cheap / inexpensive / small advantages / to let sb off lightly	convenient  cheap / inexpensive / small advantages / to let sb off lightly		
+Payment	现金	現金	xiàn jīn	xiàn jīn	cash	cash	cash		
 Payment	便		biàn   pián	biàn   pián	Then	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜	plain / informal / suitable / convenient / opportune / to urinate or defecate / equivalent to 就: then / in that case / even if / soon afterwards  see 便宜		便宜 (Payment), 便 (Payment), 随便 (Shopping 1), 便 (Shopping 1), 方便 (Environment)
 Payment	宜		Yí   yí	Yí   yí	should	surname Yi  proper / should / suitable / appropriate	surname Yi  proper / should / suitable / appropriate		便宜 (Payment), 宜 (Payment)
 Payment	金		Jīn   jīn	Jīn   jīn	gold	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音	surname Jin / surname Kim (Korean) / Jurchen Jin dynasty (1115-1234)  gold / chemical element Au / generic term for lustrous and ductile metals / money / golden / highly respected / one of the eight ancient musical instruments 八音		现金 (Payment), 金 (Payment), 奖金 (Work 3)
 Payment	太		tài	tài	too	highest / greatest / too (much) / very / extremely	highest / greatest / too (much) / very / extremely		太 (Payment), 太阳 (Environment)
-Payment	万		Mò   Wàn   wàn	Mò   Wàn   wàn	Ten thousand	see 万俟  surname Wan  ten thousand / a great number	see 万俟  surname Wan  ten thousand / a great number		No Matches Found
+Payment	万		Mò   Wàn   wàn	Mò   Wàn   wàn	Ten thousand	see 万俟  surname Wan  ten thousand / a great number	see 万俟  surname Wan  ten thousand / a great number		
 Payment	行		háng   xíng	háng   xíng	Row	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense	row / line / commercial firm / line of business / profession / to rank (first, second etc) among one's siblings (by age) / (in data tables) row / (Tw) column  to walk / to go / to travel / a visit / temporary / makeshift / current / in circulation / to do / to perform / capable / competent / effective / all right / OK! / will do / behavior / conduct / Taiwan pr. [xing4] for the behavior-conduct sense		行 (Payment), 行李 (Travel 2), 自行车 (Hobbies 3), 银行 (Travel 3), 行 (Travel 3)
 Entertainment	想		xiǎng	xiǎng	miss you	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)	to think / to believe / to suppose / to wish / to want / to miss (feel wistful about the absence of sb or sth)		想 (Entertainment), 想 (Personality and Feelings)
 Entertainment	干	乾	Gān   gān   gān   gàn	Gān   gān   gān   gàn	dry	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)	surname Gan  dry / clean / in vain / dried food / foster / adoptive / to ignore  to concern / to interfere / shield / stem  tree trunk / main part of sth / to manage / to work / to do / capable / cadre / to kill (slang) / to fuck (vulgar)		干 (Entertainment), 干杯 (Celebration), 干 (Celebration), 干净 (House), 干燥 (Weather 2)
 Entertainment	影		yǐng	yǐng	Shadow	picture / image / film / movie / photograph / reflection / shadow / trace	picture / image / film / movie / photograph / reflection / shadow / trace		影 (Entertainment), 电影 (Entertainment), 影响 (Environment)
 Entertainment	视	視	shì	shì	Regard	to look at / to regard / to inspect	to look at / to regard / to inspect		视 (Entertainment), 电视 (Entertainment)
-Entertainment	电视	電視	diàn shì	diàn shì	TV	television / TV / CL: 臺｜台, 個｜个	television / TV / CL: 臺｜台, 個｜个		No Matches Found
-Entertainment	电影	電影	diàn yǐng	diàn yǐng	the film	movie / film / CL: 部, 片, 幕, 場｜场	movie / film / CL: 部, 片, 幕, 場｜场		No Matches Found
-Entertainment	报纸	報紙	bào zhǐ	bào zhǐ	newspaper	newspaper / newsprint / CL: 份, 期, 張｜张	newspaper / newsprint / CL: 份, 期, 張｜张		No Matches Found
-Entertainment	上网	上網	shàng wǎng	shàng wǎng	Internet	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net		No Matches Found
+Entertainment	电视	電視	diàn shì	diàn shì	TV	television / TV / CL: 臺｜台, 個｜个	television / TV / CL: 臺｜台, 個｜个		
+Entertainment	电影	電影	diàn yǐng	diàn yǐng	the film	movie / film / CL: 部, 片, 幕, 場｜场	movie / film / CL: 部, 片, 幕, 場｜场		
+Entertainment	报纸	報紙	bào zhǐ	bào zhǐ	newspaper	newspaper / newsprint / CL: 份, 期, 張｜张	newspaper / newsprint / CL: 份, 期, 張｜张		
+Entertainment	上网	上網	shàng wǎng	shàng wǎng	Internet	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net	to go online / to connect to the Internet / (of a document etc) to be uploaded to the Internet / (tennis, volleyball etc) to move in close to the net		
 Entertainment	报	報	bào	bào	Report	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张	to announce / to inform / report / newspaper / recompense / revenge / CL: 份, 張｜张		报纸 (Entertainment), 报 (Entertainment), 报销 (Business 1), 报告 (Business 1), 汇报 (Business 1), 报警 (Emergency)
 Entertainment	纸	紙	zhǐ	zhǐ	paper	paper / CL: 張｜张, 沓 / classifier for documents, letter etc	paper / CL: 張｜张, 沓 / classifier for documents, letter etc		报纸 (Entertainment), 纸 (Entertainment), 纸 (School 2)
 Entertainment	网	網	wǎng	wǎng	network	net / network	net / network		上网 (Entertainment), 网 (Entertainment), 网球 (Sports 2)
-Entertainment	手机	手機	shǒu jī	shǒu jī	Cellular phone	cell phone / mobile phone / CL: 部, 支	cell phone / mobile phone / CL: 部, 支		No Matches Found
-Entertainment	新闻	新聞	xīn wén	xīn wén	news	news / CL: 條｜条, 個｜个	news / CL: 條｜条, 個｜个		No Matches Found
+Entertainment	手机	手機	shǒu jī	shǒu jī	Cellular phone	cell phone / mobile phone / CL: 部, 支	cell phone / mobile phone / CL: 部, 支		
+Entertainment	新闻	新聞	xīn wén	xīn wén	news	news / CL: 條｜条, 個｜个	news / CL: 條｜条, 個｜个		
 Entertainment	机	機	Jī   jī	Jī   jī	machine	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台	surname Ji  machine / engine / opportunity / intention / aircraft / pivot / crucial point / flexible (quick-witted) / organic / CL: 臺｜台		手机 (Entertainment), 机 (Entertainment), 照相机 (Hobbies 2), 飞机 (Travel), 机场 (Travel), 机票 (Travel), 机会 (Future), 转机 (Travel 3), 司机 (Travel 4)
 Entertainment	新		Xīn   xīn	Xīn   xīn	new	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)	abbr. for Xinjiang 新疆 or Singapore 新加坡 / surname Xin  new / newly / meso- (chemistry)		新闻 (Entertainment), 新 (Entertainment), 新鲜 (Supermarket), 新 (Hobbies 2), 新年 (Celebration)
 Entertainment	闻	聞	Wén   wén	Wén   wén	smell	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at	surname Wen  to hear / news / well-known / famous / reputation / fame / to smell / to sniff at		新闻 (Entertainment), 闻 (Entertainment)
-Entertainment	明星		míng xīng	míng xīng	Celebrity	star / celebrity	star / celebrity		No Matches Found
+Entertainment	明星		míng xīng	míng xīng	Celebrity	star / celebrity	star / celebrity		
 Entertainment	体育	體育	tǐ yù	tǐ yù	physical education	sports / physical education	sports / physical education		体育 (Entertainment), 体育馆 (School 2)
-Entertainment	节目	節目	jié mù	jié mù	program	program / item (on a program) / CL: 臺｜台, 個｜个, 套	program / item (on a program) / CL: 臺｜台, 個｜个, 套		No Matches Found
-Entertainment	韩国	韓國	Hán guó	Hán guó	Korea	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897		No Matches Found
+Entertainment	节目	節目	jié mù	jié mù	program	program / item (on a program) / CL: 臺｜台, 個｜个, 套	program / item (on a program) / CL: 臺｜台, 個｜个, 套		
+Entertainment	韩国	韓國	Hán guó	Hán guó	Korea	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897	South Korea (Republic of Korea) / Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897		
 Entertainment	体	體	tǐ	tǐ	body	body / form / style / system / substance / to experience / aspect (linguistics)	body / form / style / system / substance / to experience / aspect (linguistics)		体育 (Entertainment), 体 (Entertainment), 身体 (Health 1), 体育馆 (School 2)
 Entertainment	节	節	jiē   jié	jiē   jié	Festival	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个	see 節骨眼｜节骨眼  festival / holiday / node / joint / section / segment / part / to economize / to save / to abridge / moral integrity / classifier for segments, e.g. lessons, train wagons, biblical verses / CL: 個｜个		节目 (Entertainment), 节 (Entertainment), 节日 (Celebration), 春节 (Celebration), 季节 (Time 4), 中秋节 (Festivals), 端午节 (Festivals)
 Entertainment	韩	韓	Hán	Hán	Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han	Han, one of the Seven Hero States of the Warring States 戰國七雄｜战国七雄 / Korea from the fall of the Joseon dynasty in 1897 / Korea, esp. South Korea 大韓民國｜大韩民国 / surname Han		韩国 (Entertainment), 韩 (Entertainment)
 Entertainment	育		yù	yù	Educate	to have children / to raise or bring up / to educate	to have children / to raise or bring up / to educate		体育 (Entertainment), 育 (Entertainment), 体育馆 (School 2)
 Entertainment	目		mù	mù	Eye	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title	eye / item / section / list / catalogue / table of contents / order (taxonomy) / goal / name / title		节目 (Entertainment), 目 (Entertainment), 项目 (Business 1)
 Location 4	桌		zhuō	zhuō	table	table / desk / classifier for tables of guests at a banquet etc	table / desk / classifier for tables of guests at a banquet etc		桌 (Location 4), 桌子 (Location 4)
-Location 4	找		zhǎo	zhǎo	Find	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	to try to find / to look for / to call on sb / to find / to seek / to return / to give change		No Matches Found
-Location 4	桌子		zhuō zi	zhuō zi	table	table / desk / CL: 張｜张, 套	table / desk / CL: 張｜张, 套		No Matches Found
-Location 4	椅子		yǐ zi	yǐ zi	chair	chair / CL: 把, 套	chair / CL: 把, 套		No Matches Found
+Location 4	找		zhǎo	zhǎo	Find	to try to find / to look for / to call on sb / to find / to seek / to return / to give change	to try to find / to look for / to call on sb / to find / to seek / to return / to give change		
+Location 4	桌子		zhuō zi	zhuō zi	table	table / desk / CL: 張｜张, 套	table / desk / CL: 張｜张, 套		
+Location 4	椅子		yǐ zi	yǐ zi	chair	chair / CL: 把, 套	chair / CL: 把, 套		
 Location 4	椅		yǐ	yǐ	chair	chair	chair		椅子 (Location 4), 椅 (Location 4)
-Location 4	房间	房間	fáng jiān	fáng jiān	room	room / CL: 間｜间, 個｜个	room / CL: 間｜间, 個｜个		No Matches Found
-Location 4	冰箱		bīng xiāng	bīng xiāng	refrigerator	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个		No Matches Found
+Location 4	房间	房間	fáng jiān	fáng jiān	room	room / CL: 間｜间, 個｜个	room / CL: 間｜间, 個｜个		
+Location 4	冰箱		bīng xiāng	bīng xiāng	refrigerator	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个	icebox / freezer cabinet / refrigerator / CL: 臺｜台, 個｜个		
 Location 4	外		wài	wài	outer	outside / in addition / foreign / external	outside / in addition / foreign / external		外 (Location 4), 外面 (Weather), 意外 (Emergency)
 Location 4	房		Fáng   fáng	Fáng   fáng	room	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)	surname Fang  house / room / CL: 間｜间 / branch of an extended family / classifier for family members (or concubines)		房间 (Location 4), 房 (Location 4), 订房 (Travel 3), 退房 (Travel 3), 厨房 (House)
 Location 4	箱		xiāng	xiāng	box	box / trunk / chest	box / trunk / chest		冰箱 (Location 4), 箱 (Location 4)
 Restaurant	位		wèi	wèi	Place	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential	position / location / place / seat / classifier for people (honorific) / classifier for binary bits (e.g. 十六位 16-bit or 2 bytes) / (physics) potential		位 (Restaurant), 订位 (Restaurant)
-Restaurant	等		děng	děng	Wait	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once		No Matches Found
-Restaurant	一下		yī xià	yī xià	a bit	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once		No Matches Found
-Restaurant	进	進	jìn	jìn	Enter	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound		No Matches Found
+Restaurant	等		děng	děng	Wait	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once	class / rank / grade / equal to / same as / to wait for / to await / et cetera / and so on / et al. (and other authors) / after / as soon as / once		
+Restaurant	一下		yī xià	yī xià	a bit	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once	(used after a verb) give it a go / to do (sth for a bit to give it a try) / one time / once / in a while / all of a sudden / all at once		
+Restaurant	进	進	jìn	jìn	Enter	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound	to go forward / to advance / to go in / to enter / to put in / to submit / to take in / to admit / (math.) base of a number system / classifier for sections in a building or residential compound		
 Restaurant	坐		Zuò   zuò	Zuò   zuò	sit	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座	surname Zuo  to sit / to take a seat / to take (a bus, airplane etc) / to bear fruit / variant of 座		坐 (Restaurant), 坐 (Transportation)
-Restaurant	菜单	菜單	cài dān	cài dān	menu	menu / CL: 份, 張｜张	menu / CL: 份, 張｜张		No Matches Found
-Restaurant	英文		Yīng wén	Yīng wén	English	English (language)	English (language)		No Matches Found
+Restaurant	菜单	菜單	cài dān	cài dān	menu	menu / CL: 份, 張｜张	menu / CL: 份, 張｜张		
+Restaurant	英文		Yīng wén	Yīng wén	English	English (language)	English (language)		
 Restaurant	菜		cài	cài	dish	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor	dish (type of food) / vegetable / cuisine / CL: 盤｜盘, 道 / (coll.) (one's) type / (of one's skills etc) weak / poor		菜单 (Restaurant), 菜 (Restaurant), 点菜 (Restaurant), 蔬菜 (Supermarket), 菜 (Dining 1), 菜鸟 (Internet Slang)
 Restaurant	单	單	Shàn   dān	Shàn   dān	single	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个	surname Shan  bill / list / form / single / only / sole / odd number / CL: 個｜个		菜单 (Restaurant), 单 (Restaurant), 买单 (Restaurant), 单 (Languages 3), 简单 (Languages 3)
 Restaurant	文		Wén   wén	Wén   wén	Culture	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67	surname Wen  language / culture / writing / formal / literary / gentle / (old) classifier for coins / Kangxi radical 67		英文 (Restaurant), 文 (Restaurant), 文 (Hobbies 2), 中文 (Hobbies 2), 文化 (Hobbies 3)
-Restaurant	服务员	服務員	fú wù yuán	fú wù yuán	Waiter	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位		No Matches Found
-Restaurant	点菜	點菜	diǎn cài	diǎn cài	A la carte	to order dishes (in a restaurant)	to order dishes (in a restaurant)		No Matches Found
-Restaurant	买单	買單	mǎi dān	mǎi dān	Pay	to pay the restaurant bill	to pay the restaurant bill		No Matches Found
-Restaurant	订位	訂位	dìng wèi	dìng wèi	booking	to reserve a seat / to book a table / reservation	to reserve a seat / to book a table / reservation		No Matches Found
+Restaurant	服务员	服務員	fú wù yuán	fú wù yuán	Waiter	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位	waiter / waitress / attendant / customer service personnel / CL: 個｜个, 位		
+Restaurant	点菜	點菜	diǎn cài	diǎn cài	A la carte	to order dishes (in a restaurant)	to order dishes (in a restaurant)		
+Restaurant	买单	買單	mǎi dān	mǎi dān	Pay	to pay the restaurant bill	to pay the restaurant bill		
+Restaurant	订位	訂位	dìng wèi	dìng wèi	booking	to reserve a seat / to book a table / reservation	to reserve a seat / to book a table / reservation		
 Restaurant	服		fú   fù	fú   fù	clothes	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]	clothes / dress / garment / to serve (in the military, a prison sentence etc) / to obey / to be convinced (by an argument) / to convince / to admire / to acclimatize / to take (medicine) / mourning clothes / to wear mourning clothes  dose (measure word for medicine) / Taiwan pr. [fu2]		服务员 (Restaurant), 服 (Restaurant), 衣服 (Shopping 1), 舒服 (Health 2)
 Restaurant	务	務	wù	wù	Business	affair / business / matter / to be engaged in / to attend to / by all means	affair / business / matter / to be engaged in / to attend to / by all means		服务员 (Restaurant), 务 (Restaurant)
 Restaurant	员	員	yuán	yuán	member	person / employee / member	person / employee / member		服务员 (Restaurant), 员 (Restaurant)
 Restaurant	订	訂	dìng	dìng	Order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order	to agree / to conclude / to draw up / to subscribe to (a newspaper etc) / to order		订位 (Restaurant), 订 (Restaurant), 订房 (Travel 3), 订 (Travel 3)
-Supermarket	些		xiē	xiē	some	some / few / several / measure word indicating a small amount or small number (greater than 1)	some / few / several / measure word indicating a small amount or small number (greater than 1)		No Matches Found
+Supermarket	些		xiē	xiē	some	some / few / several / measure word indicating a small amount or small number (greater than 1)	some / few / several / measure word indicating a small amount or small number (greater than 1)		
 Supermarket	西		Xī   xī	Xī   xī	WEAT	the West / abbr. for Spain 西班牙 / Spanish  west	the West / abbr. for Spain 西班牙 / Spanish  west		西 (Supermarket), 东西 (Supermarket), 西瓜 (Supermarket), 西班牙 (Hobbies 2), 西 (Hobbies 2), 西班牙语 (Hobbies 2), 西边 (Location 6), 西安 (Culture)
 Supermarket	东	東	Dōng   dōng	Dōng   dōng	east	surname Dong  east / host (i.e. sitting on east side of guest) / landlord	surname Dong  east / host (i.e. sitting on east side of guest) / landlord		东 (Supermarket), 东西 (Supermarket), 东边 (Location 6)
-Supermarket	东西	東西	dōng xī   dōng xi	dōng xī   dōng xi	thing	east and west  thing / stuff / person / CL: 個｜个, 件	east and west  thing / stuff / person / CL: 個｜个, 件		No Matches Found
-Supermarket	超市		chāo shì	chāo shì	Supermarket	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	supermarket / abbr. for 超級市場｜超级市场 / CL: 家		No Matches Found
-Supermarket	水果		shuǐ guǒ	shuǐ guǒ	fruit	fruit / CL: 個｜个	fruit / CL: 個｜个		No Matches Found
+Supermarket	东西	東西	dōng xī   dōng xi	dōng xī   dōng xi	thing	east and west  thing / stuff / person / CL: 個｜个, 件	east and west  thing / stuff / person / CL: 個｜个, 件		
+Supermarket	超市		chāo shì	chāo shì	Supermarket	supermarket / abbr. for 超級市場｜超级市场 / CL: 家	supermarket / abbr. for 超級市場｜超级市场 / CL: 家		
+Supermarket	水果		shuǐ guǒ	shuǐ guǒ	fruit	fruit / CL: 個｜个	fruit / CL: 個｜个		
 Supermarket	超		chāo	chāo	super	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-	to exceed / to overtake / to surpass / to transcend / to pass / to cross / ultra- / super-		超市 (Supermarket), 超 (Supermarket)
 Supermarket	市		shì	shì	city	market / city / CL: 個｜个	market / city / CL: 個｜个		超市 (Supermarket), 市 (Supermarket), 市 (Location 5), 城市 (Location 5)
 Supermarket	果		guǒ	guǒ	fruit	fruit / result / resolute / indeed / if really	fruit / result / resolute / indeed / if really		水果 (Supermarket), 果 (Supermarket), 苹果 (Supermarket), 果汁 (Dining 2), 如果 (Weather)
 Supermarket	给	給	gěi   jǐ	gěi   jǐ	give	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide	to / for / for the benefit of / to give / to allow / to do sth (for sb) / (grammatical equivalent of 被) / (grammatical equivalent of 把) / (sentence intensifier)  to supply / to provide		给 (Supermarket), 给 (Invitiation 1)
-Supermarket	苹果	蘋果	píng guǒ	píng guǒ	apple	apple / CL: 個｜个, 顆｜颗	apple / CL: 個｜个, 顆｜颗		No Matches Found
-Supermarket	西瓜		xī guā	xī guā	watermelon	watermelon / CL: 顆｜颗, 粒, 個｜个	watermelon / CL: 顆｜颗, 粒, 個｜个		No Matches Found
+Supermarket	苹果	蘋果	píng guǒ	píng guǒ	apple	apple / CL: 個｜个, 顆｜颗	apple / CL: 個｜个, 顆｜颗		
+Supermarket	西瓜		xī guā	xī guā	watermelon	watermelon / CL: 顆｜颗, 粒, 個｜个	watermelon / CL: 顆｜颗, 粒, 個｜个		
 Supermarket	苹		píng   pín   píng	píng   pín   píng	apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple	(artemisia) / duckweed  marsiliaceae / clover fern  apple		苹果 (Supermarket), 苹 (Supermarket)
 Supermarket	瓜		guā	guā	melon	melon / gourd / squash	melon / gourd / squash		西瓜 (Supermarket), 瓜 (Supermarket)
-Supermarket	鸡蛋	雞蛋	jī dàn	jī dàn	egg	(chicken) egg / hen's egg / CL: 個｜个, 打	(chicken) egg / hen's egg / CL: 個｜个, 打		No Matches Found
-Supermarket	新鲜	新鮮	xīn xiān	xīn xiān	fresh	fresh (experience, food etc) / freshness / novel / uncommon	fresh (experience, food etc) / freshness / novel / uncommon		No Matches Found
+Supermarket	鸡蛋	雞蛋	jī dàn	jī dàn	egg	(chicken) egg / hen's egg / CL: 個｜个, 打	(chicken) egg / hen's egg / CL: 個｜个, 打		
+Supermarket	新鲜	新鮮	xīn xiān	xīn xiān	fresh	fresh (experience, food etc) / freshness / novel / uncommon	fresh (experience, food etc) / freshness / novel / uncommon		
 Supermarket	鸡	雞	jī	jī	Chicken	fowl / chicken / CL: 隻｜只 / (slang) prostitute	fowl / chicken / CL: 隻｜只 / (slang) prostitute		鸡蛋 (Supermarket), 鸡 (Supermarket), 鸡肉 (Dining 1), 宫保鸡丁 (Gourmet 2)
 Supermarket	蛋		dàn	dàn	egg	egg / CL: 個｜个, 打 / oval-shaped thing	egg / CL: 個｜个, 打 / oval-shaped thing		鸡蛋 (Supermarket), 蛋 (Supermarket), 蛋糕 (Dining 2)
 Supermarket	鲜	鮮	xiān   xiǎn   xiān	xiān   xiǎn   xiān	fresh	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜	fresh / bright (in color) / delicious / tasty / delicacy / aquatic foods  few / rare  fish / old variant of 鮮｜鲜		新鲜 (Supermarket), 鲜 (Supermarket)
-Supermarket	蔬菜		shū cài	shū cài	vegetables	vegetables / produce / CL: 種｜种	vegetables / produce / CL: 種｜种		No Matches Found
+Supermarket	蔬菜		shū cài	shū cài	vegetables	vegetables / produce / CL: 種｜种	vegetables / produce / CL: 種｜种		
 Supermarket	蔬		shū	shū	vegetable	vegetables	vegetables		蔬菜 (Supermarket), 蔬 (Supermarket)
 Supermarket	包		Bāo   bāo	Bāo   bāo	package	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只	surname Bao  to cover / to wrap / to hold / to include / to take charge of / to contract (to or for) / package / wrapper / container / bag / to hold or embrace / bundle / packet / CL: 個｜个, 隻｜只		包 (Supermarket), 面包 (Supermarket), 小笼包 (Gourmet 1), 包子 (Gourmet 1), 红包 (Festivals)
 Supermarket	米		Mǐ   mǐ	Mǐ   mǐ	Meter	surname Mi  rice / CL: 粒 / meter (classifier)	surname Mi  rice / CL: 粒 / meter (classifier)		米 (Supermarket), 米饭 (Dining 1)
-Supermarket	面包	麵包	miàn bāo	miàn bāo	bread	bread / CL: 片, 袋, 塊｜块	bread / CL: 片, 袋, 塊｜块		No Matches Found
+Supermarket	面包	麵包	miàn bāo	miàn bāo	bread	bread / CL: 片, 袋, 塊｜块	bread / CL: 片, 袋, 塊｜块		
 Supermarket	袋		dài	dài	bag	pouch / bag / sack / pocket	pouch / bag / sack / pocket		袋 (Supermarket), 袋子 (Shopping 4)
-Supermarket	糖		táng	táng	sugar	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	sugar / sweets / candy / CL: 顆｜颗, 塊｜块		No Matches Found
+Supermarket	糖		táng	táng	sugar	sugar / sweets / candy / CL: 顆｜颗, 塊｜块	sugar / sweets / candy / CL: 顆｜颗, 塊｜块		
 Hobbies 2	为	為	wéi   wèi	wéi   wèi	for	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to	as (in the capacity of) / to take sth as / to act as / to serve as / to behave as / to become / to be / to do / by (in the passive voice)  because of / for / to		为 (Hobbies 2), 为什么 (Hobbies 2), 因为 (Hobbies 2), 为了 (Hobbies 3), 为 (Exam), 认为 (Work 2), 为 (Work 2)
 Hobbies 2	习	習	Xí   xí	Xí   xí	Study	surname Xi  to practice / to study / habit	surname Xi  to practice / to study / habit		习 (Hobbies 2), 学习 (Hobbies 2), 练习 (Sports 2), 习惯 (Daily Routine 2), 复习 (Exam)
-Hobbies 2	学习	學習	xué xí	xué xí	Learn	to learn / to study	to learn / to study		No Matches Found
-Hobbies 2	中文		Zhōng wén	Zhōng wén	Chinese	Chinese language	Chinese language		No Matches Found
-Hobbies 2	为什么	為什麼	wèi shén me	wèi shén me	why	why? / for what reason?	why? / for what reason?		No Matches Found
-Hobbies 2	因为	因為	yīn wèi	yīn wèi	because	because / owing to / on account of	because / owing to / on account of		No Matches Found
-Hobbies 2	所以		suǒ yǐ	suǒ yǐ	and so	therefore / as a result / so / the reason why	therefore / as a result / so / the reason why		No Matches Found
+Hobbies 2	学习	學習	xué xí	xué xí	Learn	to learn / to study	to learn / to study		
+Hobbies 2	中文		Zhōng wén	Zhōng wén	Chinese	Chinese language	Chinese language		
+Hobbies 2	为什么	為什麼	wèi shén me	wèi shén me	why	why? / for what reason?	why? / for what reason?		
+Hobbies 2	因为	因為	yīn wèi	yīn wèi	because	because / owing to / on account of	because / owing to / on account of		
+Hobbies 2	所以		suǒ yǐ	suǒ yǐ	and so	therefore / as a result / so / the reason why	therefore / as a result / so / the reason why		
 Hobbies 2	西班牙		Xī bān yá	Xī bān yá	Spain	Spain	Spain		西班牙 (Hobbies 2), 西班牙语 (Hobbies 2)
 Hobbies 2	因		yīn	yīn	because	cause / reason / because	cause / reason / because		因为 (Hobbies 2), 因 (Hobbies 2)
 Hobbies 2	所		suǒ	suǒ	The	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个	actually / place / classifier for houses, small buildings, institutions etc / that which / particle introducing a relative clause or passive / CL: 個｜个		所以 (Hobbies 2), 所 (Hobbies 2), 厕所 (House)
 Hobbies 2	以		Yǐ   yǐ	Yǐ   yǐ	With	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)	abbr. for Israel 以色列  to use / by means of / according to / in order to / because of / at (a certain date or place)		所以 (Hobbies 2), 以 (Hobbies 2), 可以 (Transportation), 以后 (Daily Routine 2), 以前 (Daily Routine 2)
 Hobbies 2	牙		yá	yá	tooth	tooth / ivory / CL: 顆｜颗	tooth / ivory / CL: 顆｜颗		西班牙 (Hobbies 2), 牙 (Hobbies 2), 西班牙语 (Hobbies 2), 牙 (Daily Routine 2), 刷牙 (Daily Routine 2)
-Hobbies 2	旅游	旅遊	lǚ yóu	lǚ yóu	tourism	trip / journey / tourism / travel / tour / to travel	trip / journey / tourism / travel / tour / to travel		No Matches Found
-Hobbies 2	爱好	愛好	ài hào	ài hào	Hobby	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个		No Matches Found
-Hobbies 2	西班牙语	西班牙語	Xī bān yá yǔ	Xī bān yá yǔ	Spanish	Spanish language	Spanish language		No Matches Found
-Hobbies 2	轻松	輕鬆	qīng sōng	qīng sōng	Relaxed	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously		No Matches Found
+Hobbies 2	旅游	旅遊	lǚ yóu	lǚ yóu	tourism	trip / journey / tourism / travel / tour / to travel	trip / journey / tourism / travel / tour / to travel		
+Hobbies 2	爱好	愛好	ài hào	ài hào	Hobby	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个	to like / to take pleasure in / keen on / fond of / interest / hobby / appetite for / CL: 個｜个		
+Hobbies 2	西班牙语	西班牙語	Xī bān yá yǔ	Xī bān yá yǔ	Spanish	Spanish language	Spanish language		
+Hobbies 2	轻松	輕鬆	qīng sōng	qīng sōng	Relaxed	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously	light / gentle / relaxed / effortless / uncomplicated / to relax / to take things less seriously		
 Hobbies 2	旅		lǚ	lǚ	trip	trip / travel / to travel / brigade (army)	trip / travel / to travel / brigade (army)		旅游 (Hobbies 2), 旅 (Hobbies 2)
 Hobbies 2	轻	輕	qīng	qīng	light	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage	light / easy / gentle / soft / reckless / unimportant / frivolous / small in number / unstressed / neutral / to disparage		轻松 (Hobbies 2), 轻 (Hobbies 2), 轻 (People 3), 年轻 (People 3)
 Hobbies 2	松		Sōng   sōng   sōng	Sōng   sōng   sōng	loose	surname Song  pine / CL: 棵  loose / to loosen / to relax	surname Song  pine / CL: 棵  loose / to loosen / to relax		轻松 (Hobbies 2), 松 (Hobbies 2), 放松 (Exam), 松 (Exam)
-Hobbies 2	照相机	照相機	zhào xiàng jī	zhào xiàng jī	camera	camera / CL: 個｜个, 架, 部, 台, 隻｜只	camera / CL: 個｜个, 架, 部, 台, 隻｜只		No Matches Found
-Hobbies 2	印度		Yìn dù	Yìn dù	India	India	India		No Matches Found
-Hobbies 2	拍照		pāi zhào	pāi zhào	Photograph	to take a picture	to take a picture		No Matches Found
+Hobbies 2	照相机	照相機	zhào xiàng jī	zhào xiàng jī	camera	camera / CL: 個｜个, 架, 部, 台, 隻｜只	camera / CL: 個｜个, 架, 部, 台, 隻｜只		
+Hobbies 2	印度		Yìn dù	Yìn dù	India	India	India		
+Hobbies 2	拍照		pāi zhào	pāi zhào	Photograph	to take a picture	to take a picture		
 Hobbies 2	拍		pāi	pāi	beat	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)	to pat / to clap / to slap / to swat / to take (a photo) / to shoot (a film) / racket (sports) / beat (music)		拍照 (Hobbies 2), 拍 (Hobbies 2), 自拍 (Internet Slang)
 Hobbies 2	照		zhào	zhào	Photo	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before	according to / in accordance with / to shine / to illuminate / to reflect / to look at (one's reflection) / to take (a photo) / photo / as requested / as before		照相机 (Hobbies 2), 拍照 (Hobbies 2), 照 (Hobbies 2), 照片 (Existence), 照 (Travel 2), 护照 (Travel 2), 照 (Health 3), 照顾 (Health 3)
 Hobbies 2	印		Yìn   yìn	Yìn   yìn	Print	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image	surname Yin / abbr. for 印度  to print / to mark / to engrave / a seal / a print / a stamp / a mark / a trace / image		印度 (Hobbies 2), 印 (Hobbies 2)
@@ -455,39 +455,39 @@ Hobbies 2	度		dù   duó	dù   duó	degree	to pass / to spend (time) / measure 
 Dining 1	海		Hǎi   hǎi	Hǎi   hǎi	sea	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous	surname Hai  ocean / sea / CL: 個｜个, 片 / great number of people or things / (dialect) numerous		海 (Dining 1), 上海 (Dining 1), 海关 (Travel 2), 海边 (Travel 4)
 Dining 1	本		běn	běn	this	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc	root / stem / origin / source / this / the current / original / inherent / originally / classifier for books, periodicals, files etc		本 (Dining 1), 日本 (Dining 1), 本 (Existence), 笔记本 (School 2), 资本 (Business 1)
 Dining 1	还	還	Huán   hái   huán	Huán   hái   huán	also	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return	surname Huan  still / still in progress / still more / yet / even more / in addition / fairly / passably (good) / as early as / even / also / else  to pay back / to return		还 (Dining 1), 还是 (Dining 1), 还 (Shopping 2)
-Dining 1	上海		Shàng hǎi	Shàng hǎi	Shanghai	Shanghai municipality, central east China, abbr. to 滬｜沪	Shanghai municipality, central east China, abbr. to 滬｜沪		No Matches Found
-Dining 1	还是	還是	hái shi	hái shi	still is	or / still / nevertheless / had better	or / still / nevertheless / had better		No Matches Found
-Dining 1	日本		Rì běn	Rì běn	Japan	Japan / Japanese	Japan / Japanese		No Matches Found
+Dining 1	上海		Shàng hǎi	Shàng hǎi	Shanghai	Shanghai municipality, central east China, abbr. to 滬｜沪	Shanghai municipality, central east China, abbr. to 滬｜沪		
+Dining 1	还是	還是	hái shi	hái shi	still is	or / still / nevertheless / had better	or / still / nevertheless / had better		
+Dining 1	日本		Rì běn	Rì běn	Japan	Japan / Japanese	Japan / Japanese		
 Dining 1	肉		ròu	ròu	meat	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute	meat / flesh / pulp (of a fruit) / (coll.) (of a fruit) squashy / (of a person) flabby / irresolute		肉 (Dining 1), 鸡肉 (Dining 1), 牛肉 (Dining 1), 猪肉 (Dining 1), 羊肉 (Dining 1), 卤肉饭 (Gourmet 2)
-Dining 1	米饭	米飯	mǐ fàn	mǐ fàn	rice	(cooked) rice	(cooked) rice		No Matches Found
-Dining 1	面条	麵條	miàn tiáo	miàn tiáo	noodles	noodles	noodles		No Matches Found
-Dining 1	鸡肉	雞肉	jī ròu	jī ròu	chicken	chicken meat	chicken meat		No Matches Found
-Dining 1	牛肉		niú ròu	niú ròu	beef	beef	beef		No Matches Found
-Dining 1	猪肉	豬肉	zhū ròu	zhū ròu	pork	pork	pork		No Matches Found
-Dining 1	羊肉		yáng ròu	yáng ròu	Lamb	mutton / goat meat	mutton / goat meat		No Matches Found
-Dining 1	饮料	飲料	yǐn liào	yǐn liào	Drink	drink / beverage	drink / beverage		No Matches Found
+Dining 1	米饭	米飯	mǐ fàn	mǐ fàn	rice	(cooked) rice	(cooked) rice		
+Dining 1	面条	麵條	miàn tiáo	miàn tiáo	noodles	noodles	noodles		
+Dining 1	鸡肉	雞肉	jī ròu	jī ròu	chicken	chicken meat	chicken meat		
+Dining 1	牛肉		niú ròu	niú ròu	beef	beef	beef		
+Dining 1	猪肉	豬肉	zhū ròu	zhū ròu	pork	pork	pork		
+Dining 1	羊肉		yáng ròu	yáng ròu	Lamb	mutton / goat meat	mutton / goat meat		
+Dining 1	饮料	飲料	yǐn liào	yǐn liào	Drink	drink / beverage	drink / beverage		
 Dining 1	猪	豬	zhū	zhū	pig	hog / pig / swine / CL: 口, 頭｜头	hog / pig / swine / CL: 口, 頭｜头		猪肉 (Dining 1), 猪 (Dining 1)
 Dining 1	羊		Yáng   yáng	Yáng   yáng	sheep	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只	surname Yang  sheep / goat / CL: 頭｜头, 隻｜只		羊肉 (Dining 1), 羊 (Dining 1)
 Dining 1	饮	飲	yǐn   yìn	yǐn   yìn	drink	to drink  to give (animals) water to drink	to drink  to give (animals) water to drink		饮料 (Dining 1), 饮 (Dining 1)
 Dining 1	料		liào	liào	Fee	material / stuff / grain / feed / to expect / to anticipate / to guess	material / stuff / grain / feed / to expect / to anticipate / to guess		饮料 (Dining 1), 料 (Dining 1)
 Health 1	作		zuō   zuò	zuō   zuò	Make	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works	worker / workshop / (slang) troublesome / high-maintenance (person)  to do / to grow / to write or compose / to pretend / to regard as / to feel / writings or works		作 (Health 1), 工作 (Health 1), 作业 (School 2), 合作 (Business 2)
 Health 1	工		gōng	gōng	work	work / worker / skill / profession / trade / craft / labor	work / worker / skill / profession / trade / craft / labor		工 (Health 1), 工作 (Health 1), 工资 (Work 3)
-Health 1	累		lěi   lèi   Léi   léi	lěi   lèi   Léi   léi	tired	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around		No Matches Found
-Health 1	工作		gōng zuò	gōng zuò	jobs	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项		No Matches Found
-Health 1	觉得	覺得	jué de	jué de	feel	to think / to feel	to think / to feel		No Matches Found
-Health 1	有点儿	有點兒	yǒu diǎnr	yǒu diǎnr	kind of	slightly / a little / somewhat	slightly / a little / somewhat		No Matches Found
-Health 1	胖		pán   pàng	pán   pàng	fat	healthy / at ease  fat / plump	healthy / at ease  fat / plump		No Matches Found
-Health 1	健康		jiàn kāng	jiàn kāng	health	health / healthy	health / healthy		No Matches Found
-Health 1	不要		bù yào	bù yào	Do not	don't! / must not	don't! / must not		No Matches Found
+Health 1	累		lěi   lèi   Léi   léi	lěi   lèi   Léi   léi	tired	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around	to accumulate / to involve or implicate (Taiwan pr. [lei4]) / continuous / repeated  tired / weary / to strain / to wear out / to work hard  surname Lei  rope / to bind together / to twist around		
+Health 1	工作		gōng zuò	gōng zuò	jobs	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项	to work / (of a machine) to operate / job / work / task / CL: 個｜个, 份, 項｜项		
+Health 1	觉得	覺得	jué de	jué de	feel	to think / to feel	to think / to feel		
+Health 1	有点儿	有點兒	yǒu diǎnr	yǒu diǎnr	kind of	slightly / a little / somewhat	slightly / a little / somewhat		
+Health 1	胖		pán   pàng	pán   pàng	fat	healthy / at ease  fat / plump	healthy / at ease  fat / plump		
+Health 1	健康		jiàn kāng	jiàn kāng	health	health / healthy	health / healthy		
+Health 1	不要		bù yào	bù yào	Do not	don't! / must not	don't! / must not		
 Health 1	健		jiàn	jiàn	Healthy	healthy / to invigorate / to strengthen / to be good at / to be strong in	healthy / to invigorate / to strengthen / to be good at / to be strong in		健康 (Health 1), 健 (Health 1)
 Health 1	康		Kāng   kāng	Kāng   kāng	Kang	surname Kang  healthy / peaceful / abundant	surname Kang  healthy / peaceful / abundant		健康 (Health 1), 康 (Health 1)
-Health 1	身体	身體	shēn tǐ	shēn tǐ	body	the body / one's health / CL: 具, 個｜个 / in person	the body / one's health / CL: 具, 個｜个 / in person		No Matches Found
-Health 1	注意		zhù yì	zhù yì	note	to take note of / to pay attention to	to take note of / to pay attention to		No Matches Found
+Health 1	身体	身體	shēn tǐ	shēn tǐ	body	the body / one's health / CL: 具, 個｜个 / in person	the body / one's health / CL: 具, 個｜个 / in person		
+Health 1	注意		zhù yì	zhù yì	note	to take note of / to pay attention to	to take note of / to pay attention to		
 Health 1	身		shēn	shēn	body	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158	body / life / oneself / personally / one's morality and conduct / the main part of a structure or body / pregnant / classifier for sets of clothes: suit, twinset / Kangxi radical 158		身体 (Health 1), 身 (Health 1)
 Health 1	注		zhù   zhù	zhù   zhù	Note	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment	to inject / to pour into / to concentrate / to pay attention / stake (gambling) / classifier for sums of money / variant of 註｜注  to register / to annotate / note / comment		注意 (Health 1), 注 (Health 1), 关注 (Internet Slang)
 Health 1	意		Yì   yì	Yì   yì	meaning	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate	Italy / Italian / abbr. for 意大利  idea / meaning / thought / to think / wish / desire / intention / to expect / to anticipate		注意 (Health 1), 意 (Health 1), 意思 (Languages), 不好意思 (Invitiation 1), 意大利 (Shopping 2), 愿意 (Future), 同意 (Work 2), 满意 (Work 2), 意外 (Emergency), 生意 (Work 3), 意见 (Work 3)
-Health 1	开始	開始	kāi shǐ	kāi shǐ	Start	to begin / beginning / to start / initial / CL: 個｜个	to begin / beginning / to start / initial / CL: 個｜个		No Matches Found
-Health 1	锻炼	鍛鍊	duàn liàn	duàn liàn	work out	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself		No Matches Found
+Health 1	开始	開始	kāi shǐ	kāi shǐ	Start	to begin / beginning / to start / initial / CL: 個｜个	to begin / beginning / to start / initial / CL: 個｜个		
+Health 1	锻炼	鍛鍊	duàn liàn	duàn liàn	work out	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself	to toughen / to temper / to engage in physical exercise / to work out / (fig.) to develop one's skills / to train oneself		
 Health 1	开	開	kāi	kāi	open	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format	to open / to start / to turn on / to boil / to write out (a prescription, check, invoice etc) / to operate (a vehicle) / carat (gold) / abbr. for Kelvin, 開爾文｜开尔文 / abbr. for 開本｜开本, book format		开始 (Health 1), 开 (Health 1), 开 (Shopping 1), 开车 (Travel), 离开 (Travel 2), 开会 (Work 2)
 Health 1	锻	鍛	duàn	duàn	Wrought	to forge / to discipline / wrought	to forge / to discipline / wrought		锻炼 (Health 1), 锻 (Health 1)
 Health 1	始		shǐ	shǐ	beginning	to begin / to start / then / only then	to begin / to start / then / only then		开始 (Health 1), 始 (Health 1)
@@ -496,157 +496,157 @@ Transportation	铁	鐵	Tiě   tiě	Tiě   tiě	iron	surname Tie  iron (metal) / 
 Transportation	店		diàn	diàn	shop	inn / shop / store / CL: 家	inn / shop / store / CL: 家		店 (Transportation), 酒店 (Transportation), 商店 (Shopping 1)
 Transportation	地		de   dì	de   dì	Ground	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片	-ly / structural particle: used before a verb or adjective, linking it to preceding modifying adverbial adjunct  earth / ground / field / place / land / CL: 片		地 (Transportation), 地铁 (Transportation), 地理 (School), 地方 (Location 5), 地址 (Location 6), 地 (Personality and Feelings), 地图 (Travel 4)
 Transportation	酒		jiǔ	jiǔ	liqueur	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸	wine (esp. rice wine) / liquor / spirits / alcoholic beverage / CL: 杯, 瓶, 罐, 桶, 缸		酒 (Transportation), 酒店 (Transportation), 啤酒 (Dining 2), 酒 (Dining 3), 白酒 (Celebration), 红酒 (Celebration)
-Transportation	酒店		jiǔ diàn	jiǔ diàn	Hotels	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club		No Matches Found
-Transportation	地铁	地鐵	dì tiě	dì tiě	subway	subway / metro	subway / metro		No Matches Found
-Transportation	不准		bù zhǔn	bù zhǔn	Forbid	not to allow / to forbid / to prohibit	not to allow / to forbid / to prohibit		No Matches Found
+Transportation	酒店		jiǔ diàn	jiǔ diàn	Hotels	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club	wine shop / pub (public house) / hotel / restaurant / (Tw) hostess club		
+Transportation	地铁	地鐵	dì tiě	dì tiě	subway	subway / metro	subway / metro		
+Transportation	不准		bù zhǔn	bù zhǔn	Forbid	not to allow / to forbid / to prohibit	not to allow / to forbid / to prohibit		
 Transportation	准		zhǔn   zhǔn	zhǔn   zhǔn	quasi-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-	to allow / to grant / in accordance with / in the light of  accurate / standard / definitely / certainly / about to become (bride, son-in-law etc) / quasi- / para-		不准 (Transportation), 准 (Transportation), 准备 (School), 准 (School), 准时 (Time 4)
-Transportation	出租车	出租車	chū zū chē	chū zū chē	taxi	taxi / (Taiwan) rental car	taxi / (Taiwan) rental car		No Matches Found
-Transportation	站		zhàn	zhàn	station	station / to stand / to halt / to stop / branch of a company or organization / website	station / to stand / to halt / to stop / branch of a company or organization / website		No Matches Found
+Transportation	出租车	出租車	chū zū chē	chū zū chē	taxi	taxi / (Taiwan) rental car	taxi / (Taiwan) rental car		
+Transportation	站		zhàn	zhàn	station	station / to stand / to halt / to stop / branch of a company or organization / website	station / to stand / to halt / to stop / branch of a company or organization / website		
 Transportation	车	車	Chē   chē   jū	Chē   chē   jū	car	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)	surname Che  car / vehicle / CL: 輛｜辆 / machine / to shape with a lathe  war chariot (archaic) / rook (in Chinese chess) / rook (in chess)		出租车 (Transportation), 车 (Transportation), 汽车 (Transportation), 开车 (Travel), 火车 (Travel), 堵车 (Time 4), 自行车 (Hobbies 3), 打车 (Travel 4), 救护车 (Emergency)
 Transportation	出		chū	chū	Out	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc	to go out / to come out / to occur / to produce / to go beyond / to rise / to put forth / to happen / (used after a verb to indicate an outward direction or a positive result) / classifier for dramas, plays, operas etc		出租车 (Transportation), 出 (Transportation), 出去 (Invitiation 1), 出 (Travel 4), 出差 (Work 2)
 Transportation	租		zū	zū	rent	to hire / to rent / to charter / to rent out / to lease out / rent / land tax	to hire / to rent / to charter / to rent out / to lease out / rent / land tax		出租车 (Transportation), 租 (Transportation)
-Transportation	可以		kě yǐ	kě yǐ	can	can / may / possible / able to / not bad / pretty good	can / may / possible / able to / not bad / pretty good		No Matches Found
-Transportation	汽车	汽車	qì chē	qì chē	car	car / automobile / bus / CL: 輛｜辆	car / automobile / bus / CL: 輛｜辆		No Matches Found
-Transportation	公共		gōng gòng	gōng gòng	public	public / common / communal	public / common / communal		No Matches Found
-Transportation	船		chuán	chuán	ferry	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只		No Matches Found
+Transportation	可以		kě yǐ	kě yǐ	can	can / may / possible / able to / not bad / pretty good	can / may / possible / able to / not bad / pretty good		
+Transportation	汽车	汽車	qì chē	qì chē	car	car / automobile / bus / CL: 輛｜辆	car / automobile / bus / CL: 輛｜辆		
+Transportation	公共		gōng gòng	gōng gòng	public	public / common / communal	public / common / communal		
+Transportation	船		chuán	chuán	ferry	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只	boat / vessel / ship / CL: 條｜条, 艘, 隻｜只		
 Transportation	公		gōng	gōng	public	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)	public / collectively owned / common / international (e.g. high seas, metric system, calendar) / make public / fair / just / Duke, highest of five orders of nobility 五等爵位 / honorable (gentlemen) / father-in-law / male (animal)		公共 (Transportation), 公 (Transportation), 办公室 (Existence), 公司 (Invitation 2), 公园 (Location 5), 公斤 (Health 3)
 Transportation	汽		qì	qì	vapor	steam / vapor	steam / vapor		汽车 (Transportation), 汽 (Transportation)
 Shopping 1	件		jiàn	jiàn	Matter	item / component / classifier for events, things, clothes etc	item / component / classifier for events, things, clothes etc		件 (Shopping 1), 电子邮件 (Communication 2)
 Shopping 1	衣		yī   yì	yī   yì	clothes	clothes / CL: 件  to dress / to wear / to put on (clothes)	clothes / CL: 件  to dress / to wear / to put on (clothes)		衣 (Shopping 1), 衣服 (Shopping 1)
 Shopping 1	商		Shāng   shāng	Shāng   shāng	Business	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)	Shang Dynasty (c. 1600-1046 BC) / surname Shang  commerce / merchant / dealer / to consult / 2nd note in pentatonic scale / quotient (as in 智商, intelligence quotient)		商 (Shopping 1), 商店 (Shopping 1), 商量 (Work 3)
-Shopping 1	商店		shāng diàn	shāng diàn	store	store / shop / CL: 家, 個｜个	store / shop / CL: 家, 個｜个		No Matches Found
-Shopping 1	衣服		yī fu	yī fu	clothes	clothes / CL: 件, 套	clothes / CL: 件, 套		No Matches Found
-Shopping 1	门	門	Mén   mén	Mén   mén	door	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)		No Matches Found
-Shopping 1	欢迎	歡迎	huān yíng	huān yíng	welcome	to welcome / welcome	to welcome / welcome		No Matches Found
+Shopping 1	商店		shāng diàn	shāng diàn	store	store / shop / CL: 家, 個｜个	store / shop / CL: 家, 個｜个		
+Shopping 1	衣服		yī fu	yī fu	clothes	clothes / CL: 件, 套	clothes / CL: 件, 套		
+Shopping 1	门	門	Mén   mén	Mén   mén	door	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)	surname Men  gate / door / CL: 扇 / gateway / doorway / CL: 個｜个 / opening / valve / switch / way to do something / knack / family / house / (religious) sect / school (of thought) / class / category / phylum or division (taxonomy) / classifier for large guns / classifier for lessons, subjects, branches of technology / (suffix) -gate (i.e. scandal; derived from Watergate)		
+Shopping 1	欢迎	歡迎	huān yíng	huān yíng	welcome	to welcome / welcome	to welcome / welcome		
 Shopping 1	迎		yíng	yíng	welcome	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)	to welcome / to meet / to face / to forge ahead (esp. in the face of difficulties)		欢迎 (Shopping 1), 迎 (Shopping 1)
-Shopping 1	您		nín	nín	you	you (courteous, as opposed to informal 你)	you (courteous, as opposed to informal 你)		No Matches Found
-Shopping 1	帮忙	幫忙	bāng máng	bāng máng	help	to help / to lend a hand / to do a favor / to do a good turn	to help / to lend a hand / to do a favor / to do a good turn		No Matches Found
-Shopping 1	需要		xū yào	xū yào	need	to need / to want / to demand / to require / requirement / need	to need / to want / to demand / to require / requirement / need		No Matches Found
+Shopping 1	您		nín	nín	you	you (courteous, as opposed to informal 你)	you (courteous, as opposed to informal 你)		
+Shopping 1	帮忙	幫忙	bāng máng	bāng máng	help	to help / to lend a hand / to do a favor / to do a good turn	to help / to lend a hand / to do a favor / to do a good turn		
+Shopping 1	需要		xū yào	xū yào	need	to need / to want / to demand / to require / requirement / need	to need / to want / to demand / to require / requirement / need		
 Shopping 1	需		xū	xū	need	to require / to need / to want / necessity / need	to require / to need / to want / necessity / need		需要 (Shopping 1), 需 (Shopping 1)
-Shopping 1	随便	隨便	suí biàn	suí biàn	casual	as one wishes / as one pleases / at random / negligent / casual / wanton	as one wishes / as one pleases / at random / negligent / casual / wanton		No Matches Found
+Shopping 1	随便	隨便	suí biàn	suí biàn	casual	as one wishes / as one pleases / at random / negligent / casual / wanton	as one wishes / as one pleases / at random / negligent / casual / wanton		
 Shopping 1	随	隨	Suí   suí	Suí   suí	Follow	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently	surname Sui  to follow / to comply with / varying according to... / to allow / subsequently		随便 (Shopping 1), 随 (Shopping 1)
-Languages	读	讀	dòu   dú	dòu   dú	read	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音		No Matches Found
+Languages	读	讀	dòu   dú	dòu   dú	read	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音	comma / phrase marked by pause  to read / to study / reading of word (i.e. pronunciation), similar to 拼音		
 Languages	意思		yì si	yì si	meaning	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc	idea / opinion / meaning / wish / desire / interest / fun / token of appreciation, affection etc / CL: 個｜个 / to give as a small token / to do sth as a gesture of goodwill etc		意思 (Languages), 不好意思 (Invitiation 1)
-Languages	写	寫	xiě	xiě	write	to write	to write		No Matches Found
+Languages	写	寫	xiě	xiě	write	to write	to write		
 Languages	难	難	nán   nàn	nán   nàn	difficult	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold	difficult (to...) / problem / difficulty / difficult / not good  disaster / distress / to scold		难 (Languages), 难吃 (Food 3), 难过 (Personality and Feelings)
 Languages	思		sī	sī	think	to think / to consider	to think / to consider		意思 (Languages), 思 (Languages), 不好意思 (Invitiation 1)
-Time 3	秒		miǎo	miǎo	second	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly		No Matches Found
-Time 3	刻		kè	kè	engraved	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals		No Matches Found
+Time 3	秒		miǎo	miǎo	second	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly	second (unit of time) / arc second (angular measurement unit) / (coll.) instantly		
+Time 3	刻		kè	kè	engraved	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals	quarter (hour) / moment / to carve / to engrave / to cut / oppressive / classifier for short time intervals		
 Time 3	差		chā   chà   chāi	chā   chà   chāi	difference	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission	difference / discrepancy / to differ / error / to err / to make a mistake  to differ from / to fall short of / lacking / wrong / inferior  to send / to commission / messenger / mission		差 (Time 3), 时差 (Travel 4), 差 (Travel 4), 出差 (Work 2), 差 (Work 2)
-Time 3	小时	小時	xiǎo shí	xiǎo shí	hour	hour / CL: 個｜个	hour / CL: 個｜个		No Matches Found
-Time 3	分钟	分鐘	fēn zhōng	fēn zhōng	minute	minute	minute		No Matches Found
+Time 3	小时	小時	xiǎo shí	xiǎo shí	hour	hour / CL: 個｜个	hour / CL: 個｜个		
+Time 3	分钟	分鐘	fēn zhōng	fēn zhōng	minute	minute	minute		
 Time 3	小		xiǎo	xiǎo	small	small / tiny / few / young	small / tiny / few / young		小时 (Time 3), 小 (Time 3), 小费 (Dining 3), 小 (Shopping 2), 小笼包 (Gourmet 1), 小学 (People 3), 小姐 (Work), 小心 (Travel 4)
 Time 3	时	時	Shí   shí	Shí   shí	Time	surname Shi  o'clock / time / when / hour / season / period	surname Shi  o'clock / time / when / hour / season / period		小时 (Time 3), 时 (Time 3), 时间 (Invitiation 1), 时候 (Invitiation 1), 准时 (Time 4), 时差 (Travel 4)
 Time 3	钟	鍾	Zhōng   zhōng   zhōng	Zhōng   zhōng   zhōng	bell	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座	surname Zhong  handleless cup / goblet / to concentrate / variant of 鐘｜钟  clock / o'clock / time as measured in hours and minutes / bell / CL: 架, 座		分钟 (Time 3), 钟 (Time 3), 钟 (Time 3)
-Time 3	整		zhěng	zhěng	whole	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb		No Matches Found
+Time 3	整		zhěng	zhěng	whole	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb	exactly / in good order / whole / complete / entire / in order / orderly / to repair / to mend / to renovate / (coll.) to fix sb / to give sb a hard time / to mess with sb		
 Dining 2	杯		bēi	bēi	cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup	cup / trophy cup / classifier for certain containers of liquids: glass, cup		杯 (Dining 2), 杯子 (Dining 2), 干杯 (Celebration)
 Dining 2	啤		pí	pí	beer	beer	beer		啤 (Dining 2), 啤酒 (Dining 2)
 Dining 2	德		Dé   dé	Dé   dé	Morality	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind	Germany / German / abbr. for 德國｜德国  virtue / goodness / morality / ethics / kindness / favor / character / kind		德 (Dining 2), 德国 (Dining 2)
-Dining 2	德国	德國	Dé guó	Dé guó	Germany	Germany / German	Germany / German		No Matches Found
-Dining 2	啤酒		pí jiǔ	pí jiǔ	beer	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸		No Matches Found
-Dining 2	果汁		guǒ zhī	guǒ zhī	fruit juice	fruit juice	fruit juice		No Matches Found
+Dining 2	德国	德國	Dé guó	Dé guó	Germany	Germany / German	Germany / German		
+Dining 2	啤酒		pí jiǔ	pí jiǔ	beer	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸	beer (loanword) / CL: 杯, 瓶, 罐, 桶, 缸		
+Dining 2	果汁		guǒ zhī	guǒ zhī	fruit juice	fruit juice	fruit juice		
 Dining 2	汁		zhī	zhī	juice	juice	juice		果汁 (Dining 2), 汁 (Dining 2)
-Dining 2	香蕉		xiāng jiāo	xiāng jiāo	banana	banana / CL: 枝, 根, 個｜个, 把	banana / CL: 枝, 根, 個｜个, 把		No Matches Found
-Dining 2	蛋糕		dàn gāo	dàn gāo	cake	cake / CL: 塊｜块, 個｜个	cake / CL: 塊｜块, 個｜个		No Matches Found
+Dining 2	香蕉		xiāng jiāo	xiāng jiāo	banana	banana / CL: 枝, 根, 個｜个, 把	banana / CL: 枝, 根, 個｜个, 把		
+Dining 2	蛋糕		dàn gāo	dàn gāo	cake	cake / CL: 塊｜块, 個｜个	cake / CL: 塊｜块, 個｜个		
 Dining 2	蕉		jiāo   qiáo	jiāo   qiáo	banana	banana  see 蕉萃	banana  see 蕉萃		香蕉 (Dining 2), 蕉 (Dining 2)
 Dining 2	糕		gāo	gāo	cake	cake	cake		蛋糕 (Dining 2), 糕 (Dining 2)
-Dining 2	碗		wǎn	wǎn	bowl	bowl / cup / CL: 隻｜只, 個｜个	bowl / cup / CL: 隻｜只, 個｜个		No Matches Found
-Dining 2	杯子		bēi zi	bēi zi	cup	cup / glass / CL: 個｜个, 隻｜只	cup / glass / CL: 個｜个, 隻｜只		No Matches Found
-Dining 2	盘子	盤子	pán zi	pán zi	plate	tray / plate / dish / CL: 個｜个	tray / plate / dish / CL: 個｜个		No Matches Found
+Dining 2	碗		wǎn	wǎn	bowl	bowl / cup / CL: 隻｜只, 個｜个	bowl / cup / CL: 隻｜只, 個｜个		
+Dining 2	杯子		bēi zi	bēi zi	cup	cup / glass / CL: 個｜个, 隻｜只	cup / glass / CL: 個｜个, 隻｜只		
+Dining 2	盘子	盤子	pán zi	pán zi	plate	tray / plate / dish / CL: 個｜个	tray / plate / dish / CL: 個｜个		
 Dining 2	盘	盤	pán	pán	plate	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess	plate / dish / tray / board / hard drive (computing) / to build / to coil / to check / to examine / to transfer (property) / to make over / classifier for food: dish, helping / to coil / classifier for coils of wire / classifier for games of chess		盘子 (Dining 2), 盘 (Dining 2)
-Dining 2	筷子		kuài zi	kuài zi	chopsticks	chopsticks / CL: 對｜对, 根, 把, 雙｜双	chopsticks / CL: 對｜对, 根, 把, 雙｜双		No Matches Found
-Dining 2	刀		Dāo   dāo	Dāo   dāo	Knife	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs		No Matches Found
-Dining 2	叉		chā   chá   chǎ	chā   chá   chǎ	cross	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)		No Matches Found
+Dining 2	筷子		kuài zi	kuài zi	chopsticks	chopsticks / CL: 對｜对, 根, 把, 雙｜双	chopsticks / CL: 對｜对, 根, 把, 雙｜双		
+Dining 2	刀		Dāo   dāo	Dāo   dāo	Knife	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs	surname Dao  knife / blade / single-edged sword / cutlass / CL: 把 / (slang) dollar (loanword) / classifier for sets of one hundred sheets (of paper) / classifier for knife cuts or stabs		
+Dining 2	叉		chā   chá   chǎ	chā   chá   chǎ	cross	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)	fork / pitchfork / prong / pick / cross / intersect / 'X'  to cross / be stuck  to diverge / to open (as legs)		
 Dining 2	筷		kuài	kuài	chopsticks	chopstick	chopstick		筷子 (Dining 2), 筷 (Dining 2)
-Dining 2	勺子		sháo zi	sháo zi	Spoon	scoop / ladle / CL: 把	scoop / ladle / CL: 把		No Matches Found
+Dining 2	勺子		sháo zi	sháo zi	Spoon	scoop / ladle / CL: 把	scoop / ladle / CL: 把		
 Dining 2	勺		sháo	sháo	Spoon	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)	spoon / ladle / CL: 把 / abbr. for 公勺, centiliter (unit of volume)		勺子 (Dining 2), 勺 (Dining 2)
 Existence	室		Shì   shì	Shì   shì	room	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy	surname Shi  room / work unit / grave / scabbard / family or clan / one of the 28 constellations of Chinese astronomy		室 (Existence), 办公室 (Existence), 室 (School), 教室 (School)
 Existence	办	辦	bàn	bàn	do	to do / to manage / to handle / to go about / to run / to set up / to deal with	to do / to manage / to handle / to go about / to run / to set up / to deal with		办 (Existence), 办公室 (Existence), 怎么办 (Travel), 办 (Travel), 办法 (Work)
-Existence	辆	輛	liàng	liàng	Vehicles	classifier for vehicles	classifier for vehicles		No Matches Found
-Existence	办公室	辦公室	bàn gōng shì	bàn gōng shì	office	office / business premises / bureau / CL: 間｜间	office / business premises / bureau / CL: 間｜间		No Matches Found
-Existence	瓶子		píng zi	píng zi	bottle	bottle / CL: 個｜个	bottle / CL: 個｜个		No Matches Found
-Existence	照片		zhào piàn	zhào piàn	photo	photograph / picture / CL: 張｜张, 套, 幅	photograph / picture / CL: 張｜张, 套, 幅		No Matches Found
+Existence	辆	輛	liàng	liàng	Vehicles	classifier for vehicles	classifier for vehicles		
+Existence	办公室	辦公室	bàn gōng shì	bàn gōng shì	office	office / business premises / bureau / CL: 間｜间	office / business premises / bureau / CL: 間｜间		
+Existence	瓶子		píng zi	píng zi	bottle	bottle / CL: 個｜个	bottle / CL: 個｜个		
+Existence	照片		zhào piàn	zhào piàn	photo	photograph / picture / CL: 張｜张, 套, 幅	photograph / picture / CL: 張｜张, 套, 幅		
 Existence	瓶		píng	píng	bottle	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids	bottle / vase / pitcher / CL: 個｜个 / classifier for wine and liquids		瓶子 (Existence), 瓶 (Existence), 瓶 (Celebration)
 Existence	片		piān   piàn	piān   piàn	sheet	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc	disk / sheet  thin piece / flake / a slice / film / TV play / to slice / to carve thin / partial / incomplete / one-sided / classifier for slices, tablets, tract of land, area of water / classifier for CDs, movies, DVDs etc / used with numeral 一: classifier for scenario, scene, feeling, atmosphere, sound etc		照片 (Existence), 片 (Existence)
 Existence	鸟	鳥	niǎo	niǎo	bird	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam	bird / CL: 隻｜只, 群 / (dialect) to pay attention to / (intensifier) damned / goddam		鸟 (Existence), 菜鸟 (Internet Slang)
-Existence	树	樹	shù	shù	tree	tree / CL: 棵 / to cultivate / to set up	tree / CL: 棵 / to cultivate / to set up		No Matches Found
+Existence	树	樹	shù	shù	tree	tree / CL: 棵 / to cultivate / to set up	tree / CL: 棵 / to cultivate / to set up		
 Sports 1	步		Bù   bù	Bù   bù	step	surname Bu  a step / a pace / walk / march / stages in a process / situation	surname Bu  a step / a pace / walk / march / stages in a process / situation		步 (Sports 1), 跑步 (Sports 1)
 Sports 1	跑		páo   pǎo	páo   pǎo	run	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off	(of an animal) to paw (the ground)  to run / to run away / to escape / to run around (on errands etc) / (of a gas or liquid) to leak or evaporate / (verb complement) away / off		跑 (Sports 1), 跑步 (Sports 1)
 Sports 1	泳		yǒng	yǒng	swimming	swimming / to swim	swimming / to swim		泳 (Sports 1), 游泳 (Sports 1)
-Sports 1	游泳		yóu yǒng	yóu yǒng	Swim	swimming / to swim	swimming / to swim		No Matches Found
-Sports 1	跑步		pǎo bù	pǎo bù	Run	to run / to jog / (military) to march at the double	to run / to jog / (military) to march at the double		No Matches Found
-Sports 1	踢		tī	tī	kick	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)		No Matches Found
-Sports 1	足球		zú qiú	zú qiú	football	soccer ball / a football / CL: 個｜个 / soccer / football	soccer ball / a football / CL: 個｜个 / soccer / football		No Matches Found
+Sports 1	游泳		yóu yǒng	yóu yǒng	Swim	swimming / to swim	swimming / to swim		
+Sports 1	跑步		pǎo bù	pǎo bù	Run	to run / to jog / (military) to march at the double	to run / to jog / (military) to march at the double		
+Sports 1	踢		tī	tī	kick	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)	to kick / to play (e.g. soccer) / (slang) butch (in a lesbian relationship)		
+Sports 1	足球		zú qiú	zú qiú	football	soccer ball / a football / CL: 個｜个 / soccer / football	soccer ball / a football / CL: 個｜个 / soccer / football		
 Sports 1	打		dá   dǎ	dá   dǎ	hit	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from	dozen (loanword)  to beat / to strike / to hit / to break / to type / to mix up / to build / to fight / to fetch / to make / to tie up / to issue / to shoot / to calculate / to play (a game) / since / from		打 (Sports 1), 打扮 (Invitation 2), 打折 (Shopping 4), 打算 (Future), 打扫 (House), 打车 (Travel 4)
-Sports 1	篮球	籃球	lán qiú	lán qiú	basketball	basketball / CL: 個｜个, 隻｜只	basketball / CL: 個｜个, 隻｜只		No Matches Found
+Sports 1	篮球	籃球	lán qiú	lán qiú	basketball	basketball / CL: 個｜个, 隻｜只	basketball / CL: 個｜个, 隻｜只		
 Sports 1	足		jù   zú	jù   zú	leg	excessive  foot / to be sufficient / ample	excessive  foot / to be sufficient / ample		足球 (Sports 1), 足 (Sports 1)
 Sports 1	篮	籃	lán	lán	basket	basket (receptacle) / basket (in basketball)	basket (receptacle) / basket (in basketball)		篮球 (Sports 1), 篮 (Sports 1)
 Sports 1	球		qiú	qiú	ball	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场	ball / sphere / globe / CL: 個｜个 / ball game / match / CL: 場｜场		足球 (Sports 1), 篮球 (Sports 1), 球 (Sports 1), 乒乓球 (Sports 2), 网球 (Sports 2), 排球 (Sports 2)
-Sports 1	运动	運動	yùn dòng	yùn dòng	motion	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场		No Matches Found
+Sports 1	运动	運動	yùn dòng	yùn dòng	motion	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场	to move / to exercise / sports / exercise / motion / movement / campaign / CL: 場｜场		
 Sports 1	马	馬	Mǎ   mǎ	Mǎ   mǎ	horse	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess	surname Ma / abbr. for Malaysia 馬來西亞｜马来西亚  horse / CL: 匹 / horse or cavalry piece in Chinese chess / knight in Western chess		马 (Sports 1), 马上 (Daily Routine 2), 马路 (Travel 4)
-Sports 1	骑	騎	jì   qí	jì   qí	ride	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses		No Matches Found
+Sports 1	骑	騎	jì   qí	jì   qí	ride	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses	(Taiwan) saddle horse / mounted soldier  to ride (an animal or bike) / to sit astride / classifier for saddle-horses		
 Sports 1	运	運	yùn	yùn	Transport	to move / to transport / to use / to apply / fortune / luck / fate	to move / to transport / to use / to apply / fortune / luck / fate		运动 (Sports 1), 运 (Sports 1)
 Sports 1	动	動	dòng	dòng	move	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb	(of sth) to move / to set in movement / to displace / to touch / to make use of / to stir (emotions) / to alter / abbr. for 動詞｜动词, verb		运动 (Sports 1), 动 (Sports 1), 动物 (Culture), 活动 (Travel 4)
-Invitiation 1	吧		bā   ba	bā   ba	It	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.		No Matches Found
-Invitiation 1	出去		chū qù	chū qù	Out	to go out	to go out		No Matches Found
-Invitiation 1	时间	時間	shí jiān	shí jiān	time	time / period / CL: 段	time / period / CL: 段		No Matches Found
-Invitiation 1	时候	時候	shí hou	shí hou	time	time / length of time / moment / period	time / length of time / moment / period		No Matches Found
+Invitiation 1	吧		bā   ba	bā   ba	It	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.	bar (loanword) (serving drinks, or providing Internet access etc) / to puff (on a pipe etc) / (onom.) bang / abbr. for 貼吧｜贴吧  (modal particle indicating suggestion or surmise) / ...right? / ...OK? / ...I presume.		
+Invitiation 1	出去		chū qù	chū qù	Out	to go out	to go out		
+Invitiation 1	时间	時間	shí jiān	shí jiān	time	time / period / CL: 段	time / period / CL: 段		
+Invitiation 1	时候	時候	shí hou	shí hou	time	time / length of time / moment / period	time / length of time / moment / period		
 Invitiation 1	空		kōng   kòng	kōng   kòng	air	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time	empty / air / sky / in vain  to empty / vacant / unoccupied / space / leisure / free time		空 (Invitiation 1), 空调 (House), 空 (House)
 Invitiation 1	来	來	lái	lái	Come	to come / to arrive / to come round / ever since / next	to come / to arrive / to come round / ever since / next		来 (Invitiation 1), 从来 (Weather), 越来越 (Time 4), 后来 (Languages 2), 看起来 (Personality and Feelings), 来 (Environment)
 Invitiation 1	候		hòu	hòu	Wait	to wait / to inquire after / to watch / season / climate / (old) period of five days	to wait / to inquire after / to watch / season / climate / (old) period of five days		时候 (Invitiation 1), 候 (Invitiation 1)
 Invitiation 1	过	過	Guò   guò   guo	Guò   guò   guo	Live	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)	surname Guo  to cross / to go over / to pass (time) / to celebrate (a holiday) / to live / to get along / excessively / too-  (experienced action marker)		过 (Invitiation 1), 过 (Celebration), 经过 (Shopping 4), 难过 (Personality and Feelings), 过 (Travel 4), 过去 (Communication 2)
-Invitiation 1	一起		yī qǐ	yī qǐ	together	in the same place / together / with / altogether (in total)	in the same place / together / with / altogether (in total)		No Matches Found
-Invitiation 1	不好意思		bù hǎo yì si	bù hǎo yì si	Feel embarrassed	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)		No Matches Found
-Invitiation 1	告诉	告訴	gào sù   gào su	gào sù   gào su	tell	to press charges / to file a complaint  to tell / to inform / to let know	to press charges / to file a complaint  to tell / to inform / to let know		No Matches Found
+Invitiation 1	一起		yī qǐ	yī qǐ	together	in the same place / together / with / altogether (in total)	in the same place / together / with / altogether (in total)		
+Invitiation 1	不好意思		bù hǎo yì si	bù hǎo yì si	Feel embarrassed	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)	to feel embarrassed / to find it embarrassing / to be sorry (for inconveniencing sb)		
+Invitiation 1	告诉	告訴	gào sù   gào su	gào sù   gào su	tell	to press charges / to file a complaint  to tell / to inform / to let know	to press charges / to file a complaint  to tell / to inform / to let know		
 Invitiation 1	告		gào	gào	Tell	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue	to say / to tell / to announce / to report / to denounce / to file a lawsuit / to sue		告诉 (Invitiation 1), 告 (Invitiation 1), 报告 (Business 1), 广告 (Business 1)
 Invitiation 1	诉	訴	sù	sù	Complaint	to complain / to sue / to tell	to complain / to sue / to tell		告诉 (Invitiation 1), 诉 (Invitiation 1)
-Invitiation 1	约会	約會	yuē huì	yuē huì	appointment	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet		No Matches Found
-Invitiation 1	浪漫		làng màn	làng màn	romantic	romantic	romantic		No Matches Found
+Invitiation 1	约会	約會	yuē huì	yuē huì	appointment	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet	appointment / engagement / date / CL: 次, 個｜个 / to arrange to meet		
+Invitiation 1	浪漫		làng màn	làng màn	romantic	romantic	romantic		
 Invitiation 1	浪		làng	làng	wave	wave / breaker / unrestrained / dissipated	wave / breaker / unrestrained / dissipated		浪漫 (Invitiation 1), 浪 (Invitiation 1)
 Invitiation 1	漫		màn	màn	Overflow	free / unrestrained / to inundate	free / unrestrained / to inundate		浪漫 (Invitiation 1), 漫 (Invitiation 1), 漫游 (Travel 3)
 Health 2	该	該	gāi	gāi	That	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned	should / ought to / probably / must be / to deserve / to owe / to be sb's turn to do sth / that / the above-mentioned		该 (Health 2), 应该 (Health 2)
 Health 2	病		bìng	bìng	disease	illness / CL: 場｜场 / disease / to fall ill / defect	illness / CL: 場｜场 / disease / to fall ill / defect		病 (Health 2), 生病 (Health 2)
 Health 2	舒		Shū   shū	Shū   shū	Shu	surname Shu  to stretch / to unfold / to relax / leisurely	surname Shu  to stretch / to unfold / to relax / leisurely		舒 (Health 2), 舒服 (Health 2)
 Health 2	应	應	Yìng   yīng   yìng	Yìng   yīng   yìng	should	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with	surname Ying  to agree (to do sth) / should / ought to / must / (legal) shall  to answer / to respond / to comply with / to deal or cope with		应 (Health 2), 应该 (Health 2), 应用 (Languages 3), 应 (Languages 3)
-Health 2	生病		shēng bìng	shēng bìng	sick	to fall ill	to fall ill		No Matches Found
-Health 2	应该	應該	yīng gāi	yīng gāi	should	ought to / should / must	ought to / should / must		No Matches Found
-Health 2	舒服		shū fu	shū fu	Comfortably	comfortable / feeling well	comfortable / feeling well		No Matches Found
-Health 2	疼		téng	téng	pain	(it) hurts / sore / to love dearly	(it) hurts / sore / to love dearly		No Matches Found
+Health 2	生病		shēng bìng	shēng bìng	sick	to fall ill	to fall ill		
+Health 2	应该	應該	yīng gāi	yīng gāi	should	ought to / should / must	ought to / should / must		
+Health 2	舒服		shū fu	shū fu	Comfortably	comfortable / feeling well	comfortable / feeling well		
+Health 2	疼		téng	téng	pain	(it) hurts / sore / to love dearly	(it) hurts / sore / to love dearly		
 Health 2	头	頭	tóu   tou	tóu   tou	head	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns	head / hair style / the top / end / beginning or end / a stub / remnant / chief / boss / side / aspect / first / leading / classifier for pigs or livestock / CL: 個｜个  suffix for nouns		头 (Health 2), 头发 (Body Parts), 馒头 (Gourmet 2), 猫头鹰 (Duo)
-Health 2	休息		xiū xi	xiū xi	rest	rest / to rest	rest / to rest		No Matches Found
+Health 2	休息		xiū xi	xiū xi	rest	rest / to rest	rest / to rest		
 Health 2	休		Xiū   xiū	Xiū   xiū	Rest	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't	surname Xiu  to rest / to stop doing sth for a period of time / to cease / (imperative) don't		休息 (Health 2), 休 (Health 2)
 Health 2	息		xī	xī	interest	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]	breath / news / interest (on an investment or loan) / to cease / to stop / to rest / Taiwan pr. [xi2]		休息 (Health 2), 息 (Health 2)
-Health 2	肚子		dù zi	dù zi	belly	belly / abdomen / stomach / CL: 個｜个	belly / abdomen / stomach / CL: 個｜个		No Matches Found
+Health 2	肚子		dù zi	dù zi	belly	belly / abdomen / stomach / CL: 個｜个	belly / abdomen / stomach / CL: 個｜个		
 Health 2	肚		dǔ   dù	dǔ   dù	tripe	tripe  belly	tripe  belly		肚子 (Health 2), 肚 (Health 2)
-Health 2	药	葯	yào   yào	yào   yào	medicine	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison		No Matches Found
-Health 2	一定		yī dìng	yī dìng	for sure	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must		No Matches Found
-Health 2	感冒		gǎn mào	gǎn mào	cold	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand		No Matches Found
+Health 2	药	葯	yào   yào	yào   yào	medicine	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison	leaf of the iris / variant of 藥｜药  medicine / drug / substance used for a specific purpose (e.g. poisoning, explosion, fermenting) / CL: 種｜种, 服, 味 / to poison		
+Health 2	一定		yī dìng	yī dìng	for sure	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must	surely / certainly / necessarily / fixed / a certain (extent etc) / given / particular / must		
+Health 2	感冒		gǎn mào	gǎn mào	cold	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand	to catch cold / (common) cold / CL: 場｜场, 次 / (coll.) to be interested in (often used in the negative) / (Tw) to detest / can't stand		
 Health 2	感		gǎn	gǎn	sense	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~	to feel / to move / to touch / to affect / feeling / emotion / (suffix) sense of ~		感冒 (Health 2), 感 (Health 2), 感兴趣 (Hobbies 3), 感谢 (Business 2)
 Health 2	定		dìng	dìng	set	to set / to fix / to determine / to decide / to order	to set / to fix / to determine / to decide / to order		一定 (Health 2), 定 (Health 2), 决定 (Work 2), 定 (Work 2)
 Health 2	冒		Mào   mào	Mào   mào	Risk	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover	surname Mao  to emit / to give off / to send out (or up, forth) / to brave / to face / reckless / to falsely adopt (sb's identity etc) / to feign / (literary) to cover		感冒 (Health 2), 冒 (Health 2)
 Health 2	留		liú	liú	stay	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve	to leave (a message etc) / to retain / to stay / to remain / to keep / to preserve		留 (Health 2), 留学 (Future)
-Health 2	请假	請假	qǐng jià	qǐng jià	Ask for leave	to request leave of absence	to request leave of absence		No Matches Found
-Health 2	发烧	發燒	fā shāo	fā shāo	fever	to have a high temperature (from illness) / to have a fever	to have a high temperature (from illness) / to have a fever		No Matches Found
+Health 2	请假	請假	qǐng jià	qǐng jià	Ask for leave	to request leave of absence	to request leave of absence		
+Health 2	发烧	發燒	fā shāo	fā shāo	fever	to have a high temperature (from illness) / to have a fever	to have a high temperature (from illness) / to have a fever		
 Health 2	别	別	Bié   bié   biè	Bié   bié   biè	do not	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc	surname Bie  to leave / to depart / to separate / to distinguish / to classify / other / another / don't ...! / to pin / to stick (sth) in  to make sb change their ways, opinions etc		别 (Health 2), 别人 (People 2), 特别 (Hobbies 3)
 Health 2	发	發	fā   fà	fā   fà	hair	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]	to send out / to show (one's feeling) / to issue / to develop / to make a bundle of money / classifier for gunshots (rounds)  hair / Taiwan pr. [fa3]		发烧 (Health 2), 发 (Health 2), 头发 (Body Parts), 发 (Body Parts), 发现 (Travel 2), 发 (Travel 2), 发 (Communication 2), 发财 (Festivals), 转发 (Internet Slang), 发生 (Emergency)
 Health 2	假		jiǎ   jià	jiǎ   jià	false	fake / false / artificial / to borrow / if / suppose  vacation	fake / false / artificial / to borrow / if / suppose  vacation		请假 (Health 2), 假 (Health 2), 放假 (Exam), 暑假 (Exam), 寒假 (Exam)
 Health 2	烧	燒	shāo	shāo	burn	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head	to burn / to cook / to stew / to bake / to roast / to heat / to boil (tea, water etc) / fever / to run a temperature / (coll.) to let things go to one's head		发烧 (Health 2), 烧 (Health 2)
 Invitation 2	派		pài	pài	send	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie	clique / school / group / faction / to dispatch / to send / to assign / to appoint / pi (Greek letter Ππ) / the circular ratio pi = 3.1415926 / (loanword) pie		派 (Invitation 2), 派对 (Invitation 2)
 Invitation 2	能		Néng   néng	Néng   néng	can	surname Neng  can / to be able to / might possibly / ability / (physics) energy	surname Neng  can / to be able to / might possibly / ability / (physics) energy		能 (Invitation 2), 可能 (Weather)
-Invitation 2	生日		shēng rì	shēng rì	birthday	birthday / CL: 個｜个	birthday / CL: 個｜个		No Matches Found
-Invitation 2	派对	派對	pài duì	pài duì	Party	party (loanword)	party (loanword)		No Matches Found
-Invitation 2	打扮		dǎ ban	dǎ ban	dress up	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress		No Matches Found
+Invitation 2	生日		shēng rì	shēng rì	birthday	birthday / CL: 個｜个	birthday / CL: 個｜个		
+Invitation 2	派对	派對	pài duì	pài duì	Party	party (loanword)	party (loanword)		
+Invitation 2	打扮		dǎ ban	dǎ ban	dress up	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress	to decorate / to dress / to make up / to adorn / manner of dressing / style of dress		
 Invitation 2	扮		bàn	bàn	Play	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)	to disguise oneself as / to dress up / to play (a role) / to put on (an expression)		打扮 (Invitation 2), 扮 (Invitation 2)
-Invitation 2	希望		xī wàng	xī wàng	hope	to wish for / to desire / hope / CL: 個｜个	to wish for / to desire / hope / CL: 個｜个		No Matches Found
-Invitation 2	跟		gēn	gēn	with	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)		No Matches Found
+Invitation 2	希望		xī wàng	xī wàng	hope	to wish for / to desire / hope / CL: 個｜个	to wish for / to desire / hope / CL: 個｜个		
+Invitation 2	跟		gēn	gēn	with	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)	heel / to follow closely / to go with / (of a woman) to marry sb / with / compared with / to / towards / and (joining two nouns)		
 Invitation 2	希		xī	xī	hope	to hope / to admire / variant of 稀	to hope / to admire / variant of 稀		希望 (Invitation 2), 希 (Invitation 2)
 Invitation 2	望		wàng   wàng	wàng   wàng	hope	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望	full moon / to hope / to expect / to visit / to gaze (into the distance) / to look towards / towards  15th day of month (lunar calendar) / old variant of 望		希望 (Invitation 2), 望 (Invitation 2), 失望 (Sports 2)
-Invitation 2	大家		dà jiā	dà jiā	everyone	everyone / influential family / great expert	everyone / influential family / great expert		No Matches Found
-Invitation 2	公司		gōng sī	gōng sī	the company	(business) company / company / firm / corporation / incorporated / CL: 家	(business) company / company / firm / corporation / incorporated / CL: 家		No Matches Found
-Invitation 2	正在		zhèng zài	zhèng zài	Seizai	just at (that time) / right in (that place) / right in the middle of (doing sth)	just at (that time) / right in (that place) / right in the middle of (doing sth)		No Matches Found
+Invitation 2	大家		dà jiā	dà jiā	everyone	everyone / influential family / great expert	everyone / influential family / great expert		
+Invitation 2	公司		gōng sī	gōng sī	the company	(business) company / company / firm / corporation / incorporated / CL: 家	(business) company / company / firm / corporation / incorporated / CL: 家		
+Invitation 2	正在		zhèng zài	zhèng zài	Seizai	just at (that time) / right in (that place) / right in the middle of (doing sth)	just at (that time) / right in (that place) / right in the middle of (doing sth)		
 Invitation 2	正		zhēng   zhèng	zhēng   zhèng	positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive	first month of the lunar year  straight / upright / proper / main / principal / to correct / to rectify / exactly / just (at that time) / right (in that place) / (math.) positive		正在 (Invitation 2), 正 (Invitation 2)
 Invitation 2	司		Sī   sī	Sī   sī	Department	surname Si  to take charge of / to manage / department (under a ministry)	surname Si  to take charge of / to manage / department (under a ministry)		公司 (Invitation 2), 司 (Invitation 2), 司机 (Travel 4)
-Invitation 2	事情		shì qing	shì qing	thing	affair / matter / thing / business / CL: 件, 樁｜桩	affair / matter / thing / business / CL: 件, 樁｜桩		No Matches Found
+Invitation 2	事情		shì qing	shì qing	thing	affair / matter / thing / business / CL: 件, 樁｜桩	affair / matter / thing / business / CL: 件, 樁｜桩		
 Invitation 2	才		cái   cái	cái   cái	only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only	ability / talent / sb of a certain type / a capable individual / only / only then / just now  a moment ago / just now / (indicating sth happening later than expected) / (preceded by a clause of condition or reason) not until / (followed by a numerical clause) only		才 (Invitation 2), 刚才 (Communication 2)
 Invitation 2	事		shì	shì	Thing	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回	matter / thing / item / work / affair / CL: 件, 樁｜桩, 回		事情 (Invitation 2), 事 (Invitation 2), 故事 (Daily Routine 2), 同事 (Work), 事 (Emergency)
 Invitation 2	情		qíng	qíng	situation	feeling / emotion / passion / situation	feeling / emotion / passion / situation		事情 (Invitation 2), 情 (Invitation 2), 热情 (Personality and Feelings)
@@ -654,524 +654,524 @@ Dining 3	费	費	Fèi   fèi	Fèi   fèi	fee	surname Fei  to cost / to spend / f
 Dining 3	完		wán	wán	Finish	to finish / to be over / whole / complete / entire	to finish / to be over / whole / complete / entire		完 (Dining 3), 完成 (School 2)
 Dining 3	经	經	Jīng   jīng	Jīng   jīng	through	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济	surname Jing  classics / sacred book / scripture / to pass through / to undergo / to bear / to endure / warp (textile) / longitude / menstruation / channel (TCM) / abbr. for economics 經濟｜经济		经 (Dining 3), 已经 (Dining 3), 经 (Shopping 4), 经过 (Shopping 4), 经常 (Personality and Feelings), 经理 (Work)
 Dining 3	已		yǐ	yǐ	Already	already / to stop / then / afterwards	already / to stop / then / afterwards		已 (Dining 3), 已经 (Dining 3)
-Dining 3	已经	已經	yǐ jīng	yǐ jīng	already	already	already		No Matches Found
-Dining 3	小费	小費	xiǎo fèi	xiǎo fèi	tip	tip / gratuity	tip / gratuity		No Matches Found
-Dining 3	饱	飽	bǎo	bǎo	full	to eat till full / satisfied	to eat till full / satisfied		No Matches Found
-Dining 3	好吃		hǎo chī   hào chī	hǎo chī   hào chī	good to eat	tasty / delicious  to be fond of eating / to be gluttonous	tasty / delicious  to be fond of eating / to be gluttonous		No Matches Found
+Dining 3	已经	已經	yǐ jīng	yǐ jīng	already	already	already		
+Dining 3	小费	小費	xiǎo fèi	xiǎo fèi	tip	tip / gratuity	tip / gratuity		
+Dining 3	饱	飽	bǎo	bǎo	full	to eat till full / satisfied	to eat till full / satisfied		
+Dining 3	好吃		hǎo chī   hào chī	hǎo chī   hào chī	good to eat	tasty / delicious  to be fond of eating / to be gluttonous	tasty / delicious  to be fond of eating / to be gluttonous		
 Dining 3	真		zhēn	zhēn	true	really / truly / indeed / real / true / genuine	really / truly / indeed / real / true / genuine		真 (Dining 3), 认真 (Future)
-Dining 3	饿	餓	è	è	hungry	to be hungry / hungry / to starve (sb)	to be hungry / hungry / to starve (sb)		No Matches Found
-Dining 3	好喝		hǎo hē	hǎo hē	Tasty	tasty (drinks)	tasty (drinks)		No Matches Found
-Dining 3	渴		kě	kě	thirsty	thirsty	thirsty		No Matches Found
-Dining 3	巧克力		qiǎo kè lì	qiǎo kè lì	chocolate	chocolate (loanword) / CL: 塊｜块	chocolate (loanword) / CL: 塊｜块		No Matches Found
-Dining 3	味道		wèi dao	wèi dao	taste	flavor / smell / hint of	flavor / smell / hint of		No Matches Found
-Dining 3	甜点	甜點	tián diǎn	tián diǎn	dessert	dessert	dessert		No Matches Found
+Dining 3	饿	餓	è	è	hungry	to be hungry / hungry / to starve (sb)	to be hungry / hungry / to starve (sb)		
+Dining 3	好喝		hǎo hē	hǎo hē	Tasty	tasty (drinks)	tasty (drinks)		
+Dining 3	渴		kě	kě	thirsty	thirsty	thirsty		
+Dining 3	巧克力		qiǎo kè lì	qiǎo kè lì	chocolate	chocolate (loanword) / CL: 塊｜块	chocolate (loanword) / CL: 塊｜块		
+Dining 3	味道		wèi dao	wèi dao	taste	flavor / smell / hint of	flavor / smell / hint of		
+Dining 3	甜点	甜點	tián diǎn	tián diǎn	dessert	dessert	dessert		
 Dining 3	甜		tián	tián	sweet	sweet	sweet		甜点 (Dining 3), 甜 (Dining 3), 甜 (Food 3)
 Dining 3	巧		qiǎo	qiǎo	Opportunely	opportunely / coincidentally / as it happens / skillful / timely	opportunely / coincidentally / as it happens / skillful / timely		巧克力 (Dining 3), 巧 (Dining 3)
 Dining 3	克		kè   Kè   kēi	kè   Kè   kēi	Gram	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat	to be able to / to subdue / to restrain / to overcome / gram / Tibetan unit of land area, about 6 ares  Ke (c. 2000 BC), seventh of the legendary Flame Emperors, 炎帝 descended from Shennong 神農｜神农 Farmer God  to scold / to beat		巧克力 (Dining 3), 克 (Dining 3)
 Dining 3	力		Lì   lì	Lì   lì	force	surname Li  power / force / strength / ability / strenuously	surname Li  power / force / strength / ability / strenuously		巧克力 (Dining 3), 力 (Dining 3), 努力 (Languages 2), 力 (Languages 2), 压力 (Work 3)
 Shopping 2	试	試	shì	shì	test	to test / to try / experiment / examination / test	to test / to try / experiment / examination / test		试 (Shopping 2), 考试 (School), 面试 (Work 2)
-Shopping 2	蓝	藍	Lán   lán	Lán   lán	blue	surname Lan  blue / indigo plant	surname Lan  blue / indigo plant		No Matches Found
+Shopping 2	蓝	藍	Lán   lán	Lán   lán	blue	surname Lan  blue / indigo plant	surname Lan  blue / indigo plant		
 Shopping 2	条	條	tiáo	tiáo	article	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)	strip / item / article / clause (of law or treaty) / classifier for long thin things (ribbon, river, road, trousers etc)		面条 (Dining 1), 条 (Shopping 2), 油条 (Gourmet 1)
 Shopping 2	裙		qún	qún	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条		裙 (Shopping 2), 裙子 (Shopping 2)
-Shopping 2	裙子		qún zi	qún zi	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条		No Matches Found
-Shopping 2	双	雙	Shuāng   shuāng	Shuāng   shuāng	double	surname Shuang  two / double / pair / both / even (number)	surname Shuang  two / double / pair / both / even (number)		No Matches Found
-Shopping 2	鞋子		xié zi	xié zi	Shoe	shoe	shoe		No Matches Found
-Shopping 2	意大利		Yì dà lì	Yì dà lì	Italy	Italy / Italian	Italy / Italian		No Matches Found
+Shopping 2	裙子		qún zi	qún zi	skirt	skirt / CL: 條｜条	skirt / CL: 條｜条		
+Shopping 2	双	雙	Shuāng   shuāng	Shuāng   shuāng	double	surname Shuang  two / double / pair / both / even (number)	surname Shuang  two / double / pair / both / even (number)		
+Shopping 2	鞋子		xié zi	xié zi	Shoe	shoe	shoe		
+Shopping 2	意大利		Yì dà lì	Yì dà lì	Italy	Italy / Italian	Italy / Italian		
 Shopping 2	色		sè   shǎi	sè   shǎi	color	color / CL: 種｜种 / look / appearance / sex  color / dice	color / CL: 種｜种 / look / appearance / sex  color / dice		色 (Shopping 2), 颜色 (Shopping 3), 色 (Shopping 3)
 Shopping 2	鞋		xié	xié	shoe	shoe / CL: 雙｜双, 隻｜只	shoe / CL: 雙｜双, 隻｜只		鞋子 (Shopping 2), 鞋 (Shopping 2), 皮鞋 (Shopping 4)
 Shopping 2	利		Lì   lì	Lì   lì	Profit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit	surname Li  sharp / favorable / advantage / benefit / profit / interest / to do good to / to benefit		意大利 (Shopping 2), 利 (Shopping 2), 澳大利亚 (Time 4), 流利 (Languages 3), 利 (Languages 3)
 Shopping 2	比		Bǐ   bǐ   bì	Bǐ   bǐ   bì	ratio	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near	Belgium / Belgian / abbr. for 比利時｜比利时  (particle used for comparison and '-er than') / to compare / to contrast / to gesture (with hands) / ratio  to associate with / to be near		比 (Shopping 2), 比赛 (Sports 2), 比较 (People 3)
-Shopping 2	衬衫	襯衫	chèn shān	chèn shān	shirt	shirt / blouse / CL: 件	shirt / blouse / CL: 件		No Matches Found
+Shopping 2	衬衫	襯衫	chèn shān	chèn shān	shirt	shirt / blouse / CL: 件	shirt / blouse / CL: 件		
 Shopping 2	衬	襯	chèn	chèn	lining	(of garments) against the skin / to line / lining / to contrast with / to assist financially	(of garments) against the skin / to line / lining / to contrast with / to assist financially		衬衫 (Shopping 2), 衬 (Shopping 2)
 Shopping 2	衫		shān	shān	Shirt	garment / jacket with open slits in place of sleeves	garment / jacket with open slits in place of sleeves		衬衫 (Shopping 2), 衫 (Shopping 2)
-Shopping 2	裤子	褲子	kù zi	kù zi	pants	trousers / pants / CL: 條｜条	trousers / pants / CL: 條｜条		No Matches Found
-Shopping 2	好看		hǎo kàn	hǎo kàn	good looking	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated		No Matches Found
+Shopping 2	裤子	褲子	kù zi	kù zi	pants	trousers / pants / CL: 條｜条	trousers / pants / CL: 條｜条		
+Shopping 2	好看		hǎo kàn	hǎo kàn	good looking	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated	good-looking / nice-looking / good (of a movie, book, TV show etc) / embarrassed / humiliated		
 Shopping 2	裤	褲	kù	kù	pants	underpants / trousers / pants	underpants / trousers / pants		裤子 (Shopping 2), 裤 (Shopping 2)
 Shopping 2	质	質	zhì	zhì	quality	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]	character / nature / quality / plain / to pawn / pledge / hostage / to question / Taiwan pr. [zhi2]		质 (Shopping 2), 质量 (Shopping 2)
 Shopping 2	量		liáng   liàng	liáng   liàng	the amount	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word	to measure  capacity / quantity / amount / to estimate / abbr. for 量詞｜量词, classifier (in Chinese grammar) / measure word		量 (Shopping 2), 质量 (Shopping 2), 商量 (Work 3)
-Shopping 2	质量	質量	zhì liàng	zhì liàng	quality	quality / (physics) mass / CL: 個｜个	quality / (physics) mass / CL: 個｜个		No Matches Found
+Shopping 2	质量	質量	zhì liàng	zhì liàng	quality	quality / (physics) mass / CL: 個｜个	quality / (physics) mass / CL: 個｜个		
 Body Parts	朵		duǒ	duǒ	Flowers	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc	flower / earlobe / fig. item on both sides / classifier for flowers, clouds etc		朵 (Body Parts), 耳朵 (Body Parts)
 Body Parts	睛		jīng	jīng	eye	eye / eyeball	eye / eyeball		睛 (Body Parts), 眼睛 (Body Parts)
 Body Parts	绿	綠	lǜ	lǜ	green	green	green		绿 (Body Parts), 红绿灯 (Travel 4)
 Body Parts	耳		ěr	ěr	ear	ear / handle (archaeology) / and that is all (classical Chinese)	ear / handle (archaeology) / and that is all (classical Chinese)		耳 (Body Parts), 耳朵 (Body Parts)
 Body Parts	眼		yǎn	yǎn	eye	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)	eye / small hole / crux (of a matter) / CL: 隻｜只, 雙｜双 / classifier for big hollow things (wells, stoves, pots etc)		眼 (Body Parts), 眼睛 (Body Parts), 眼镜 (People 3)
-Body Parts	耳朵		ěr duo	ěr duo	ear	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)		No Matches Found
-Body Parts	眼睛		yǎn jing	yǎn jing	eye	eye / CL: 隻｜只, 雙｜双	eye / CL: 隻｜只, 雙｜双		No Matches Found
-Body Parts	头发	頭髮	tóu fa	tóu fa	hair	hair (on the head)	hair (on the head)		No Matches Found
-Body Parts	脸	臉	liǎn	liǎn	face	face / CL: 張｜张, 個｜个	face / CL: 張｜张, 個｜个		No Matches Found
-Body Parts	又		yòu	yòu	also	(once) again / also / both... and... / and yet / (used for emphasis) anyway	(once) again / also / both... and... / and yet / (used for emphasis) anyway		No Matches Found
+Body Parts	耳朵		ěr duo	ěr duo	ear	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)	ear / CL: 隻｜只, 個｜个, 對｜对 / handle (on a cup)		
+Body Parts	眼睛		yǎn jing	yǎn jing	eye	eye / CL: 隻｜只, 雙｜双	eye / CL: 隻｜只, 雙｜双		
+Body Parts	头发	頭髮	tóu fa	tóu fa	hair	hair (on the head)	hair (on the head)		
+Body Parts	脸	臉	liǎn	liǎn	face	face / CL: 張｜张, 個｜个	face / CL: 張｜张, 個｜个		
+Body Parts	又		yòu	yòu	also	(once) again / also / both... and... / and yet / (used for emphasis) anyway	(once) again / also / both... and... / and yet / (used for emphasis) anyway		
 Body Parts	黑		Hēi   hēi	Hēi   hēi	black	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)	abbr. for Heilongjiang province 黑龍江｜黑龙江  black / dark / sinister / secret / shady / illegal / to hide (sth) away / to vilify / (loanword) to hack (computing)		黑 (Body Parts), 黑板 (School 2)
-Body Parts	嘴巴		zuǐ ba	zuǐ ba	mouth	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	mouth / CL: 張｜张 / slap in the face / CL: 個｜个		No Matches Found
-Body Parts	鼻子		bí zi	bí zi	nose	nose / CL: 個｜个, 隻｜只	nose / CL: 個｜个, 隻｜只		No Matches Found
-Body Parts	脚	腳	jiǎo	jiǎo	foot	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks		No Matches Found
+Body Parts	嘴巴		zuǐ ba	zuǐ ba	mouth	mouth / CL: 張｜张 / slap in the face / CL: 個｜个	mouth / CL: 張｜张 / slap in the face / CL: 個｜个		
+Body Parts	鼻子		bí zi	bí zi	nose	nose / CL: 個｜个, 隻｜只	nose / CL: 個｜个, 隻｜只		
+Body Parts	脚	腳	jiǎo	jiǎo	foot	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks	foot / leg (of an animal or an object) / base (of an object) / CL: 雙｜双, 隻｜只 / classifier for kicks		
 Body Parts	嘴		zuǐ	zuǐ	mouth	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个	mouth / beak / nozzle / spout (of teapot etc) / CL: 張｜张, 個｜个		嘴巴 (Body Parts), 嘴 (Body Parts)
 Body Parts	鼻		bí	bí	nose	nose	nose		鼻子 (Body Parts), 鼻 (Body Parts)
 Body Parts	巴		Bā   bā	Bā   bā	-bar	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail	Ba state during Zhou dynasty (in east of modern Sichuan) / abbr. for east Sichuan or Chongqing / surname Ba / abbr. for Palestine or Palestinian / abbr. for Pakistan  to long for / to wish / to cling to / to stick to / sth that sticks / close to / next to / spread open / informal abbr. for bus 巴士 / bar (unit of pressure) / nominalizing suffix on certain nouns, such as 尾巴, tail		嘴巴 (Body Parts), 巴 (Body Parts)
-Travel	远	遠	yuǎn   yuàn	yuǎn   yuàn	far	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)		No Matches Found
+Travel	远	遠	yuǎn   yuàn	yuǎn   yuàn	far	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)	far / distant / remote / (intensifier in a comparison) by far / much (lower etc)  to distance oneself from (classical)		
 Travel	离		chī   Lí   lí	chī   Lí   lí	from	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲	mythical beast (archaic)  surname Li  to leave / to part from / to be away from / (in giving distances) from / without (sth) / independent of / one of the Eight Trigrams 八卦, symbolizing fire / ☲		离 (Travel), 离开 (Travel 2)
-Travel	走路		zǒu lù	zǒu lù	walk	to walk / to go on foot	to walk / to go on foot		No Matches Found
-Travel	开车	開車	kāi chē	kāi chē	Drive a car	to drive a car	to drive a car		No Matches Found
-Travel	飞机	飛機	fēi jī	fēi jī	aircraft	airplane / CL: 架	airplane / CL: 架		No Matches Found
-Travel	机场	機場	jī chǎng	jī chǎng	airport	airport / airfield / CL: 家, 處｜处	airport / airfield / CL: 家, 處｜处		No Matches Found
+Travel	走路		zǒu lù	zǒu lù	walk	to walk / to go on foot	to walk / to go on foot		
+Travel	开车	開車	kāi chē	kāi chē	Drive a car	to drive a car	to drive a car		
+Travel	飞机	飛機	fēi jī	fēi jī	aircraft	airplane / CL: 架	airplane / CL: 架		
+Travel	机场	機場	jī chǎng	jī chǎng	airport	airport / airfield / CL: 家, 處｜处	airport / airfield / CL: 家, 處｜处		
 Travel	飞	飛	fēi	fēi	fly	to fly	to fly		飞机 (Travel), 飞 (Travel), 起飞 (Travel 2)
 Travel	场	場	cháng   chǎng	cháng   chǎng	field	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams	threshing floor / classifier for events and happenings: spell, episode, bout  large place used for a specific purpose / stage / scene (of a play) / classifier for sporting or recreational activities / classifier for number of exams		机场 (Travel), 场 (Travel)
-Travel	靠		kào	kào	by	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)		No Matches Found
-Travel	停		tíng	tíng	stop	to stop / to halt / to park (a car)	to stop / to halt / to park (a car)		No Matches Found
-Travel	火车	火車	huǒ chē	huǒ chē	train	train / CL: 列, 節｜节, 班, 趟	train / CL: 列, 節｜节, 班, 趟		No Matches Found
+Travel	靠		kào	kào	by	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)	to lean against or on / to stand by the side of / to come near to / to depend on / to trust / to fuck (vulgar) / traditional military costume drama where the performers wear armor (old)		
+Travel	停		tíng	tíng	stop	to stop / to halt / to park (a car)	to stop / to halt / to park (a car)		
+Travel	火车	火車	huǒ chē	huǒ chē	train	train / CL: 列, 節｜节, 班, 趟	train / CL: 列, 節｜节, 班, 趟		
 Travel	票		piào	piào	ticket	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions	ticket / ballot / banknote / CL: 張｜张 / person held for ransom / amateur performance of Chinese opera / classifier for groups, batches, business transactions		票 (Travel), 机票 (Travel)
-Travel	机票	機票	jī piào	jī piào	Air tickets	air ticket / passenger ticket / CL: 張｜张	air ticket / passenger ticket / CL: 張｜张		No Matches Found
+Travel	机票	機票	jī piào	jī piào	Air tickets	air ticket / passenger ticket / CL: 張｜张	air ticket / passenger ticket / CL: 張｜张		
 Travel	火		Huǒ   huǒ	Huǒ   huǒ	fire	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)	surname Huo  fire / urgent / ammunition / fiery or flaming / internal heat (Chinese medicine) / hot (popular) / classifier for military units (old)		火车 (Travel), 火 (Travel), 火锅 (Gourmet 1)
-Travel	迟到	遲到	chí dào	chí dào	be late	to arrive late	to arrive late		No Matches Found
-Travel	让	讓	ràng	ràng	Let	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)		No Matches Found
-Travel	怎么办	怎麼辦	zěn me bàn	zěn me bàn	How to do	what's to be done	what's to be done		No Matches Found
+Travel	迟到	遲到	chí dào	chí dào	be late	to arrive late	to arrive late		
+Travel	让	讓	ràng	ràng	Let	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)	to yield / to permit / to let sb do sth / to have sb do sth / to make sb (feel sad etc) / by (indicates the agent in a passive clause, like 被)		
+Travel	怎么办	怎麼辦	zěn me bàn	zěn me bàn	How to do	what's to be done	what's to be done		
 Travel	迟	遲	Chí   chí	Chí   chí	late	surname Chi  late / delayed / slow	surname Chi  late / delayed / slow		迟到 (Travel), 迟 (Travel)
-Weather	冷		Lěng   lěng	Lěng   lěng	cold	surname Leng  cold	surname Leng  cold		No Matches Found
-Weather	晴		qíng	qíng	clear	clear / fine (weather)	clear / fine (weather)		No Matches Found
-Weather	天气	天氣	tiān qì	tiān qì	the weather	weather	weather		No Matches Found
-Weather	雨		yǔ   yù	yǔ   yù	rain	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet		No Matches Found
-Weather	雪		Xuě   xuě	Xuě   xuě	snow	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean		No Matches Found
-Weather	阴	陰	Yīn   yīn	Yīn   yīn	Yin	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia		No Matches Found
+Weather	冷		Lěng   lěng	Lěng   lěng	cold	surname Leng  cold	surname Leng  cold		
+Weather	晴		qíng	qíng	clear	clear / fine (weather)	clear / fine (weather)		
+Weather	天气	天氣	tiān qì	tiān qì	the weather	weather	weather		
+Weather	雨		yǔ   yù	yǔ   yù	rain	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet	rain / CL: 陣｜阵, 場｜场  to rain / (of rain, snow etc) to fall / to precipitate / to wet		
+Weather	雪		Xuě   xuě	Xuě   xuě	snow	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean	surname Xue  snow / snowfall / CL: 場｜场 / to have the appearance of snow / to wipe away, off or out / to clean		
+Weather	阴	陰	Yīn   yīn	Yīn   yīn	Yin	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia	surname Yin  overcast (weather) / cloudy / shady / Yin (the negative principle of Yin and Yang) / negative (electric.) / feminine / moon / implicit / hidden / genitalia		
 Weather	着	著	zhāo   zháo   zhe   zhuó	zhāo   zháo   zhe   zhuó	The	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply	(chess) move / trick / all right! / (dialect) to add  to touch / to come in contact with / to feel / to be affected by / to catch fire / to burn / (coll.) to fall asleep / (after a verb) hitting the mark / succeeding in  aspect particle indicating action in progress  to wear (clothes) / to contact / to use / to apply		着 (Weather), 着急 (Health 3), 着 (Health 3)
-Weather	伞	傘	sǎn   sǎn	sǎn   sǎn	umbrella	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞		No Matches Found
-Weather	带	帶	dài	dài	band	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise		No Matches Found
-Weather	外面		wài miàn	wài miàn	outside	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance		No Matches Found
-Weather	可能		kě néng	kě néng	may	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个		No Matches Found
-Weather	刮		guā   guā	guā   guā	scratch	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)		No Matches Found
+Weather	伞	傘	sǎn   sǎn	sǎn   sǎn	umbrella	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞	umbrella / parasol / CL: 把  damask silk / variant of 傘｜伞		
+Weather	带	帶	dài	dài	band	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise	band / belt / girdle / ribbon / tire / area / zone / region / CL: 條｜条 / to wear / to carry / to take along / to bear (i.e. to have) / to lead / to bring / to look after / to raise		
+Weather	外面		wài miàn	wài miàn	outside	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance	outside (also pr. [wai4 mian5] for this sense) / surface / exterior / external appearance		
+Weather	可能		kě néng	kě néng	may	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个	might (happen) / possible / probable / possibility / probability / maybe / perhaps / CL: 個｜个		
+Weather	刮		guā   guā	guā   guā	scratch	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)	to scrape / to blow / to shave / to plunder / to extort  to blow (of the wind)		
 Weather	风	風	fēng	fēng	wind	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝	wind / news / style / custom / manner / CL: 陣｜阵, 絲｜丝		风 (Weather), 风景 (Travel 4), 风险 (Business 2)
-Weather	如果		rú guǒ	rú guǒ	in case	if / in case / in the event that	if / in case / in the event that		No Matches Found
-Weather	就		jiù	jiù	on	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning		No Matches Found
-Weather	从来	從來	cóng lái	cóng lái	Never	always / at all times / never (if used in negative sentence)	always / at all times / never (if used in negative sentence)		No Matches Found
+Weather	如果		rú guǒ	rú guǒ	in case	if / in case / in the event that	if / in case / in the event that		
+Weather	就		jiù	jiù	on	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning	at once / right away / only / just (emphasis) / as early as / already / as soon as / then / in that case / as many as / even if / to approach / to move towards / to undertake / to engage in / to suffer / subjected to / to accomplish / to take advantage of / to go with (of foods) / with regard to / concerning		
+Weather	从来	從來	cóng lái	cóng lái	Never	always / at all times / never (if used in negative sentence)	always / at all times / never (if used in negative sentence)		
 Weather	如		rú	rú	Such as	as / as if / such as	as / as if / such as		如果 (Weather), 如 (Weather)
-Weather	里面	裡面	lǐ miàn	lǐ miàn	inside	inside / interior / also pr. [li3 mian5]	inside / interior / also pr. [li3 mian5]		No Matches Found
+Weather	里面	裡面	lǐ miàn	lǐ miàn	inside	inside / interior / also pr. [li3 mian5]	inside / interior / also pr. [li3 mian5]		
 Shopping 3	然		rán	rán	However	correct / right / so / thus / like this / -ly	correct / right / so / thus / like this / -ly		然 (Shopping 3), 虽然 (Shopping 3), 然后 (Location 6), 当然 (Future), 突然 (Work)
 Shopping 3	但		dàn	dàn	but	but / yet / however / only / merely / still	but / yet / however / only / merely / still		但 (Shopping 3), 但是 (Shopping 3), 不但 (People 2)
 Shopping 3	虽	雖	suī	suī	although	although / even though	although / even though		虽 (Shopping 3), 虽然 (Shopping 3)
 Shopping 3	短		duǎn	duǎn	short	short / brief / to lack / weak point / fault	short / brief / to lack / weak point / fault		短 (Shopping 3), 短信 (Communication 2)
 Shopping 3	长	長	cháng   zhǎng	cháng   zhǎng	long	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance	length / long / forever / always / constantly  chief / head / elder / to grow / to develop / to increase / to enhance		长 (Shopping 3), 长 (People 3), 校长 (School 2), 长江 (Culture), 长城 (Culture)
-Shopping 3	虽然	雖然	suī rán	suī rán	although	although / even though / even if	although / even though / even if		No Matches Found
-Shopping 3	但是		dàn shì	dàn shì	but	but / however	but / however		No Matches Found
+Shopping 3	虽然	雖然	suī rán	suī rán	although	although / even though / even if	although / even though / even if		
+Shopping 3	但是		dàn shì	dàn shì	but	but / however	but / however		
 Shopping 3	红	紅	Hóng   hóng	Hóng   hóng	red	surname Hong  red / popular / revolutionary / bonus	surname Hong  red / popular / revolutionary / bonus		红 (Shopping 3), 红酒 (Celebration), 红绿灯 (Travel 4), 红包 (Festivals)
-Shopping 3	颜色	顏色	yán sè	yán sè	colour	color / countenance / appearance / facial expression / pigment / dyestuff	color / countenance / appearance / facial expression / pigment / dyestuff		No Matches Found
-Shopping 3	穿		chuān	chuān	wear	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread		No Matches Found
+Shopping 3	颜色	顏色	yán sè	yán sè	colour	color / countenance / appearance / facial expression / pigment / dyestuff	color / countenance / appearance / facial expression / pigment / dyestuff		
+Shopping 3	穿		chuān	chuān	wear	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread	to wear / to put on / to dress / to bore through / to pierce / to perforate / to penetrate / to pass through / to thread		
 Shopping 3	颜	顏	Yán   yán	Yán   yán	Color	surname Yan  color / face / countenance	surname Yan  color / face / countenance		颜色 (Shopping 3), 颜 (Shopping 3)
 Shopping 3	黄	黃	Huáng   huáng	Huáng   huáng	yellow	surname Huang or Hwang  yellow / pornographic / to fall through	surname Huang or Hwang  yellow / pornographic / to fall through		黄 (Shopping 3), 黄河 (Culture)
-Shopping 3	手表	手錶	shǒu biǎo	shǒu biǎo	Watch	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	wrist watch / CL: 塊｜块, 隻｜只, 個｜个		No Matches Found
-Shopping 3	卖	賣	mài	mài	Sell	to sell / to betray / to spare no effort / to show off or flaunt	to sell / to betray / to spare no effort / to show off or flaunt		No Matches Found
-Shopping 3	帽子		mào zi	mào zi	hat	hat / cap / (fig.) label / bad name / CL: 頂｜顶	hat / cap / (fig.) label / bad name / CL: 頂｜顶		No Matches Found
+Shopping 3	手表	手錶	shǒu biǎo	shǒu biǎo	Watch	wrist watch / CL: 塊｜块, 隻｜只, 個｜个	wrist watch / CL: 塊｜块, 隻｜只, 個｜个		
+Shopping 3	卖	賣	mài	mài	Sell	to sell / to betray / to spare no effort / to show off or flaunt	to sell / to betray / to spare no effort / to show off or flaunt		
+Shopping 3	帽子		mào zi	mào zi	hat	hat / cap / (fig.) label / bad name / CL: 頂｜顶	hat / cap / (fig.) label / bad name / CL: 頂｜顶		
 Shopping 3	帽		mào	mào	cap	hat / cap	hat / cap		帽子 (Shopping 3), 帽 (Shopping 3)
 Shopping 3	表		biǎo   biǎo	biǎo   biǎo	table	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch	exterior surface / family relationship via females / to show (one's opinion) / a model / a table (listing information) / a form / a meter (measuring sth)  wrist or pocket watch		手表 (Shopping 3), 表 (Shopping 3), 表演 (Travel 4), 表现 (Work 2)
-Shopping 3	紫		zǐ	zǐ	purple	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki		No Matches Found
+Shopping 3	紫		zǐ	zǐ	purple	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki	purple / violet / amethyst / Lithospermum erythrorhizon (flowering plant whose root provides red purple dye) / Japanese: murasaki		
 People 2	绍	紹	Shào   shào	Shào   shào	Introduce	surname Shao  to continue / to carry on	surname Shao  to continue / to carry on		绍 (People 2), 介绍 (People 2)
 People 2	介		jiè	jiè	Introduction	to introduce / to lie between / between / shell / armor	to introduce / to lie between / between / shell / armor		介 (People 2), 介绍 (People 2)
-People 2	介绍	介紹	jiè shào	jiè shào	Introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction		No Matches Found
+People 2	介绍	介紹	jiè shào	jiè shào	Introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction	to introduce (sb to sb) / to give a presentation / to present (sb for a job etc) / introduction		
 People 2	帅	帥	Shuài   shuài	Shuài   shuài	Shuai	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!	surname Shuai  handsome / graceful / smart / commander in chief / (coll.) cool! / sweet!		帅 (People 2), 高富帅 (Internet Slang)
 People 2	笑		xiào	xiào	Lol	laugh / smile / CL: 個｜个	laugh / smile / CL: 個｜个		笑 (People 2), 好笑 (Personality and Feelings)
-People 2	说话	說話	shuō huà	shuō huà	speak	to speak / to say / to talk / to gossip / to tell stories / talk / word	to speak / to say / to talk / to gossip / to tell stories / talk / word		No Matches Found
-People 2	聪明	聰明	cōng ming	cōng ming	clever	intelligent / clever / bright / smart / acute (of sight and hearing)	intelligent / clever / bright / smart / acute (of sight and hearing)		No Matches Found
-People 2	别人	別人	bié ren	bié ren	other people	other people / others / other person	other people / others / other person		No Matches Found
-People 2	不但		bù dàn	bù dàn	Not only	not only (... but also...)	not only (... but also...)		No Matches Found
-People 2	而且		ér qiě	ér qiě	and	(not only ...) but also / moreover / in addition / furthermore	(not only ...) but also / moreover / in addition / furthermore		No Matches Found
+People 2	说话	說話	shuō huà	shuō huà	speak	to speak / to say / to talk / to gossip / to tell stories / talk / word	to speak / to say / to talk / to gossip / to tell stories / talk / word		
+People 2	聪明	聰明	cōng ming	cōng ming	clever	intelligent / clever / bright / smart / acute (of sight and hearing)	intelligent / clever / bright / smart / acute (of sight and hearing)		
+People 2	别人	別人	bié ren	bié ren	other people	other people / others / other person	other people / others / other person		
+People 2	不但		bù dàn	bù dàn	Not only	not only (... but also...)	not only (... but also...)		
+People 2	而且		ér qiě	ér qiě	and	(not only ...) but also / moreover / in addition / furthermore	(not only ...) but also / moreover / in addition / furthermore		
 People 2	聪	聰	cōng	cōng	Clever	quick at hearing / wise / clever / sharp-witted / intelligent / acute	quick at hearing / wise / clever / sharp-witted / intelligent / acute		聪明 (People 2), 聪 (People 2)
 People 2	而		ér	ér	and	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)	and / as well as / and so / but (not) / yet (not) / (indicates causal relation) / (indicates change of state) / (indicates contrast)		而且 (People 2), 而 (People 2)
 People 2	且		qiě	qiě	And	and / moreover / yet / for the time being / to be about to / both (... and...)	and / moreover / yet / for the time being / to be about to / both (... and...)		而且 (People 2), 且 (People 2)
 Celebration	春		Chūn   chūn	Chūn   chūn	spring	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life	surname Chun  spring (season) / gay / joyful / youthful / love / lust / life		春 (Celebration), 春节 (Celebration), 春 (Time 4), 春卷 (Gourmet 2)
-Celebration	快乐	快樂	kuài lè	kuài lè	happy	happy / merry	happy / merry		No Matches Found
-Celebration	节日	節日	jié rì	jié rì	festival	holiday / festival / CL: 個｜个	holiday / festival / CL: 個｜个		No Matches Found
-Celebration	春节	春節	Chūn jié	Chūn jié	Spring Festival	Spring Festival (Chinese New Year)	Spring Festival (Chinese New Year)		No Matches Found
-Celebration	礼物	禮物	lǐ wù	lǐ wù	gift	gift / present / CL: 件, 個｜个, 份	gift / present / CL: 件, 個｜个, 份		No Matches Found
-Celebration	送		sòng	sòng	give away	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send		No Matches Found
-Celebration	新年		xīn nián	xīn nián	new Year	New Year / CL: 個｜个	New Year / CL: 個｜个		No Matches Found
-Celebration	白酒		bái jiǔ	bái jiǔ	Spirit	baijiu, a spirit usually distilled from sorghum	baijiu, a spirit usually distilled from sorghum		No Matches Found
+Celebration	快乐	快樂	kuài lè	kuài lè	happy	happy / merry	happy / merry		
+Celebration	节日	節日	jié rì	jié rì	festival	holiday / festival / CL: 個｜个	holiday / festival / CL: 個｜个		
+Celebration	春节	春節	Chūn jié	Chūn jié	Spring Festival	Spring Festival (Chinese New Year)	Spring Festival (Chinese New Year)		
+Celebration	礼物	禮物	lǐ wù	lǐ wù	gift	gift / present / CL: 件, 個｜个, 份	gift / present / CL: 件, 個｜个, 份		
+Celebration	送		sòng	sòng	give away	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send	to deliver / to carry / to give (as a present) / to present (with) / to see off / to send		
+Celebration	新年		xīn nián	xīn nián	new Year	New Year / CL: 個｜个	New Year / CL: 個｜个		
+Celebration	白酒		bái jiǔ	bái jiǔ	Spirit	baijiu, a spirit usually distilled from sorghum	baijiu, a spirit usually distilled from sorghum		
 Celebration	礼	禮	Lǐ   lǐ	Lǐ   lǐ	ceremony	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy	surname Li / abbr. for 禮記｜礼记, Classic of Rites  gift / rite / ceremony / CL: 份 / propriety / etiquette / courtesy		礼物 (Celebration), 礼 (Celebration)
 Celebration	物		wù	wù	object	thing / object / matter / abbr. for physics 物理	thing / object / matter / abbr. for physics 物理		礼物 (Celebration), 物 (Celebration), 动物 (Culture), 博物馆 (Travel 4)
-Celebration	干杯	乾杯	gān bēi	gān bēi	Cheers	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup		No Matches Found
-Celebration	祝		Zhù   zhù	Zhù   zhù	wish	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	surname Zhu  to wish / to express good wishes / to pray / (old) wizard		No Matches Found
-Celebration	法国	法國	Fǎ guó	Fǎ guó	France	France / French	France / French		No Matches Found
-Celebration	红酒		hóng jiǔ	hóng jiǔ	Red wine	Red wine	Red wine		No Matches Found
+Celebration	干杯	乾杯	gān bēi	gān bēi	Cheers	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup	to drink a toast / Cheers! (proposing a toast) / Here's to you! / Bottoms up! / lit. dry cup		
+Celebration	祝		Zhù   zhù	Zhù   zhù	wish	surname Zhu  to wish / to express good wishes / to pray / (old) wizard	surname Zhu  to wish / to express good wishes / to pray / (old) wizard		
+Celebration	法国	法國	Fǎ guó	Fǎ guó	France	France / French	France / French		
+Celebration	红酒		hóng jiǔ	hóng jiǔ	Red wine	Red wine	Red wine		
 Celebration	法		Fǎ   fǎ	Fǎ   fǎ	law	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist	France / French / abbr. for 法國｜法国 / Taiwan pr. [Fa4]  law / method / way / Buddhist teaching / Legalist		法国 (Celebration), 法 (Celebration), 办法 (Work), 法 (Work), 语法 (Languages 3)
 Sports 2	赛	賽	sài	sài	Competition	to compete / competition / match / to surpass / better than / superior to / to excel	to compete / competition / match / to surpass / better than / superior to / to excel		赛 (Sports 2), 比赛 (Sports 2)
 Sports 2	练	練	liàn	liàn	practice	to practice / to train / to drill / to perfect (one's skill) / exercise	to practice / to train / to drill / to perfect (one's skill) / exercise		练 (Sports 2), 练习 (Sports 2)
-Sports 2	练习	練習	liàn xí	liàn xí	Exercise	to practice / exercise / drill / practice / CL: 個｜个	to practice / exercise / drill / practice / CL: 個｜个		No Matches Found
-Sports 2	比赛	比賽	bǐ sài	bǐ sài	game	competition (sports etc) / match / CL: 場｜场, 次 / to compete	competition (sports etc) / match / CL: 場｜场, 次 / to compete		No Matches Found
-Sports 2	好在		hǎo zài	hǎo zài	Fortunately	luckily / fortunately	luckily / fortunately		No Matches Found
-Sports 2	乒乓球		pīng pāng qiú	pīng pāng qiú	pingpong	table tennis / ping-pong / table tennis ball / CL: 個｜个	table tennis / ping-pong / table tennis ball / CL: 個｜个		No Matches Found
+Sports 2	练习	練習	liàn xí	liàn xí	Exercise	to practice / exercise / drill / practice / CL: 個｜个	to practice / exercise / drill / practice / CL: 個｜个		
+Sports 2	比赛	比賽	bǐ sài	bǐ sài	game	competition (sports etc) / match / CL: 場｜场, 次 / to compete	competition (sports etc) / match / CL: 場｜场, 次 / to compete		
+Sports 2	好在		hǎo zài	hǎo zài	Fortunately	luckily / fortunately	luckily / fortunately		
+Sports 2	乒乓球		pīng pāng qiú	pīng pāng qiú	pingpong	table tennis / ping-pong / table tennis ball / CL: 個｜个	table tennis / ping-pong / table tennis ball / CL: 個｜个		
 Sports 2	乒		pīng	pīng	Table tennis	(onom.) ping / bing	(onom.) ping / bing		乒乓球 (Sports 2), 乒 (Sports 2)
 Sports 2	乓		pāng	pāng	Bang	(onom.) bang	(onom.) bang		乒乓球 (Sports 2), 乓 (Sports 2)
-Sports 2	参加	參加	cān jiā	cān jiā	participate	to participate / to take part / to join	to participate / to take part / to join		No Matches Found
-Sports 2	第		dì	dì	The first	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just		No Matches Found
+Sports 2	参加	參加	cān jiā	cān jiā	participate	to participate / to take part / to join	to participate / to take part / to join		
+Sports 2	第		dì	dì	The first	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just	(prefix indicating ordinal number, e.g. first, number two etc) / order / (old) rank in the imperial examinations / mansion / (literary) but / just		
 Sports 2	参	參	cān   shēn	cān   shēn	Ginseng	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations	to take part in / to participate / to join / to attend / to counsel / unequal / varied / irregular / uneven / not uniform / abbr. for 參議院｜参议院 Senate, Upper House  ginseng / one of the 28 constellations		参加 (Sports 2), 参 (Sports 2), 参观 (Travel 4)
-Sports 2	网球	網球	wǎng qiú	wǎng qiú	tennis	tennis / tennis ball / CL: 個｜个	tennis / tennis ball / CL: 個｜个		No Matches Found
-Sports 2	排球		pái qiú	pái qiú	volleyball	volleyball / CL: 個｜个	volleyball / CL: 個｜个		No Matches Found
-Sports 2	加油		jiā yóu	jiā yóu	Refuel	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on		No Matches Found
+Sports 2	网球	網球	wǎng qiú	wǎng qiú	tennis	tennis / tennis ball / CL: 個｜个	tennis / tennis ball / CL: 個｜个		
+Sports 2	排球		pái qiú	pái qiú	volleyball	volleyball / CL: 個｜个	volleyball / CL: 個｜个		
+Sports 2	加油		jiā yóu	jiā yóu	Refuel	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on	to add oil / to top up with gas / to refuel / to accelerate / to step on the gas / (fig.) to make an extra effort / to cheer sb on		
 Sports 2	排		pái	pái	row	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc	a row / a line / to set in order / to arrange / to line up / to eliminate / to drain / to push open / platoon / raft / classifier for lines, rows etc		排球 (Sports 2), 排 (Sports 2), 安排 (Travel 4), 排 (Travel 4)
 Sports 2	油		yóu	yóu	oil	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning	oil / fat / grease / petroleum / to apply tung oil, paint or varnish / oily / greasy / glib / cunning		加油 (Sports 2), 油 (Sports 2), 油条 (Gourmet 1), 油 (Gourmet 1)
-Sports 2	输	輸	shū	shū	lose	to lose / to transport / to donate / to enter (a password)	to lose / to transport / to donate / to enter (a password)		No Matches Found
-Sports 2	赢	贏	yíng	yíng	win	to beat / to win / to profit	to beat / to win / to profit		No Matches Found
-Sports 2	失望		shī wàng	shī wàng	Disappointed	disappointed / to lose hope / to despair	disappointed / to lose hope / to despair		No Matches Found
-Sports 2	信心		xìn xīn	xìn xīn	confidence	confidence / faith (in sb or sth) / CL: 個｜个	confidence / faith (in sb or sth) / CL: 個｜个		No Matches Found
+Sports 2	输	輸	shū	shū	lose	to lose / to transport / to donate / to enter (a password)	to lose / to transport / to donate / to enter (a password)		
+Sports 2	赢	贏	yíng	yíng	win	to beat / to win / to profit	to beat / to win / to profit		
+Sports 2	失望		shī wàng	shī wàng	Disappointed	disappointed / to lose hope / to despair	disappointed / to lose hope / to despair		
+Sports 2	信心		xìn xīn	xìn xīn	confidence	confidence / faith (in sb or sth) / CL: 個｜个	confidence / faith (in sb or sth) / CL: 個｜个		
 Sports 2	失		shī	shī	Lose	to lose / to miss / to fail	to lose / to miss / to fail		失望 (Sports 2), 失 (Sports 2)
 Sports 2	心		xīn	xīn	heart	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个	heart / mind / intention / center / core / CL: 顆｜颗, 個｜个		信心 (Sports 2), 心 (Sports 2), 点心 (Gourmet 1), 关心 (Personality and Feelings), 放心 (Future), 担心 (Exam), 小心 (Travel 4)
 School	同	仝	tóng   tóng   tòng	tóng   tóng   tòng	with	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同	(used in given names) / variant of 同  like / same / similar / together / alike / with  see 衚衕｜胡同		同 (School), 同学 (School), 同事 (Work), 同意 (Work 2), 合同 (Business 1)
 School	课	課	kè	kè	class	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination	subject / course / CL: 門｜门 / class / lesson / CL: 堂, 節｜节 / to levy / tax / form of divination		课 (School), 下课 (School)
 School	教		Jiào   jiāo   jiào	Jiào   jiāo   jiào	teach	surname Jiao  to teach  religion / teaching / to make / to cause / to tell	surname Jiao  to teach  religion / teaching / to make / to cause / to tell		教 (School), 教室 (School), 教 (School 2)
-School	教室		jiào shì	jiào shì	Classroom	classroom / CL: 間｜间	classroom / CL: 間｜间		No Matches Found
-School	同学	同學	tóng xué	tóng xué	Classmate	to study at the same school / fellow student / classmate / CL: 位, 個｜个	to study at the same school / fellow student / classmate / CL: 位, 個｜个		No Matches Found
-School	地理		dì lǐ	dì lǐ	Geography	geography	geography		No Matches Found
+School	教室		jiào shì	jiào shì	Classroom	classroom / CL: 間｜间	classroom / CL: 間｜间		
+School	同学	同學	tóng xué	tóng xué	Classmate	to study at the same school / fellow student / classmate / CL: 位, 個｜个	to study at the same school / fellow student / classmate / CL: 位, 個｜个		
+School	地理		dì lǐ	dì lǐ	Geography	geography	geography		
 School	理		lǐ	lǐ	Reason	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up	texture / grain (of wood) / inner essence / intrinsic order / reason / logic / truth / science / natural science (esp. physics) / to manage / to pay attention to / to run (affairs) / to handle / to put in order / to tidy up		地理 (School), 理 (School), 经理 (Work)
-School	懂		dǒng	dǒng	understand	to understand / to comprehend	to understand / to comprehend		No Matches Found
-School	问题	問題	wèn tí	wèn tí	problem	question / problem / issue / topic / CL: 個｜个	question / problem / issue / topic / CL: 個｜个		No Matches Found
+School	懂		dǒng	dǒng	understand	to understand / to comprehend	to understand / to comprehend		
+School	问题	問題	wèn tí	wèn tí	problem	question / problem / issue / topic / CL: 個｜个	question / problem / issue / topic / CL: 個｜个		
 School	笔	筆	bǐ	bǐ	pen	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝	pen / pencil / writing brush / to write or compose / the strokes of Chinese characters / classifier for sums of money, deals / CL: 支, 枝		笔 (School), 笔记 (School 2), 铅笔 (School 2), 笔记本 (School 2)
 School	题	題	Tí   tí	Tí   tí	question	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道	surname Ti  topic / problem for discussion / exam question / subject / to inscribe / to mention / CL: 個｜个, 道		问题 (School), 题 (School), 题 (School)
-School	美术	美術	měi shù	měi shù	art	art / fine arts / painting / CL: 種｜种	art / fine arts / painting / CL: 種｜种		No Matches Found
+School	美术	美術	měi shù	měi shù	art	art / fine arts / painting / CL: 種｜种	art / fine arts / painting / CL: 種｜种		
 School	术	術	shù   zhú	shù   zhú	Technique	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea	method / technique  various genera of flowers of Asteracea family (daisies and chrysanthemums), including Atractylis lancea		美术 (School), 术 (School)
-School	考试	考試	kǎo shì	kǎo shì	examination	to take an exam / exam / CL: 次	to take an exam / exam / CL: 次		No Matches Found
-School	准备	準備	zhǔn bèi	zhǔn bèi	ready	preparation / to prepare / to intend / to be about to / reserve (fund)	preparation / to prepare / to intend / to be about to / reserve (fund)		No Matches Found
+School	考试	考試	kǎo shì	kǎo shì	examination	to take an exam / exam / CL: 次	to take an exam / exam / CL: 次		
+School	准备	準備	zhǔn bèi	zhǔn bèi	ready	preparation / to prepare / to intend / to be about to / reserve (fund)	preparation / to prepare / to intend / to be about to / reserve (fund)		
 School	考	攷	kǎo   kǎo	kǎo   kǎo	test	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father	to beat / to hit / variant of 考 / to inspect / to test / to take an exam  to check / to verify / to test / to examine / to take an exam / to take an entrance exam for / deceased father		考试 (School), 考 (School), 考 (Languages 2)
 School	备	備	bèi	bèi	Equipment	to prepare / get ready / to provide or equip	to prepare / get ready / to provide or equip		准备 (School), 备 (School)
-School	科学	科學	kē xué	kē xué	science	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种		No Matches Found
+School	科学	科學	kē xué	kē xué	science	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种	science / scientific knowledge / scientific / rational / CL: 門｜门, 個｜个, 種｜种		
 School	科		kē	kē	Family	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个	branch of study / administrative section / division / field / branch / stage directions / family (taxonomy) / rules / laws / to mete out (punishment) / to levy (taxes etc) / to fine sb / CL: 個｜个		科学 (School), 科 (School)
-School	下课	下課	xià kè	xià kè	Finish class	to finish class / to get out of class	to finish class / to get out of class		No Matches Found
-Family 3	爷爷	爺爺	yé ye	yé ye	grandfather	(coll.) father's father / paternal grandfather / CL: 個｜个	(coll.) father's father / paternal grandfather / CL: 個｜个		No Matches Found
-Family 3	奶奶		nǎi nai	nǎi nai	grandmother	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts		No Matches Found
-Family 3	阿姨		ā yí	ā yí	Auntie	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个		No Matches Found
+School	下课	下課	xià kè	xià kè	Finish class	to finish class / to get out of class	to finish class / to get out of class		
+Family 3	爷爷	爺爺	yé ye	yé ye	grandfather	(coll.) father's father / paternal grandfather / CL: 個｜个	(coll.) father's father / paternal grandfather / CL: 個｜个		
+Family 3	奶奶		nǎi nai	nǎi nai	grandmother	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts	(informal) grandma (paternal grandmother) / (respectful) mistress of the house / CL: 位 / (coll.) boobies / breasts		
+Family 3	阿姨		ā yí	ā yí	Auntie	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个	maternal aunt / step-mother / childcare worker / nursemaid / woman of similar age to one's parents (term of address used by child) / CL: 個｜个		
 Family 3	爷	爺	yé	yé	Father	grandpa / old gentleman	grandpa / old gentleman		爷爷 (Family 3), 爷 (Family 3)
 Family 3	阿		Ā   ā   ē	Ā   ā   ē	A	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter	abbr. for Afghanistan 阿富汗  prefix used before monosyllabic names, kinship terms etc to indicate familiarity / used in transliteration / also pr. [a4]  flatter		阿姨 (Family 3), 阿 (Family 3)
 Family 3	姨		yí	yí	aunt	mother's sister / aunt	mother's sister / aunt		阿姨 (Family 3), 姨 (Family 3)
-Family 3	兄弟姐妹		xiōng dì jiě mèi	xiōng dì jiě mèi	brothers and sisters	Brothers and Sisters	Brothers and Sisters		No Matches Found
+Family 3	兄弟姐妹		xiōng dì jiě mèi	xiōng dì jiě mèi	brothers and sisters	Brothers and Sisters	Brothers and Sisters		
 Family 3	关系	關係	guān xi	guān xi	relationship	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个	relation / relationship / to concern / to affect / to have to do with / guanxi / CL: 個｜个		没关系 (Phrases 1), 关系 (Family 3)
-Family 3	叔叔		shū shu	shū shu	uncle	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个		No Matches Found
-Family 3	父母		fù mǔ	fù mǔ	parents	father and mother / parents	father and mother / parents		No Matches Found
+Family 3	叔叔		shū shu	shū shu	uncle	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个	father's younger brother / uncle / Taiwan pr. [shu2 shu5] / CL: 個｜个		
+Family 3	父母		fù mǔ	fù mǔ	parents	father and mother / parents	father and mother / parents		
 Family 3	兄		xiōng	xiōng	Brother	elder brother	elder brother		兄弟姐妹 (Family 3), 兄 (Family 3)
 Family 3	叔		shū	shū	uncle	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]	uncle / father's younger brother / husband's younger brother / Taiwan pr. [shu2]		叔叔 (Family 3), 叔 (Family 3)
 Family 3	父		fù	fù	father	father	father		父母 (Family 3), 父 (Family 3)
 Family 3	母		mǔ	mǔ	mother	mother / elderly female relative / origin / source / (of animals) female	mother / elderly female relative / origin / source / (of animals) female		父母 (Family 3), 母 (Family 3)
-Family 3	像		xiàng	xiàng	image	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)		No Matches Found
-Family 3	一样	一樣	yī yàng	yī yàng	same	same / like / equal to / the same as / just like	same / like / equal to / the same as / just like		No Matches Found
-Family 3	亲戚	親戚	qīn qi	qīn qi	relative	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位		No Matches Found
+Family 3	像		xiàng	xiàng	image	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)	to resemble / to be like / to look as if / such as / appearance / image / portrait / image under a mapping (math.)		
+Family 3	一样	一樣	yī yàng	yī yàng	same	same / like / equal to / the same as / just like	same / like / equal to / the same as / just like		
+Family 3	亲戚	親戚	qīn qi	qīn qi	relative	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位	a relative (i.e. family relation) / CL: 門｜门, 個｜个, 位		
 Family 3	戚		Qī   qī	Qī   qī	Qi	surname Qi  relative / parent / grief / sorrow / battle-axe	surname Qi  relative / parent / grief / sorrow / battle-axe		亲戚 (Family 3), 戚 (Family 3)
 Family 3	亲	親	qīn   qìng	qīn   qìng	Dear	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring	parent / one's own (flesh and blood) / relative / related / marriage / bride / close / intimate / in person / first-hand / in favor of / pro- / to kiss / (Internet slang) dear  parents-in-law of one's offspring		亲戚 (Family 3), 亲 (Family 3)
-Gourmet 1	拉面	拉麵	lā miàn	lā miàn	Hand-Pulled Noodle	pulled noodles / ramen	pulled noodles / ramen		No Matches Found
-Gourmet 1	点心	點心	diǎn xin	diǎn xin	dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert		No Matches Found
-Gourmet 1	小笼包	小籠包	xiǎo lóng bāo	xiǎo lóng bāo	Dumplings	steamed dumpling	steamed dumpling		No Matches Found
+Gourmet 1	拉面	拉麵	lā miàn	lā miàn	Hand-Pulled Noodle	pulled noodles / ramen	pulled noodles / ramen		
+Gourmet 1	点心	點心	diǎn xin	diǎn xin	dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert	light refreshments / pastry / dimsum (in Cantonese cooking) / dessert		
+Gourmet 1	小笼包	小籠包	xiǎo lóng bāo	xiǎo lóng bāo	Dumplings	steamed dumpling	steamed dumpling		
 Gourmet 1	拉		lā	lā	Pull	to pull / to play (a bowed instrument) / to drag / to draw / to chat	to pull / to play (a bowed instrument) / to drag / to draw / to chat		拉面 (Gourmet 1), 拉 (Gourmet 1)
 Gourmet 1	笼	籠	lóng   lǒng	lóng   lǒng	cage	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]	enclosing frame made of bamboo, wire etc / cage / basket / steamer basket / to cover / to cage / to embrace / to manipulate through trickery  to cover / to cage / covering / also pr. [long2]		小笼包 (Gourmet 1), 笼 (Gourmet 1)
-Gourmet 1	粥		yù   zhōu	yù   zhōu	Gruel	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗		No Matches Found
-Gourmet 1	油条	油條	yóu tiáo	yóu tiáo	Fritters	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person		No Matches Found
-Gourmet 1	豆浆	豆漿	dòu jiāng	dòu jiāng	Milk	soy milk	soy milk		No Matches Found
+Gourmet 1	粥		yù   zhōu	yù   zhōu	Gruel	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗	see 葷粥｜荤粥  congee / gruel / porridge / CL: 碗		
+Gourmet 1	油条	油條	yóu tiáo	yóu tiáo	Fritters	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person	youtiao (deep-fried breadstick) / CL: 根 / slick and sly person		
+Gourmet 1	豆浆	豆漿	dòu jiāng	dòu jiāng	Milk	soy milk	soy milk		
 Gourmet 1	豆		dòu	dòu	beans	bean / pea / CL: 棵, 粒 / sacrificial vessel	bean / pea / CL: 棵, 粒 / sacrificial vessel		豆浆 (Gourmet 1), 豆 (Gourmet 1), 豆花 (Gourmet 2)
 Gourmet 1	浆	漿	jiāng   jiàng	jiāng   jiàng	Pulp	broth / serum / to starch  starch paste	broth / serum / to starch  starch paste		豆浆 (Gourmet 1), 浆 (Gourmet 1)
-Gourmet 1	火锅	火鍋	huǒ guō	huǒ guō	Hot Pot	hotpot	hotpot		No Matches Found
-Gourmet 1	包子		bāo zi	bāo zi	bun	steamed stuffed bun / CL: 個｜个	steamed stuffed bun / CL: 個｜个		No Matches Found
-Gourmet 1	炒饭	炒飯	chǎo fàn	chǎo fàn	Fried rice	fried rice / (slang) (Tw) to have sex	fried rice / (slang) (Tw) to have sex		No Matches Found
+Gourmet 1	火锅	火鍋	huǒ guō	huǒ guō	Hot Pot	hotpot	hotpot		
+Gourmet 1	包子		bāo zi	bāo zi	bun	steamed stuffed bun / CL: 個｜个	steamed stuffed bun / CL: 個｜个		
+Gourmet 1	炒饭	炒飯	chǎo fàn	chǎo fàn	Fried rice	fried rice / (slang) (Tw) to have sex	fried rice / (slang) (Tw) to have sex		
 Gourmet 1	锅	鍋	guō	guō	pot	pot / pan / boiler / CL: 口, 隻｜只	pot / pan / boiler / CL: 口, 隻｜只		火锅 (Gourmet 1), 锅 (Gourmet 1)
 Gourmet 1	炒		chǎo	chǎo	fry	to sauté / to stir-fry / to speculate / to hype / to fire (sb)	to sauté / to stir-fry / to speculate / to hype / to fire (sb)		炒饭 (Gourmet 1), 炒 (Gourmet 1)
-Time 4	夏		Xià   xià	Xià   xià	summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer		No Matches Found
-Time 4	冬		dōng   Dōng   dōng	dōng   Dōng   dōng	winter	winter  surname Dong  (onom.) beating a drum / rat-a-tat	winter  surname Dong  (onom.) beating a drum / rat-a-tat		No Matches Found
+Time 4	夏		Xià   xià	Xià   xià	summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer	the Xia or Hsia dynasty c. 2000 BC / Xia of the Sixteen Kingdoms (407-432) / surname Xia  summer		
+Time 4	冬		dōng   Dōng   dōng	dōng   Dōng   dōng	winter	winter  surname Dong  (onom.) beating a drum / rat-a-tat	winter  surname Dong  (onom.) beating a drum / rat-a-tat		
 Time 4	秋		Qiū   qiū   qiū	Qiū   qiū   qiū	autumn	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千	surname Qiu  autumn / fall / harvest time  see 鞦韆｜秋千		秋 (Time 4), 中秋节 (Festivals)
 Time 4	季		Jì   jì	Jì   jì	season	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields	surname Ji  season / the last month of a season / fourth or youngest amongst brothers / classifier for seasonal crop yields		季 (Time 4), 季节 (Time 4)
 Time 4	澳		Ào   ào	Ào   ào	Australia	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor	abbr. for Macao 澳門｜澳门 / abbr. for Australia 澳大利亞｜澳大利亚  deep bay / cove / harbor		澳 (Time 4), 澳大利亚 (Time 4)
 Time 4	亚	亞	yà	yà	Asia	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]	Asia / Asian / second / next to / inferior / sub- / Taiwan pr. [ya3]		亚 (Time 4), 澳大利亚 (Time 4)
-Time 4	季节	季節	jì jié	jì jié	season	time / season / period / CL: 個｜个	time / season / period / CL: 個｜个		No Matches Found
-Time 4	澳大利亚	澳大利亞	Ào dà lì yà	Ào dà lì yà	Australia	Australia	Australia		No Matches Found
-Time 4	越来越	越來越	yuè lái yuè	yuè lái yuè	More	more and more	more and more		No Matches Found
-Time 4	前天		qián tiān	qián tiān	The day before yesterday	the day before yesterday	the day before yesterday		No Matches Found
-Time 4	后天	後天	hòu tiān	hòu tiān	acquired	the day after tomorrow / acquired (not innate) / a posteriori	the day after tomorrow / acquired (not innate) / a posteriori		No Matches Found
-Time 4	堵车	堵車	dǔ chē	dǔ chē	Traffic jam	traffic jam / choking	traffic jam / choking		No Matches Found
-Time 4	大概		dà gài	dà gài	probably	roughly / probably / rough / approximate / about / general idea	roughly / probably / rough / approximate / about / general idea		No Matches Found
-Time 4	准时	準時	zhǔn shí	zhǔn shí	on time	on time / punctual / on schedule	on time / punctual / on schedule		No Matches Found
+Time 4	季节	季節	jì jié	jì jié	season	time / season / period / CL: 個｜个	time / season / period / CL: 個｜个		
+Time 4	澳大利亚	澳大利亞	Ào dà lì yà	Ào dà lì yà	Australia	Australia	Australia		
+Time 4	越来越	越來越	yuè lái yuè	yuè lái yuè	More	more and more	more and more		
+Time 4	前天		qián tiān	qián tiān	The day before yesterday	the day before yesterday	the day before yesterday		
+Time 4	后天	後天	hòu tiān	hòu tiān	acquired	the day after tomorrow / acquired (not innate) / a posteriori	the day after tomorrow / acquired (not innate) / a posteriori		
+Time 4	堵车	堵車	dǔ chē	dǔ chē	Traffic jam	traffic jam / choking	traffic jam / choking		
+Time 4	大概		dà gài	dà gài	probably	roughly / probably / rough / approximate / about / general idea	roughly / probably / rough / approximate / about / general idea		
+Time 4	准时	準時	zhǔn shí	zhǔn shí	on time	on time / punctual / on schedule	on time / punctual / on schedule		
 Time 4	刚	剛	gāng	gāng	just	hard / firm / strong / just / barely / exactly	hard / firm / strong / just / barely / exactly		刚 (Time 4), 刚才 (Communication 2)
 Time 4	堵		dǔ	dǔ	Blocking	to stop up / (to feel) stifled or suffocated / wall / classifier for walls	to stop up / (to feel) stifled or suffocated / wall / classifier for walls		堵车 (Time 4), 堵 (Time 4)
 Time 4	概		gài	gài	General	general / approximate	general / approximate		大概 (Time 4), 概 (Time 4)
 Location 5	城		chéng	chéng	city	city walls / city / town / CL: 座, 道, 個｜个	city walls / city / town / CL: 座, 道, 個｜个		城 (Location 5), 城市 (Location 5), 长城 (Culture)
 Location 5	附		fù	fù	Attached	to add / to attach / to be close to / to be attached	to add / to attach / to be close to / to be attached		附 (Location 5), 附近 (Location 5)
 Location 5	园	園	Yuán   yuán	Yuán   yuán	garden	surname Yuan  land used for growing plants / site used for public recreation	surname Yuan  land used for growing plants / site used for public recreation		园 (Location 5), 公园 (Location 5), 园 (Festivals)
-Location 5	城市		chéng shì	chéng shì	city	city / town / CL: 座	city / town / CL: 座		No Matches Found
-Location 5	附近		fù jìn	fù jìn	nearby	(in the) vicinity / nearby / neighboring / next to	(in the) vicinity / nearby / neighboring / next to		No Matches Found
-Location 5	公园	公園	gōng yuán	gōng yuán	park	park (for public recreation) / CL: 個｜个, 座	park (for public recreation) / CL: 個｜个, 座		No Matches Found
+Location 5	城市		chéng shì	chéng shì	city	city / town / CL: 座	city / town / CL: 座		
+Location 5	附近		fù jìn	fù jìn	nearby	(in the) vicinity / nearby / neighboring / next to	(in the) vicinity / nearby / neighboring / next to		
+Location 5	公园	公園	gōng yuán	gōng yuán	park	park (for public recreation) / CL: 個｜个, 座	park (for public recreation) / CL: 個｜个, 座		
 Location 5	图	圖	tú	tú	Map	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek	diagram / picture / drawing / chart / map / CL: 張｜张 / to plan / to scheme / to attempt / to pursue / to seek		图 (Location 5), 图书馆 (Location 5), 地图 (Travel 4), 美图 (Internet Slang)
 Location 5	方		Fāng   fāng	Fāng   fāng	How to	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter	surname Fang  square / power or involution (mathematics) / upright / honest / fair and square / direction / side / party (to a contract, dispute etc) / place / method / prescription (medicine) / just when / only or just / classifier for square things / abbr. for square or cubic meter		方 (Location 5), 地方 (Location 5), 北方 (Food 3), 南方 (Food 3), 方便 (Environment)
-Location 5	中间	中間	zhōng jiān	zhōng jiān	intermediate	between / intermediate / mid / middle	between / intermediate / mid / middle		No Matches Found
-Location 5	图书馆	圖書館	tú shū guǎn	tú shū guǎn	library	library / CL: 家, 個｜个	library / CL: 家, 個｜个		No Matches Found
-Location 5	地方		dì fāng   dì fang	dì fāng   dì fang	local	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块		No Matches Found
-Location 5	上面		shàng miàn	shàng miàn	On	on top of / above-mentioned / also pr. [shang4 mian5]	on top of / above-mentioned / also pr. [shang4 mian5]		No Matches Found
-Location 5	下面		xià miàn   xià miàn	xià miàn   xià miàn	below	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles		No Matches Found
-Location 5	咖啡馆	咖啡館	kā fēi guǎn	kā fēi guǎn	coffee shop	café / coffee shop / CL: 家	café / coffee shop / CL: 家		No Matches Found
+Location 5	中间	中間	zhōng jiān	zhōng jiān	intermediate	between / intermediate / mid / middle	between / intermediate / mid / middle		
+Location 5	图书馆	圖書館	tú shū guǎn	tú shū guǎn	library	library / CL: 家, 個｜个	library / CL: 家, 個｜个		
+Location 5	地方		dì fāng   dì fang	dì fāng   dì fang	local	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块	region / regional (away from the central administration) / local  area / place / space / room / territory / CL: 處｜处, 個｜个, 塊｜块		
+Location 5	上面		shàng miàn	shàng miàn	On	on top of / above-mentioned / also pr. [shang4 mian5]	on top of / above-mentioned / also pr. [shang4 mian5]		
+Location 5	下面		xià miàn   xià miàn	xià miàn   xià miàn	below	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles	below / under / next / the following / also pr. [xia4 mian5]  to boil noodles		
+Location 5	咖啡馆	咖啡館	kā fēi guǎn	kā fēi guǎn	coffee shop	café / coffee shop / CL: 家	café / coffee shop / CL: 家		
 Shopping 4	折		shé   zhē   zhé	shé   zhē   zhé	fold	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book	to break (e.g. stick or bone) / a loss  to turn sth over / to turn upside down / to tip sth out (of a container)  to break / to fracture / to snap / to suffer loss / to bend / to twist / to turn / to change direction / convinced / to convert into (currency) / discount / rebate / tenth (in price) / classifier for theatrical scenes / to fold / accounts book		折 (Shopping 4), 打折 (Shopping 4)
-Shopping 4	角		Jué   jiǎo   jué	Jué   jiǎo   jué	angle	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale		No Matches Found
+Shopping 4	角		Jué   jiǎo   jué	Jué   jiǎo   jué	angle	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale	surname Jue  angle / corner / horn / horn-shaped / unit of money equal to 0.1 yuan / CL: 個｜个  role (theater) / to compete / ancient three legged wine vessel / third note of pentatonic scale		
 Shopping 4	花		Huā   huā	Huā   huā	flower	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)	surname Hua  flower / blossom / CL: 朵, 支, 束, 把, 盆, 簇 / fancy pattern / florid / to spend (money, time)		花 (Shopping 4), 花 (Environment), 豆花 (Gourmet 2)
-Shopping 4	打折		dǎ zhé	dǎ zhé	Discount	to give a discount	to give a discount		No Matches Found
-Shopping 4	旧	舊	jiù	jiù	old	old / opposite: new 新 / former / worn (with age)	old / opposite: new 新 / former / worn (with age)		No Matches Found
+Shopping 4	打折		dǎ zhé	dǎ zhé	Discount	to give a discount	to give a discount		
+Shopping 4	旧	舊	jiù	jiù	old	old / opposite: new 新 / former / worn (with age)	old / opposite: new 新 / former / worn (with age)		
 Shopping 4	皮		Pí   pí	Pí   pí	skin	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty	surname Pi  leather / skin / fur / CL: 張｜张 / pico- (one trillionth) / naughty		皮 (Shopping 4), 皮鞋 (Shopping 4)
 Shopping 4	换	換	huàn	huàn	change	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)	to exchange / to change (clothes etc) / to substitute / to switch / to convert (currency)		换 (Shopping 4), 换钱 (Travel 3)
-Shopping 4	皮鞋		pí xié	pí xié	leather shoes	leather shoes	leather shoes		No Matches Found
-Shopping 4	经过	經過	jīng guò	jīng guò	through	to pass / to go through / process / course / CL: 個｜个	to pass / to go through / process / course / CL: 個｜个		No Matches Found
-Shopping 4	退货	退貨	tuì huò	tuì huò	Returns	to return merchandise / to withdraw a product	to return merchandise / to withdraw a product		No Matches Found
-Shopping 4	退款		tuì kuǎn	tuì kuǎn	Refund	to refund / refund	to refund / refund		No Matches Found
+Shopping 4	皮鞋		pí xié	pí xié	leather shoes	leather shoes	leather shoes		
+Shopping 4	经过	經過	jīng guò	jīng guò	through	to pass / to go through / process / course / CL: 個｜个	to pass / to go through / process / course / CL: 個｜个		
+Shopping 4	退货	退貨	tuì huò	tuì huò	Returns	to return merchandise / to withdraw a product	to return merchandise / to withdraw a product		
+Shopping 4	退款		tuì kuǎn	tuì kuǎn	Refund	to refund / refund	to refund / refund		
 Shopping 4	退		tuì	tuì	Retreat	to retreat / to decline / to move back / to withdraw	to retreat / to decline / to move back / to withdraw		退货 (Shopping 4), 退款 (Shopping 4), 退 (Shopping 4), 退房 (Travel 3)
 Shopping 4	货	貨	huò	huò	goods	goods / money / commodity / CL: 個｜个	goods / money / commodity / CL: 個｜个		退货 (Shopping 4), 货 (Shopping 4), 吃货 (Internet Slang)
 Shopping 4	款		kuǎn	kuǎn	paragraph	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)	section / paragraph / funds / CL: 筆｜笔, 個｜个 / classifier for versions or models (of a product)		退款 (Shopping 4), 款 (Shopping 4)
-Shopping 4	袋子		dài zi	dài zi	bag	bag	bag		No Matches Found
+Shopping 4	袋子		dài zi	dài zi	bag	bag	bag		
 Daily Routine 2	惯	慣	guàn	guàn	used	accustomed to / used to / indulge / to spoil (a child)	accustomed to / used to / indulge / to spoil (a child)		惯 (Daily Routine 2), 习惯 (Daily Routine 2)
 Daily Routine 2	刷		shuā   shuà	shuā   shuà	brush	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select	to brush / to paint / to daub / to paste up / to skip class (of students) / to fire from a job  to select		刷 (Daily Routine 2), 刷牙 (Daily Routine 2), 刷 (Internet Slang)
-Daily Routine 2	习惯	習慣	xí guàn	xí guàn	habit	habit / custom / usual practice / to be used to / CL: 個｜个	habit / custom / usual practice / to be used to / CL: 個｜个		No Matches Found
-Daily Routine 2	刷牙		shuā yá	shuā yá	Brush teeth	to brush one's teeth	to brush one's teeth		No Matches Found
-Daily Routine 2	马上	馬上	mǎ shàng	mǎ shàng	immediately	at once / right away / immediately / on horseback (i.e. by military force)	at once / right away / immediately / on horseback (i.e. by military force)		No Matches Found
-Daily Routine 2	以后	以後	yǐ hòu	yǐ hòu	after	after / later / afterwards / following / later on / in the future	after / later / afterwards / following / later on / in the future		No Matches Found
+Daily Routine 2	习惯	習慣	xí guàn	xí guàn	habit	habit / custom / usual practice / to be used to / CL: 個｜个	habit / custom / usual practice / to be used to / CL: 個｜个		
+Daily Routine 2	刷牙		shuā yá	shuā yá	Brush teeth	to brush one's teeth	to brush one's teeth		
+Daily Routine 2	马上	馬上	mǎ shàng	mǎ shàng	immediately	at once / right away / immediately / on horseback (i.e. by military force)	at once / right away / immediately / on horseback (i.e. by military force)		
+Daily Routine 2	以后	以後	yǐ hòu	yǐ hòu	after	after / later / afterwards / following / later on / in the future	after / later / afterwards / following / later on / in the future		
 Daily Routine 2	澡		zǎo	zǎo	bath	bath	bath		澡 (Daily Routine 2), 洗澡 (Daily Routine 2)
 Daily Routine 2	总	總	zǒng	zǒng	total	always / to assemble / gather / total / overall / head / chief / general / in every case	always / to assemble / gather / total / overall / head / chief / general / in every case		总 (Daily Routine 2), 总是 (Daily Routine 2)
-Daily Routine 2	洗澡		xǐ zǎo	xǐ zǎo	Bathe	to bathe / to take a shower	to bathe / to take a shower		No Matches Found
-Daily Routine 2	一边	一邊	yī biān	yī biān	One side	one side / either side / on the one hand / on the other hand / doing while	one side / either side / on the one hand / on the other hand / doing while		No Matches Found
-Daily Routine 2	总是	總是	zǒng shì	zǒng shì	always	always	always		No Matches Found
-Daily Routine 2	讲	講	jiǎng	jiǎng	speak	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture		No Matches Found
+Daily Routine 2	洗澡		xǐ zǎo	xǐ zǎo	Bathe	to bathe / to take a shower	to bathe / to take a shower		
+Daily Routine 2	一边	一邊	yī biān	yī biān	One side	one side / either side / on the one hand / on the other hand / doing while	one side / either side / on the one hand / on the other hand / doing while		
+Daily Routine 2	总是	總是	zǒng shì	zǒng shì	always	always	always		
+Daily Routine 2	讲	講	jiǎng	jiǎng	speak	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture	to speak / to explain / to negotiate / to emphasise / to be particular about / as far as sth is concerned / speech / lecture		
 Daily Routine 2	故		gù	gù	Therefore	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead	happening / instance / reason / cause / intentional / former / old / friend / therefore / hence / (of people) to die, dead		故 (Daily Routine 2), 故事 (Daily Routine 2), 故宫 (Culture)
-Daily Routine 2	故事		gù shì   gù shi	gù shì   gù shi	story	old practice / CL: 個｜个  narrative / story / tale	old practice / CL: 個｜个  narrative / story / tale		No Matches Found
-Daily Routine 2	以前		yǐ qián	yǐ qián	before	before / formerly / previous / ago	before / formerly / previous / ago		No Matches Found
-Daily Routine 2	做梦	做夢	zuò mèng	zuò mèng	dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream		No Matches Found
+Daily Routine 2	故事		gù shì   gù shi	gù shì   gù shi	story	old practice / CL: 個｜个  narrative / story / tale	old practice / CL: 個｜个  narrative / story / tale		
+Daily Routine 2	以前		yǐ qián	yǐ qián	before	before / formerly / previous / ago	before / formerly / previous / ago		
+Daily Routine 2	做梦	做夢	zuò mèng	zuò mèng	dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream	to dream / to have a dream / fig. illusion / fantasy / pipe dream		
 Daily Routine 2	梦	夢	mèng	mèng	dream	dream / CL: 場｜场, 個｜个	dream / CL: 場｜场, 個｜个		做梦 (Daily Routine 2), 梦 (Daily Routine 2)
 Food 3	除		chú	chú	except	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including	to get rid of / to remove / to exclude / to eliminate / to wipe out / to divide / except / not including		除 (Food 3), 除了 (Food 3)
 Food 3	其		qí	qí	its	his / her / its / their / that / such / it (refers to sth preceding it)	his / her / its / their / that / such / it (refers to sth preceding it)		其 (Food 3), 其他 (Food 3), 其实 (Communication 2)
 Food 3	饺	餃	jiǎo	jiǎo	dumpling	dumplings with meat filling	dumplings with meat filling		饺 (Food 3), 饺子 (Food 3)
-Food 3	北方		běi fāng	běi fāng	north	north / the northern part a country / China north of the Yellow River	north / the northern part a country / China north of the Yellow River		No Matches Found
-Food 3	除了		chú le	chú le	apart from	besides / apart from (... also...) / in addition to / except (for)	besides / apart from (... also...) / in addition to / except (for)		No Matches Found
-Food 3	其他		qí tā	qí tā	other	other / (sth or sb) else / the rest	other / (sth or sb) else / the rest		No Matches Found
-Food 3	饺子	餃子	jiǎo zi	jiǎo zi	Dumplings	dumpling / pot-sticker / CL: 個｜个, 隻｜只	dumpling / pot-sticker / CL: 個｜个, 隻｜只		No Matches Found
+Food 3	北方		běi fāng	běi fāng	north	north / the northern part a country / China north of the Yellow River	north / the northern part a country / China north of the Yellow River		
+Food 3	除了		chú le	chú le	apart from	besides / apart from (... also...) / in addition to / except (for)	besides / apart from (... also...) / in addition to / except (for)		
+Food 3	其他		qí tā	qí tā	other	other / (sth or sb) else / the rest	other / (sth or sb) else / the rest		
+Food 3	饺子	餃子	jiǎo zi	jiǎo zi	Dumplings	dumpling / pot-sticker / CL: 個｜个, 隻｜只	dumpling / pot-sticker / CL: 個｜个, 隻｜只		
 Food 3	辣		là	là	hot	hot (spicy) / pungent	hot (spicy) / pungent		辣 (Food 3), 酸辣汤 (Gourmet 2)
-Food 3	极	極	jí	jí	pole	extremely / pole (geography, physics) / utmost / top	extremely / pole (geography, physics) / utmost / top		No Matches Found
+Food 3	极	極	jí	jí	pole	extremely / pole (geography, physics) / utmost / top	extremely / pole (geography, physics) / utmost / top		
 Food 3	苦		kǔ	kǔ	bitter	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly	bitter / hardship / pain / to suffer / to bring suffering to / painstakingly		苦 (Food 3), 辛苦 (Business 2)
-Food 3	盐	鹽	yán	yán	salt	salt / CL: 粒	salt / CL: 粒		No Matches Found
-Food 3	咸		Xián   xián   xián	Xián   xián   xián	salty	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly		No Matches Found
+Food 3	盐	鹽	yán	yán	salt	salt / CL: 粒	salt / CL: 粒		
+Food 3	咸		Xián   xián   xián	Xián   xián   xián	salty	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly	surname Xian  all / everyone / each / widespread / harmonious  salted / salty / stingy / miserly		
 Food 3	南		Nán   nán	Nán   nán	south	surname Nan  south	surname Nan  south		南 (Food 3), 南方 (Food 3), 南边 (Location 6)
-Food 3	南方		nán fāng	nán fāng	south	south / the southern part of the country / the South	south / the southern part of the country / the South		No Matches Found
-Food 3	难吃	難吃	nán chī	nán chī	Unpalatable	unpalatable	unpalatable		No Matches Found
+Food 3	南方		nán fāng	nán fāng	south	south / the southern part of the country / the South	south / the southern part of the country / the South		
+Food 3	难吃	難吃	nán chī	nán chī	Unpalatable	unpalatable	unpalatable		
 People 3	级	級	jí	jí	level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level	level / grade / rank / step (of stairs) / CL: 個｜个 / classifier: step, level		级 (People 3), 年级 (People 3)
-People 3	个子	個子	gè zi	gè zi	Stature	height / stature / build / size	height / stature / build / size		No Matches Found
-People 3	年级	年級	nián jí	nián jí	grade	grade / year (in school, college etc) / CL: 個｜个	grade / year (in school, college etc) / CL: 個｜个		No Matches Found
-People 3	小学	小學	xiǎo xué	xiǎo xué	primary school	elementary school / primary school / CL: 個｜个	elementary school / primary school / CL: 個｜个		No Matches Found
-People 3	初中		chū zhōng	chū zhōng	junior high school	junior high school / abbr. for 初級中學｜初级中学	junior high school / abbr. for 初級中學｜初级中学		No Matches Found
+People 3	个子	個子	gè zi	gè zi	Stature	height / stature / build / size	height / stature / build / size		
+People 3	年级	年級	nián jí	nián jí	grade	grade / year (in school, college etc) / CL: 個｜个	grade / year (in school, college etc) / CL: 個｜个		
+People 3	小学	小學	xiǎo xué	xiǎo xué	primary school	elementary school / primary school / CL: 個｜个	elementary school / primary school / CL: 個｜个		
+People 3	初中		chū zhōng	chū zhōng	junior high school	junior high school / abbr. for 初級中學｜初级中学	junior high school / abbr. for 初級中學｜初级中学		
 People 3	初		chū	chū	First	at first / (at the) beginning / first / junior / basic	at first / (at the) beginning / first / junior / basic		初中 (People 3), 初 (People 3)
 People 3	较	較	jiào	jiào	Relatively	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]	to compare / to dispute / compared to / (before adj.) relatively / comparatively / rather / also pr. [jiao3]		较 (People 3), 比较 (People 3)
-People 3	年轻	年輕	nián qīng	nián qīng	young	young	young		No Matches Found
-People 3	比较	比較	bǐ jiào	bǐ jiào	Compare	to compare / to contrast / comparatively / relatively / quite / comparison	to compare / to contrast / comparatively / relatively / quite / comparison		No Matches Found
-People 3	眼镜	眼鏡	yǎn jìng	yǎn jìng	glasses	spectacles / eyeglasses / CL: 副	spectacles / eyeglasses / CL: 副		No Matches Found
-People 3	戴		Dài   dài	Dài   dài	wore	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support		No Matches Found
+People 3	年轻	年輕	nián qīng	nián qīng	young	young	young		
+People 3	比较	比較	bǐ jiào	bǐ jiào	Compare	to compare / to contrast / comparatively / relatively / quite / comparison	to compare / to contrast / comparatively / relatively / quite / comparison		
+People 3	眼镜	眼鏡	yǎn jìng	yǎn jìng	glasses	spectacles / eyeglasses / CL: 副	spectacles / eyeglasses / CL: 副		
+People 3	戴		Dài   dài	Dài   dài	wore	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support	surname Dai  to put on or wear (glasses, hat, gloves etc) / to respect / to bear / to support		
 People 3	镜	鏡	jìng	jìng	mirror	mirror / lens	mirror / lens		眼镜 (People 3), 镜 (People 3)
 Location 6	先		xiān	xiān	first	early / prior / former / in advance / first	early / prior / former / in advance / first		先 (Location 6), 先生 (Work)
-Location 6	然后	然後	rán hòu	rán hòu	then	after / then (afterwards) / after that / afterwards	after / then (afterwards) / after that / afterwards		No Matches Found
-Location 6	西边	西邊	xī biān	xī biān	The west	west / west side / western part / to the west of	west / west side / western part / to the west of		No Matches Found
-Location 6	东边	東邊	dōng bian	dōng bian	The east	east / east side / eastern part / to the east of	east / east side / eastern part / to the east of		No Matches Found
-Location 6	北边	北邊	běi biān	běi biān	North	north / north side / northern part / to the north of	north / north side / northern part / to the north of		No Matches Found
-Location 6	一直		yī zhí	yī zhí	Up	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along		No Matches Found
-Location 6	最后	最後	zuì hòu	zuì hòu	At last	final / last / finally / ultimate	final / last / finally / ultimate		No Matches Found
-Location 6	南边	南邊	nán bian	nán bian	South	south / south side / southern part / to the south of	south / south side / southern part / to the south of		No Matches Found
+Location 6	然后	然後	rán hòu	rán hòu	then	after / then (afterwards) / after that / afterwards	after / then (afterwards) / after that / afterwards		
+Location 6	西边	西邊	xī biān	xī biān	The west	west / west side / western part / to the west of	west / west side / western part / to the west of		
+Location 6	东边	東邊	dōng bian	dōng bian	The east	east / east side / eastern part / to the east of	east / east side / eastern part / to the east of		
+Location 6	北边	北邊	běi biān	běi biān	North	north / north side / northern part / to the north of	north / north side / northern part / to the north of		
+Location 6	一直		yī zhí	yī zhí	Up	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along	straight (in a straight line) / continuously / always / from the beginning of ... up to ... / all along		
+Location 6	最后	最後	zuì hòu	zuì hòu	At last	final / last / finally / ultimate	final / last / finally / ultimate		
+Location 6	南边	南邊	nán bian	nán bian	South	south / south side / southern part / to the south of	south / south side / southern part / to the south of		
 Location 6	直		Zhí   zhí	Zhí   zhí	straight	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters	surname Zhi / Zhi (c. 2000 BC), fifth of the legendary Flame Emperors 炎帝 descended from Shennong 神農｜神农 Farmer God  straight / to straighten / fair and reasonable / frank / straightforward / (indicates continuing motion or action) / vertical / vertical downward stroke in Chinese characters		一直 (Location 6), 直 (Location 6)
-Location 6	迷路		mí lù	mí lù	get lost	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)		No Matches Found
-Location 6	地址		dì zhǐ	dì zhǐ	address	address / CL: 個｜个	address / CL: 個｜个		No Matches Found
-Location 6	周围	周圍	zhōu wéi	zhōu wéi	around	surroundings / environment / to encompass	surroundings / environment / to encompass		No Matches Found
+Location 6	迷路		mí lù	mí lù	get lost	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)	to lose the way / lost / labyrinth / labyrinthus vestibularis (of the inner ear)		
+Location 6	地址		dì zhǐ	dì zhǐ	address	address / CL: 個｜个	address / CL: 個｜个		
+Location 6	周围	周圍	zhōu wéi	zhōu wéi	around	surroundings / environment / to encompass	surroundings / environment / to encompass		
 Location 6	迷		mí	mí	fan	to bewilder / crazy about / fan / enthusiast / lost / confused	to bewilder / crazy about / fan / enthusiast / lost / confused		迷路 (Location 6), 迷 (Location 6)
 Location 6	址		zhǐ	zhǐ	site	location / site	location / site		地址 (Location 6), 址 (Location 6)
 Location 6	围	圍	Wéi   wéi	Wéi   wéi	Enclose	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)	surname Wei  to encircle / to surround / all around / to wear by wrapping around (scarf, shawl)		周围 (Location 6), 围 (Location 6)
 Daily Routine 3	般		bān   pán	bān   pán	Sort	sort / kind / class / way / manner  see 般樂｜般乐	sort / kind / class / way / manner  see 般樂｜般乐		般 (Daily Routine 3), 一般 (Daily Routine 3)
 Daily Routine 3	聊		liáo	liáo	chat	to chat / to depend upon (literary) / temporarily / just / slightly	to chat / to depend upon (literary) / temporarily / just / slightly		聊 (Daily Routine 3), 聊天 (Daily Routine 3)
-Daily Routine 3	聊天		liáo tiān	liáo tiān	to chat with	to chat / to gossip	to chat / to gossip		No Matches Found
-Daily Routine 3	一般		yī bān	yī bān	general	same / ordinary / so-so / common / general / generally / in general	same / ordinary / so-so / common / general / generally / in general		No Matches Found
-Daily Routine 3	见面	見面	jiàn miàn	jiàn miàn	meet	to meet / to see each other / CL: 次	to meet / to see each other / CL: 次		No Matches Found
-Daily Routine 3	自己		zì jǐ	zì jǐ	Own	oneself / one's own	oneself / one's own		No Matches Found
-Daily Routine 3	一个人	一個人	yī gè rén	yī gè rén	A person	by oneself (without assistance) / alone (without company)	by oneself (without assistance) / alone (without company)		No Matches Found
+Daily Routine 3	聊天		liáo tiān	liáo tiān	to chat with	to chat / to gossip	to chat / to gossip		
+Daily Routine 3	一般		yī bān	yī bān	general	same / ordinary / so-so / common / general / generally / in general	same / ordinary / so-so / common / general / generally / in general		
+Daily Routine 3	见面	見面	jiàn miàn	jiàn miàn	meet	to meet / to see each other / CL: 次	to meet / to see each other / CL: 次		
+Daily Routine 3	自己		zì jǐ	zì jǐ	Own	oneself / one's own	oneself / one's own		
+Daily Routine 3	一个人	一個人	yī gè rén	yī gè rén	A person	by oneself (without assistance) / alone (without company)	by oneself (without assistance) / alone (without company)		
 Daily Routine 3	自		zì	zì	from	self / oneself / from / since / naturally / surely	self / oneself / from / since / naturally / surely		自己 (Daily Routine 3), 自 (Daily Routine 3), 自行车 (Hobbies 3), 自拍 (Internet Slang)
 Daily Routine 3	己		jǐ	jǐ	already	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa	self / oneself / sixth of the ten Heavenly Stems 十天干 / sixth in order / letter 'F' or roman 'VI' in list 'A, B, C', or 'I, II, III' etc / hexa		自己 (Daily Routine 3), 己 (Daily Routine 3)
 Travel 2	证	証	zhèng   zhèng	zhèng   zhèng	certificate	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症	to admonish / variant of 證｜证  certificate / proof / to prove / to demonstrate / to confirm / variant of 症		证 (Travel 2), 签证 (Travel 2)
 Travel 2	签	簽	qiān   qiān	qiān   qiān	sign	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag	to sign one's name / visa / variant of 籤｜签  inscribed bamboo stick (used in divination, gambling, drawing lots etc) / small wood sliver / label / tag		签 (Travel 2), 签证 (Travel 2), 签名 (Business 1)
 Travel 2	护	護	hù	hù	Protect	to protect	to protect		护 (Travel 2), 护照 (Travel 2), 护 (Emergency), 救护车 (Emergency)
-Travel 2	护照	護照	hù zhào	hù zhào	passport	passport / CL: 本, 個｜个	passport / CL: 本, 個｜个		No Matches Found
-Travel 2	签证	簽證	qiān zhèng	qiān zhèng	visa	visa / certificate / to certify / CL: 個｜个	visa / certificate / to certify / CL: 個｜个		No Matches Found
-Travel 2	发现	發現	fā xiàn	fā xiàn	Find	to find / to discover	to find / to discover		No Matches Found
-Travel 2	起飞	起飛	qǐ fēi	qǐ fēi	take off	(of an aircraft) to take off	(of an aircraft) to take off		No Matches Found
-Travel 2	离开	離開	lí kāi	lí kāi	go away	to depart / to leave	to depart / to leave		No Matches Found
-Travel 2	检查	檢查	jiǎn chá	jiǎn chá	an examination	inspection / to examine / to inspect / CL: 次	inspection / to examine / to inspect / CL: 次		No Matches Found
-Travel 2	行李		xíng li	xíng li	Baggage	luggage / CL: 件	luggage / CL: 件		No Matches Found
-Travel 2	安全		ān quán	ān quán	Safety	safe / secure / safety / security	safe / secure / safety / security		No Matches Found
+Travel 2	护照	護照	hù zhào	hù zhào	passport	passport / CL: 本, 個｜个	passport / CL: 本, 個｜个		
+Travel 2	签证	簽證	qiān zhèng	qiān zhèng	visa	visa / certificate / to certify / CL: 個｜个	visa / certificate / to certify / CL: 個｜个		
+Travel 2	发现	發現	fā xiàn	fā xiàn	Find	to find / to discover	to find / to discover		
+Travel 2	起飞	起飛	qǐ fēi	qǐ fēi	take off	(of an aircraft) to take off	(of an aircraft) to take off		
+Travel 2	离开	離開	lí kāi	lí kāi	go away	to depart / to leave	to depart / to leave		
+Travel 2	检查	檢查	jiǎn chá	jiǎn chá	an examination	inspection / to examine / to inspect / CL: 次	inspection / to examine / to inspect / CL: 次		
+Travel 2	行李		xíng li	xíng li	Baggage	luggage / CL: 件	luggage / CL: 件		
+Travel 2	安全		ān quán	ān quán	Safety	safe / secure / safety / security	safe / secure / safety / security		
 Travel 2	检	檢	jiǎn	jiǎn	Check	to check / to examine / to inspect / to exercise restraint	to check / to examine / to inspect / to exercise restraint		检查 (Travel 2), 检 (Travel 2)
 Travel 2	查		Zhā   chá   zhā	Zhā   chá   zhā	check	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查	surname Zha  to research / to check / to investigate / to examine / to refer to / to look up (e.g. a word in a dictionary)  see 山查		检查 (Travel 2), 查 (Travel 2)
-Travel 2	几乎	幾乎	jī hū	jī hū	almost	almost / nearly / practically	almost / nearly / practically		No Matches Found
-Travel 2	忘记	忘記	wàng jì	wàng jì	forget	to forget	to forget		No Matches Found
-Travel 2	海关	海關	hǎi guān	hǎi guān	Customs	customs (i.e. border crossing inspection) / CL: 個｜个	customs (i.e. border crossing inspection) / CL: 個｜个		No Matches Found
+Travel 2	几乎	幾乎	jī hū	jī hū	almost	almost / nearly / practically	almost / nearly / practically		
+Travel 2	忘记	忘記	wàng jì	wàng jì	forget	to forget	to forget		
+Travel 2	海关	海關	hǎi guān	hǎi guān	Customs	customs (i.e. border crossing inspection) / CL: 個｜个	customs (i.e. border crossing inspection) / CL: 個｜个		
 Travel 2	忘		wàng	wàng	forget	to forget / to overlook / to neglect	to forget / to overlook / to neglect		忘记 (Travel 2), 忘 (Travel 2), 忘 (Work)
 Travel 2	记	記	jì	jì	Remember	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots	to record / to note / to memorize / to remember / mark / sign / classifier for blows, kicks, shots		忘记 (Travel 2), 记 (Travel 2), 笔记 (School 2), 笔记本 (School 2), 记得 (Exam)
 Travel 2	乎		hū	hū	Down	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)	(classical particle similar to 於｜于) in / at / from / because / than / (classical final particle similar to 嗎｜吗, 吧, 呢, expressing question, doubt or astonishment)		几乎 (Travel 2), 乎 (Travel 2)
 Languages 2	言		yán	yán	Speech	words / speech / to say / to talk	words / speech / to say / to talk		言 (Languages 2), 语言 (Languages 2)
 Languages 2	易		Yì   yì	Yì   yì	easy	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange	surname Yi / abbr. for 易經｜易经, the Book of Changes  easy / amiable / to change / to exchange		易 (Languages 2), 容易 (Languages 2)
 Languages 2	容		Róng   róng	Róng   róng	Allow	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance	surname Rong  to hold / to contain / to allow / to tolerate / appearance / look / countenance		容 (Languages 2), 容易 (Languages 2)
-Languages 2	种	種	zhǒng   zhòng	zhǒng   zhòng	Kind	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate		No Matches Found
-Languages 2	容易		róng yì	róng yì	easily	easy / likely / liable (to)	easy / likely / liable (to)		No Matches Found
-Languages 2	语言	語言	yǔ yán	yǔ yán	Language	language / CL: 門｜门, 種｜种	language / CL: 門｜门, 種｜种		No Matches Found
-Languages 2	更		gēng   gèng	gēng   gèng	more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more		No Matches Found
-Languages 2	努力		nǔ lì	nǔ lì	Strive	great effort / to strive / to try hard	great effort / to strive / to try hard		No Matches Found
-Languages 2	汉字	漢字	hàn zì	hàn zì	Chinese character	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự		No Matches Found
+Languages 2	种	種	zhǒng   zhòng	zhǒng   zhòng	Kind	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate	seed / species / kind / type / classifier for types, kinds, sorts  to plant / to grow / to cultivate		
+Languages 2	容易		róng yì	róng yì	easily	easy / likely / liable (to)	easy / likely / liable (to)		
+Languages 2	语言	語言	yǔ yán	yǔ yán	Language	language / CL: 門｜门, 種｜种	language / CL: 門｜门, 種｜种		
+Languages 2	更		gēng   gèng	gēng   gèng	more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more	to change or replace / to experience / one of the five two-hour periods into which the night was formerly divided / watch (e.g. of a sentry or guard)  more / even more / further / still / still more		
+Languages 2	努力		nǔ lì	nǔ lì	Strive	great effort / to strive / to try hard	great effort / to strive / to try hard		
+Languages 2	汉字	漢字	hàn zì	hàn zì	Chinese character	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự	Chinese character / CL: 個｜个 / Japanese: kanji / Korean: hanja / Vietnamese: hán tự		
 Languages 2	努		nǔ	nǔ	Strive	to exert / to strive	to exert / to strive		努力 (Languages 2), 努 (Languages 2)
-Languages 2	提高		tí gāo	tí gāo	improve	to raise / to increase / to improve	to raise / to increase / to improve		No Matches Found
-Languages 2	水平		shuǐ píng	shuǐ píng	Level	level (of achievement etc) / standard / horizontal	level (of achievement etc) / standard / horizontal		No Matches Found
-Languages 2	后来	後來	hòu lái	hòu lái	later	afterwards / later	afterwards / later		No Matches Found
+Languages 2	提高		tí gāo	tí gāo	improve	to raise / to increase / to improve	to raise / to increase / to improve		
+Languages 2	水平		shuǐ píng	shuǐ píng	Level	level (of achievement etc) / standard / horizontal	level (of achievement etc) / standard / horizontal		
+Languages 2	后来	後來	hòu lái	hòu lái	later	afterwards / later	afterwards / later		
 Languages 2	提		tí	tí	mention	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid	to carry (hanging down from the hand) / to lift / to put forward / to mention / to raise (an issue) / upwards character stroke / lifting brush stroke (in painting) / scoop for measuring liquid		提高 (Languages 2), 提 (Languages 2), 提醒 (Duo)
 Languages 2	平		Píng   píng	Píng   píng	level	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声	surname Ping  flat / level / equal / to tie (make the same score) / to draw (score) / calm / peaceful / see also 平聲｜平声		水平 (Languages 2), 平 (Languages 2)
-Personality and Feelings	看起来	看起來	kàn qǐ lai	kàn qǐ lai	Looks	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be		No Matches Found
-Personality and Feelings	奇怪		qí guài	qí guài	strange	strange / odd / to marvel / to be baffled	strange / odd / to marvel / to be baffled		No Matches Found
-Personality and Feelings	生气	生氣	shēng qì	shēng qì	pissed off	to get angry / to take offense / angry / vitality / liveliness	to get angry / to take offense / angry / vitality / liveliness		No Matches Found
-Personality and Feelings	紧张	緊張	jǐn zhāng	jǐn zhāng	tension	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵		No Matches Found
+Personality and Feelings	看起来	看起來	kàn qǐ lai	kàn qǐ lai	Looks	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be	seemingly / apparently / looks as if / appear to be / gives the impression that / seems on the face of it to be		
+Personality and Feelings	奇怪		qí guài	qí guài	strange	strange / odd / to marvel / to be baffled	strange / odd / to marvel / to be baffled		
+Personality and Feelings	生气	生氣	shēng qì	shēng qì	pissed off	to get angry / to take offense / angry / vitality / liveliness	to get angry / to take offense / angry / vitality / liveliness		
+Personality and Feelings	紧张	緊張	jǐn zhāng	jǐn zhāng	tension	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵	nervous / keyed up / intense / tense / strained / in short supply / scarce / CL: 陣｜阵		
 Personality and Feelings	奇		jī   qí	jī   qí	odd	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually	odd (number)  strange / odd / weird / wonderful / surprisingly / unusually		奇怪 (Personality and Feelings), 奇 (Personality and Feelings)
 Personality and Feelings	怪		guài	guài	strange	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather	bewildering / odd / strange / uncanny / devil / monster / to wonder at / to blame / quite / rather		奇怪 (Personality and Feelings), 怪 (Personality and Feelings)
 Personality and Feelings	紧	緊	jǐn	jǐn	tight	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten	tight / strict / close at hand / near / urgent / tense / hard up / short of money / to tighten		紧张 (Personality and Feelings), 紧 (Personality and Feelings)
-Personality and Feelings	难过	難過	nán guò	nán guò	Sorry	to feel sad / to feel unwell / (of life) to be difficult	to feel sad / to feel unwell / (of life) to be difficult		No Matches Found
-Personality and Feelings	哭		kū	kū	cry	to cry / to weep	to cry / to weep		No Matches Found
-Personality and Feelings	可怕		kě pà	kě pà	terrible	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly		No Matches Found
-Personality and Feelings	热情	熱情	rè qíng	rè qíng	enthusiasm	cordial / enthusiastic / passion / passionate / passionately	cordial / enthusiastic / passion / passionate / passionately		No Matches Found
-Personality and Feelings	关心	關心	guān xīn	guān xīn	care	to be concerned about / to care about	to be concerned about / to care about		No Matches Found
-Personality and Feelings	经常	經常	jīng cháng	jīng cháng	often	frequently / constantly / regularly / often / day-to-day / everyday / daily	frequently / constantly / regularly / often / day-to-day / everyday / daily		No Matches Found
-Personality and Feelings	遇到		yù dào	yù dào	Experience	to meet / to run into / to come across	to meet / to run into / to come across		No Matches Found
-Personality and Feelings	好笑		hǎo xiào	hǎo xiào	funny	laughable / funny / ridiculous	laughable / funny / ridiculous		No Matches Found
+Personality and Feelings	难过	難過	nán guò	nán guò	Sorry	to feel sad / to feel unwell / (of life) to be difficult	to feel sad / to feel unwell / (of life) to be difficult		
+Personality and Feelings	哭		kū	kū	cry	to cry / to weep	to cry / to weep		
+Personality and Feelings	可怕		kě pà	kě pà	terrible	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly	awful / dreadful / fearful / formidable / frightful / scary / hideous / horrible / terrible / terribly		
+Personality and Feelings	热情	熱情	rè qíng	rè qíng	enthusiasm	cordial / enthusiastic / passion / passionate / passionately	cordial / enthusiastic / passion / passionate / passionately		
+Personality and Feelings	关心	關心	guān xīn	guān xīn	care	to be concerned about / to care about	to be concerned about / to care about		
+Personality and Feelings	经常	經常	jīng cháng	jīng cháng	often	frequently / constantly / regularly / often / day-to-day / everyday / daily	frequently / constantly / regularly / often / day-to-day / everyday / daily		
+Personality and Feelings	遇到		yù dào	yù dào	Experience	to meet / to run into / to come across	to meet / to run into / to come across		
+Personality and Feelings	好笑		hǎo xiào	hǎo xiào	funny	laughable / funny / ridiculous	laughable / funny / ridiculous		
 Personality and Feelings	遇		Yù   yù	Yù   yù	Encounter	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance	surname Yu  to meet / to encounter / to treat / to receive / opportunity / chance		遇到 (Personality and Feelings), 遇 (Personality and Feelings)
 School 2	求		qiú	qiú	begging	to seek / to look for / to request / to demand / to beseech	to seek / to look for / to request / to demand / to beseech		求 (School 2), 要求 (School 2)
-School 2	校长	校長	xiào zhǎng	xiào zhǎng	principal	(college, university) president / headmaster / CL: 個｜个, 位, 名	(college, university) president / headmaster / CL: 個｜个, 位, 名		No Matches Found
-School 2	要求		yāo qiú	yāo qiú	Claim	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点		No Matches Found
-School 2	食堂		shí táng	shí táng	Cafeteria	dining hall / CL: 個｜个, 間｜间	dining hall / CL: 個｜个, 間｜间		No Matches Found
+School 2	校长	校長	xiào zhǎng	xiào zhǎng	principal	(college, university) president / headmaster / CL: 個｜个, 位, 名	(college, university) president / headmaster / CL: 個｜个, 位, 名		
+School 2	要求		yāo qiú	yāo qiú	Claim	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点	to request / to require / requirement / to stake a claim / to ask / to demand / CL: 點｜点		
+School 2	食堂		shí táng	shí táng	Cafeteria	dining hall / CL: 個｜个, 間｜间	dining hall / CL: 個｜个, 間｜间		
 School 2	食		shí   sì	shí   sì	food	to eat / food / animal feed / eclipse  to feed	to eat / food / animal feed / eclipse  to feed		食堂 (School 2), 食 (School 2)
 School 2	堂		táng	táng	Hall	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture	(main) hall / large room for a specific purpose / CL: 間｜间 / relationship between cousins etc on the paternal side of a family / of the same clan / classifier for classes, lectures etc / classifier for sets of furniture		食堂 (School 2), 堂 (School 2)
-School 2	必须	必須	bì xū	bì xū	have to	to have to / must / compulsory / necessarily	to have to / must / compulsory / necessarily		No Matches Found
-School 2	完成		wán chéng	wán chéng	carry out	to complete / to accomplish	to complete / to accomplish		No Matches Found
-School 2	作业	作業	zuò yè	zuò yè	operation	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	school assignment / homework / work / task / operation / CL: 個｜个 / to operate		No Matches Found
-School 2	高中		gāo zhōng   gāo zhòng	gāo zhōng   gāo zhòng	Senior middle school	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)		No Matches Found
+School 2	必须	必須	bì xū	bì xū	have to	to have to / must / compulsory / necessarily	to have to / must / compulsory / necessarily		
+School 2	完成		wán chéng	wán chéng	carry out	to complete / to accomplish	to complete / to accomplish		
+School 2	作业	作業	zuò yè	zuò yè	operation	school assignment / homework / work / task / operation / CL: 個｜个 / to operate	school assignment / homework / work / task / operation / CL: 個｜个 / to operate		
+School 2	高中		gāo zhōng   gāo zhòng	gāo zhōng   gāo zhòng	Senior middle school	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)	senior high school / abbr. for 高級中學｜高级中学  to pass brilliantly (used in congratulatory fashion)		
 School 2	必		bì	bì	must	certainly / must / will / necessarily	certainly / must / will / necessarily		必须 (School 2), 必 (School 2)
 School 2	成		Chéng   chéng	Chéng   chéng	to make	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth	surname Cheng  to succeed / to finish / to complete / to accomplish / to become / to turn into / to be all right / OK! / one tenth		完成 (School 2), 成 (School 2), 成绩 (Exam), 成 (Exam)
 School 2	须	須	xū   xū	xū   xū	must	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel	must / to have to / to wait  beard / mustache / feeler (of an insect etc) / tassel		必须 (School 2), 须 (School 2)
 School 2	业	業	Yè   yè	Yè   yè	industry	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already	surname Ye  line of business / industry / occupation / job / employment / school studies / enterprise / property / (Buddhism) karma / deed / to engage in / already		作业 (School 2), 业 (School 2), 专业 (Exam)
-School 2	向		Xiàng   xiàng   xiàng	Xiàng   xiàng   xiàng	to	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向		No Matches Found
-School 2	借		jiè	jiè	borrow	to lend / to borrow / by means of / to take (an opportunity)	to lend / to borrow / by means of / to take (an opportunity)		No Matches Found
+School 2	向		Xiàng   xiàng   xiàng	Xiàng   xiàng   xiàng	to	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向	surname Xiang  towards / to face / to turn towards / direction / to support / to side with / shortly before / formerly / always / all along  to tend toward / to guide / variant of 向		
+School 2	借		jiè	jiè	borrow	to lend / to borrow / by means of / to take (an opportunity)	to lend / to borrow / by means of / to take (an opportunity)		
 School 2	笔记	筆記	bǐ jì	bǐ jì	notes	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本	to take down (in writing) / notes / a type of literature consisting mainly of short sketches / CL: 本		笔记 (School 2), 笔记本 (School 2)
-School 2	铅笔	鉛筆	qiān bǐ	qiān bǐ	pencil	(lead) pencil / CL: 支, 枝, 桿｜杆	(lead) pencil / CL: 支, 枝, 桿｜杆		No Matches Found
+School 2	铅笔	鉛筆	qiān bǐ	qiān bǐ	pencil	(lead) pencil / CL: 支, 枝, 桿｜杆	(lead) pencil / CL: 支, 枝, 桿｜杆		
 School 2	铅	鉛	qiān	qiān	lead	lead (chemistry)	lead (chemistry)		铅笔 (School 2), 铅 (School 2)
-School 2	清楚		qīng chu	qīng chu	clear	clear / distinct / to understand thoroughly / to be clear about	clear / distinct / to understand thoroughly / to be clear about		No Matches Found
-School 2	黑板		hēi bǎn	hēi bǎn	blackboard	blackboard / CL: 塊｜块, 個｜个	blackboard / CL: 塊｜块, 個｜个		No Matches Found
-School 2	笔记本	筆記本	bǐ jì běn	bǐ jì běn	notebook	notebook (stationery) / CL: 本 / notebook (computing)	notebook (stationery) / CL: 本 / notebook (computing)		No Matches Found
+School 2	清楚		qīng chu	qīng chu	clear	clear / distinct / to understand thoroughly / to be clear about	clear / distinct / to understand thoroughly / to be clear about		
+School 2	黑板		hēi bǎn	hēi bǎn	blackboard	blackboard / CL: 塊｜块, 個｜个	blackboard / CL: 塊｜块, 個｜个		
+School 2	笔记本	筆記本	bǐ jì běn	bǐ jì běn	notebook	notebook (stationery) / CL: 本 / notebook (computing)	notebook (stationery) / CL: 本 / notebook (computing)		
 School 2	清		Qīng   qīng	Qīng   qīng	clear	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge	Qing or Ch'ing dynasty of Imperial China (1644-1911) / surname Qing  clear / distinct / quiet / just and honest / pure / to settle or clear up / to clean up or purge		清楚 (School 2), 清 (School 2)
 School 2	楚		Chǔ   chǔ	Chǔ   chǔ	Chu	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)	surname Chu / abbr. for Hubei 湖北省 and Hunan 湖南省 provinces together / Chinese kingdom during the Spring and Autumn and Warring States Periods (722-221 BC)  distinct / clear / orderly / pain / suffering / deciduous bush used in Chinese medicine (genus Vitex) / punishment cane (old)		清楚 (School 2), 楚 (School 2)
 School 2	板		bǎn   bǎn   pàn	bǎn   bǎn   pàn	board	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)	board / plank / plate / shutter / table tennis bat / clappers (music) / CL: 塊｜块 / accented beat in Chinese music / hard / stiff / to stop smiling or look serious  see 老闆｜老板, boss  to catch sight of in a doorway (old)		黑板 (School 2), 板 (School 2), 老板 (Work 2), 板 (Work 2)
-School 2	体育馆	體育館	tǐ yù guǎn	tǐ yù guǎn	stadium	gym / gymnasium / stadium / CL: 個｜个	gym / gymnasium / stadium / CL: 個｜个		No Matches Found
+School 2	体育馆	體育館	tǐ yù guǎn	tǐ yù guǎn	stadium	gym / gymnasium / stadium / CL: 個｜个	gym / gymnasium / stadium / CL: 個｜个		
 Future	化		huà	huà	Of	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学	to make into / to change into / -ization / to ... -ize / to transform / abbr. for 化學｜化学		化 (Future), 变化 (Future), 文化 (Hobbies 3)
 Future	算		suàn	suàn	Count	to regard as / to figure / to calculate / to compute	to regard as / to figure / to calculate / to compute		算 (Future), 打算 (Future), 预算 (Business 1)
-Future	搬		bān	bān	move	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately		No Matches Found
+Future	搬		bān	bān	move	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately	to move (i.e. relocate oneself) / to move (sth relatively heavy or bulky) / to shift / to copy indiscriminately		
 Future	变	變	biàn	biàn	change	to change / to become different / to transform / to vary / rebellion	to change / to become different / to transform / to vary / rebellion		变 (Future), 变化 (Future)
-Future	打算		dǎ suàn	dǎ suàn	intend	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个		No Matches Found
-Future	变化	變化	biàn huà	biàn huà	Variety	change / variation / to change / to vary / CL: 個｜个	change / variation / to change / to vary / CL: 個｜个		No Matches Found
-Future	机会	機會	jī huì	jī huì	opportunity	opportunity / chance / occasion / CL: 個｜个	opportunity / chance / occasion / CL: 個｜个		No Matches Found
-Future	留学	留學	liú xué	liú xué	Study abroad	to study abroad	to study abroad		No Matches Found
-Future	国家	國家	guó jiā	guó jiā	country	country / nation / state / CL: 個｜个	country / nation / state / CL: 個｜个		No Matches Found
-Future	选择	選擇	xuǎn zé	xuǎn zé	select	to select / to pick / choice / option / alternative	to select / to pick / choice / option / alternative		No Matches Found
+Future	打算		dǎ suàn	dǎ suàn	intend	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个	to plan / to intend / to calculate / plan / intention / calculation / CL: 個｜个		
+Future	变化	變化	biàn huà	biàn huà	Variety	change / variation / to change / to vary / CL: 個｜个	change / variation / to change / to vary / CL: 個｜个		
+Future	机会	機會	jī huì	jī huì	opportunity	opportunity / chance / occasion / CL: 個｜个	opportunity / chance / occasion / CL: 個｜个		
+Future	留学	留學	liú xué	liú xué	Study abroad	to study abroad	to study abroad		
+Future	国家	國家	guó jiā	guó jiā	country	country / nation / state / CL: 個｜个	country / nation / state / CL: 個｜个		
+Future	选择	選擇	xuǎn zé	xuǎn zé	select	to select / to pick / choice / option / alternative	to select / to pick / choice / option / alternative		
 Future	选	選	xuǎn	xuǎn	selected	to choose / to pick / to select / to elect	to choose / to pick / to select / to elect		选择 (Future), 选 (Future)
 Future	择	擇	zé	zé	Choose	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]	to select / to choose / to pick over / to pick out / to differentiate / to eliminate / also pr. [zhai2]		选择 (Future), 择 (Future)
-Future	结婚	結婚	jié hūn	jié hūn	marry	to marry / to get married / CL: 次	to marry / to get married / CL: 次		No Matches Found
-Future	愿意	願意	yuàn yì	yuàn yì	willing	to wish / to want / ready / willing (to do sth)	to wish / to want / ready / willing (to do sth)		No Matches Found
-Future	认真	認真	rèn zhēn	rèn zhēn	serious	conscientious / earnest / serious / to take seriously / to take to heart	conscientious / earnest / serious / to take seriously / to take to heart		No Matches Found
+Future	结婚	結婚	jié hūn	jié hūn	marry	to marry / to get married / CL: 次	to marry / to get married / CL: 次		
+Future	愿意	願意	yuàn yì	yuàn yì	willing	to wish / to want / ready / willing (to do sth)	to wish / to want / ready / willing (to do sth)		
+Future	认真	認真	rèn zhēn	rèn zhēn	serious	conscientious / earnest / serious / to take seriously / to take to heart	conscientious / earnest / serious / to take seriously / to take to heart		
 Future	结	結	jiē   jié	jiē   jié	Knot	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)	(of a plant) to produce (fruit or seeds) / Taiwan pr. [jie2]  knot / sturdy / bond / to tie / to bind / to check out (of a hotel)		结婚 (Future), 结 (Future), 结束 (Exam), 结 (Exam)
 Future	愿		yuàn   yuàn	yuàn   yuàn	willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing	honest / prudent / variant of 願｜愿  to hope / to wish / to desire / hoped-for / ready / willing		愿意 (Future), 愿 (Future)
 Future	婚		hūn	hūn	marriage	to marry / marriage / wedding / to take a wife	to marry / marriage / wedding / to take a wife		结婚 (Future), 婚 (Future)
-Future	当然	當然	dāng rán	dāng rán	of course	only natural / as it should be / certainly / of course / without doubt	only natural / as it should be / certainly / of course / without doubt		No Matches Found
-Future	放心		fàng xīn	fàng xīn	rest assured	to feel relieved / to feel reassured / to be at ease	to feel relieved / to feel reassured / to be at ease		No Matches Found
-Future	害怕		hài pà	hài pà	Afraid	to be afraid / to be scared	to be afraid / to be scared		No Matches Found
+Future	当然	當然	dāng rán	dāng rán	of course	only natural / as it should be / certainly / of course / without doubt	only natural / as it should be / certainly / of course / without doubt		
+Future	放心		fàng xīn	fàng xīn	rest assured	to feel relieved / to feel reassured / to be at ease	to feel relieved / to feel reassured / to be at ease		
+Future	害怕		hài pà	hài pà	Afraid	to be afraid / to be scared	to be afraid / to be scared		
 Future	当	噹	dāng   dāng   dàng	dāng   dāng   dàng	when	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)	(onom.) dong / ding dong (bell)  to be / to act as / manage / withstand / when / during / ought / should / match equally / equal / same / obstruct / just at (a time or place) / on the spot / right / just at  at or in the very same... / suitable / adequate / fitting / proper / to replace / to regard as / to think / to pawn / (coll.) to fail (a student)		当然 (Future), 当 (Future)
 Future	害		hài	hài	harm	to do harm to / to cause trouble to / harm / evil / calamity	to do harm to / to cause trouble to / harm / evil / calamity		害怕 (Future), 害 (Future)
 Future	怕		Pà   pà	Pà   pà	afraid	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps	surname Pa  to be afraid / to fear / to dread / to be unable to endure / perhaps		可怕 (Personality and Feelings), 害怕 (Future), 怕 (Future)
-Future	分手		fēn shǒu	fēn shǒu	Breaking up	to part company / to split up / to break up	to part company / to split up / to break up		No Matches Found
+Future	分手		fēn shǒu	fēn shǒu	Breaking up	to part company / to split up / to break up	to part company / to split up / to break up		
 Environment	境		jìng	jìng	territory	border / place / condition / boundary / circumstances / territory	border / place / condition / boundary / circumstances / territory		境 (Environment), 环境 (Environment)
 Environment	环	環	Huán   huán	Huán   huán	ring	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in	surname Huan  ring / hoop / loop / (chain) link / classifier for scores in archery etc / to surround / to encircle / to hem in		环 (Environment), 环境 (Environment)
-Environment	层	層	céng	céng	Floor	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)		No Matches Found
-Environment	方便		fāng biàn	fāng biàn	Convenience	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself		No Matches Found
-Environment	环境	環境	huán jìng	huán jìng	surroundings	environment / circumstances / surroundings / CL: 個｜个 / ambient	environment / circumstances / surroundings / CL: 個｜个 / ambient		No Matches Found
-Environment	草		cǎo	cǎo	grass	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根		No Matches Found
-Environment	太阳	太陽	tài yang	tài yang	sun	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴		No Matches Found
-Environment	星星		xīng xing	xīng xing	star	star in the sky	star in the sky		No Matches Found
+Environment	层	層	céng	céng	Floor	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)	layer / stratum / laminated / floor (of a building) / storey / classifier for layers / repeated / sheaf (math.)		
+Environment	方便		fāng biàn	fāng biàn	Convenience	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself	convenient / suitable / to facilitate / to make things easy / having money to spare / (euphemism) to relieve oneself		
+Environment	环境	環境	huán jìng	huán jìng	surroundings	environment / circumstances / surroundings / CL: 個｜个 / ambient	environment / circumstances / surroundings / CL: 個｜个 / ambient		
+Environment	草		cǎo	cǎo	grass	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根	grass / straw / manuscript / draft (of a document) / careless / rough / CL: 棵, 撮, 株, 根		
+Environment	太阳	太陽	tài yang	tài yang	sun	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴	sun / CL: 個｜个 / abbr. for 太陽穴｜太阳穴		
+Environment	星星		xīng xing	xīng xing	star	star in the sky	star in the sky		
 Environment	阳	陽	yáng	yáng	Positive	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯	positive (electric.) / sun / male principle (Taoism) / Yang, opposite: 陰｜阴 ☯		太阳 (Environment), 阳 (Environment)
-Environment	安静	安靜	ān jìng	ān jìng	be quiet	quiet / peaceful / calm	quiet / peaceful / calm		No Matches Found
-Environment	楼	樓	Lóu   lóu	Lóu   lóu	floor	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋		No Matches Found
+Environment	安静	安靜	ān jìng	ān jìng	be quiet	quiet / peaceful / calm	quiet / peaceful / calm		
+Environment	楼	樓	Lóu   lóu	Lóu   lóu	floor	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋	surname Lou  house with more than 1 story / storied building / floor / CL: 層｜层, 座, 棟｜栋		
 Environment	静	靜	jìng	jìng	Quiet	still / calm / quiet / not moving	still / calm / quiet / not moving		安静 (Environment), 静 (Environment)
-Environment	声音	聲音	shēng yīn	shēng yīn	sound	voice / sound / CL: 個｜个	voice / sound / CL: 個｜个		No Matches Found
-Environment	影响	影響	yǐng xiǎng	yǐng xiǎng	influences	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股		No Matches Found
-Environment	邻居	鄰居	lín jū	lín jū	neighbor	neighbor / next door / CL: 個｜个	neighbor / next door / CL: 個｜个		No Matches Found
+Environment	声音	聲音	shēng yīn	shēng yīn	sound	voice / sound / CL: 個｜个	voice / sound / CL: 個｜个		
+Environment	影响	影響	yǐng xiǎng	yǐng xiǎng	influences	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股	influence / effect / to influence / to affect (usually adversely) / to disturb / CL: 股		
+Environment	邻居	鄰居	lín jū	lín jū	neighbor	neighbor / next door / CL: 個｜个	neighbor / next door / CL: 個｜个		
 Environment	声	聲	shēng	shēng	sound	sound / voice / tone / noise / classifier for sounds	sound / voice / tone / noise / classifier for sounds		声音 (Environment), 声 (Environment)
 Environment	邻	鄰	lín	lín	adjacent	neighbor / adjacent / close to	neighbor / adjacent / close to		邻居 (Environment), 邻 (Environment), 多邻国 (Languages 3)
 Environment	响	響	xiǎng	xiǎng	ring	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises	echo / sound / noise / to make a sound / to sound / to ring / loud / classifier for noises		影响 (Environment), 响 (Environment)
 Environment	居		Jū   jī   jū	Jū   jī   jū	House	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms	surname Ju  (archaic) sentence-final particle expressing a doubting attitude  to reside / to be (in a certain position) / to store up / to be at a standstill / residence / house / restaurant / classifier for bedrooms		邻居 (Environment), 居 (Environment)
-Environment	垃圾		lā jī	lā jī	Rubbish	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]		No Matches Found
-Environment	桶		tǒng	tǒng	barrel	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只		No Matches Found
-Environment	丢	丟	diū	diū	throw	to lose / to put aside / to throw	to lose / to put aside / to throw		No Matches Found
-Environment	脏	臟	zàng   zāng	zàng   zāng	dirty	viscera / (anatomy) organ  dirty / filthy	viscera / (anatomy) organ  dirty / filthy		No Matches Found
+Environment	垃圾		lā jī	lā jī	Rubbish	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]	trash / refuse / garbage / (coll.) of poor quality / Taiwan pr. [le4 se4]		
+Environment	桶		tǒng	tǒng	barrel	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只	bucket / (trash) can / barrel (of oil etc) / CL: 個｜个, 隻｜只		
+Environment	丢	丟	diū	diū	throw	to lose / to put aside / to throw	to lose / to put aside / to throw		
+Environment	脏	臟	zàng   zāng	zàng   zāng	dirty	viscera / (anatomy) organ  dirty / filthy	viscera / (anatomy) organ  dirty / filthy		
 Environment	垃		lā	lā	garbage	see 垃圾 / Taiwan pr. [le4]	see 垃圾 / Taiwan pr. [le4]		垃圾 (Environment), 垃 (Environment)
 Environment	圾		jī	jī	Rubbish	see 垃圾 / Taiwan pr. [se4]	see 垃圾 / Taiwan pr. [se4]		垃圾 (Environment), 圾 (Environment)
-Work	先生		Xiān sheng   xiān sheng	Xiān sheng   xiān sheng	Mr	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位		No Matches Found
-Work	小姐		xiǎo jie	xiǎo jie	Young lady	young lady / miss / (slang) prostitute / CL: 個｜个, 位	young lady / miss / (slang) prostitute / CL: 個｜个, 位		No Matches Found
-Work	经理	經理	jīng lǐ	jīng lǐ	manager	manager / director / CL: 個｜个, 位, 名	manager / director / CL: 個｜个, 位, 名		No Matches Found
-Work	同事		tóng shì	tóng shì	colleague	colleague / co-worker / CL: 個｜个, 位	colleague / co-worker / CL: 個｜个, 位		No Matches Found
-Work	突然		tū rán	tū rán	suddenly	sudden / abrupt / unexpected	sudden / abrupt / unexpected		No Matches Found
-Work	重要		zhòng yào	zhòng yào	important	important / significant / major	important / significant / major		No Matches Found
-Work	会议	會議	huì yì	huì yì	meeting	meeting / conference / CL: 場｜场, 屆｜届	meeting / conference / CL: 場｜场, 屆｜届		No Matches Found
+Work	先生		Xiān sheng   xiān sheng	Xiān sheng   xiān sheng	Mr	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位	Mister (Mr.)  teacher / husband / doctor (dialect) / CL: 位		
+Work	小姐		xiǎo jie	xiǎo jie	Young lady	young lady / miss / (slang) prostitute / CL: 個｜个, 位	young lady / miss / (slang) prostitute / CL: 個｜个, 位		
+Work	经理	經理	jīng lǐ	jīng lǐ	manager	manager / director / CL: 個｜个, 位, 名	manager / director / CL: 個｜个, 位, 名		
+Work	同事		tóng shì	tóng shì	colleague	colleague / co-worker / CL: 個｜个, 位	colleague / co-worker / CL: 個｜个, 位		
+Work	突然		tū rán	tū rán	suddenly	sudden / abrupt / unexpected	sudden / abrupt / unexpected		
+Work	重要		zhòng yào	zhòng yào	important	important / significant / major	important / significant / major		
+Work	会议	會議	huì yì	huì yì	meeting	meeting / conference / CL: 場｜场, 屆｜届	meeting / conference / CL: 場｜场, 屆｜届		
 Work	突		tū	tū	Sudden	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]	to dash / to move forward quickly / to bulge / to protrude / to break through / to rush out / sudden / Taiwan pr. [tu2]		突然 (Work), 突 (Work)
 Work	重		chóng   zhòng	chóng   zhòng	weight	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to	to repeat / repetition / again / re- / classifier: layer  heavy / serious / to attach importance to		重要 (Work), 重 (Work), 严重 (Emergency)
 Work	议	議	yì	yì	Discuss	to comment on / to discuss / to suggest	to comment on / to discuss / to suggest		会议 (Work), 议 (Work), 协议 (Business 1), 议 (Business 1)
-Work	解决	解決	jiě jué	jiě jué	solve	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch		No Matches Found
-Work	办法	辦法	bàn fǎ	bàn fǎ	Method	means / method / way (of doing sth) / CL: 條｜条, 個｜个	means / method / way (of doing sth) / CL: 條｜条, 個｜个		No Matches Found
-Work	相信		xiāng xìn	xiāng xìn	Believe	to be convinced (that sth is true) / to believe / to accept sth as true	to be convinced (that sth is true) / to believe / to accept sth as true		No Matches Found
+Work	解决	解決	jiě jué	jiě jué	solve	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch	to settle (a dispute) / to resolve / to solve / to dispose of / to dispatch		
+Work	办法	辦法	bàn fǎ	bàn fǎ	Method	means / method / way (of doing sth) / CL: 條｜条, 個｜个	means / method / way (of doing sth) / CL: 條｜条, 個｜个		
+Work	相信		xiāng xìn	xiāng xìn	Believe	to be convinced (that sth is true) / to believe / to accept sth as true	to be convinced (that sth is true) / to believe / to accept sth as true		
 Work	决	決	jué	jué	Decide	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly	to decide / to determine / to execute (sb) / (of a dam etc) to breach or burst / definitely / certainly		解决 (Work), 决 (Work), 决定 (Work 2)
 Work	解		Xiè   jiě   jiè   xiè	Xiè   jiě   jiè   xiè	solution	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)	surname Xie  to divide / to break up / to split / to separate / to dissolve / to solve / to melt / to remove / to untie / to loosen / to open / to emancipate / to explain / to understand / to know / a solution / a dissection  to transport under guard  acrobatic display (esp. on horseback) (old) / variant of 懈 and 邂 (old)		解决 (Work), 解 (Work), 了解 (Hobbies 3)
 Culture	界		jiè	jiè	boundary	boundary / scope / extent / circles / group / kingdom (taxonomy)	boundary / scope / extent / circles / group / kingdom (taxonomy)		界 (Culture), 世界 (Culture)
 Culture	河		hé	hé	River	river / CL: 條｜条, 道	river / CL: 條｜条, 道		河 (Culture), 黄河 (Culture)
 Culture	世		Shì   shì	Shì   shì	world	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble	surname Shi  life / age / generation / era / world / lifetime / epoch / descendant / noble		世 (Culture), 世界 (Culture)
-Culture	黄河	黃河	Huáng Hé	Huáng Hé	Yellow River	Yellow River or Huang He	Yellow River or Huang He		No Matches Found
-Culture	动物	動物	dòng wù	dòng wù	animal	animal / CL: 隻｜只, 群, 個｜个	animal / CL: 隻｜只, 群, 個｜个		No Matches Found
-Culture	有名		yǒu míng	yǒu míng	Famous	famous / well-known	famous / well-known		No Matches Found
-Culture	世界		shì jiè	shì jiè	world	world / CL: 個｜个	world / CL: 個｜个		No Matches Found
-Culture	长江	長江	Cháng Jiāng	Cháng Jiāng	Yangtze	Yangtze River, or Chang Jiang	Yangtze River, or Chang Jiang		No Matches Found
+Culture	黄河	黃河	Huáng Hé	Huáng Hé	Yellow River	Yellow River or Huang He	Yellow River or Huang He		
+Culture	动物	動物	dòng wù	dòng wù	animal	animal / CL: 隻｜只, 群, 個｜个	animal / CL: 隻｜只, 群, 個｜个		
+Culture	有名		yǒu míng	yǒu míng	Famous	famous / well-known	famous / well-known		
+Culture	世界		shì jiè	shì jiè	world	world / CL: 個｜个	world / CL: 個｜个		
+Culture	长江	長江	Cháng Jiāng	Cháng Jiāng	Yangtze	Yangtze River, or Chang Jiang	Yangtze River, or Chang Jiang		
 Culture	江		Jiāng   jiāng	Jiāng   jiāng	River	surname Jiang  river / CL: 條｜条, 道	surname Jiang  river / CL: 條｜条, 道		长江 (Culture), 江 (Culture)
-Culture	多么	多麼	duō me	duō me	how	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent		No Matches Found
-Culture	熊猫	熊貓	xióng māo	xióng māo	panda	panda / CL: 隻｜只	panda / CL: 隻｜只		No Matches Found
-Culture	西安		Xī ān	Xī ān	Xi'an	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区		No Matches Found
-Culture	啊		ā   á   ǎ   à   a	ā   á   ǎ   à   a	what	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent		No Matches Found
+Culture	多么	多麼	duō me	duō me	how	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent	how (wonderful etc) / what (a great idea etc) / however (difficult it may be etc) / (in interrogative sentences) how (much etc) / to what extent		
+Culture	熊猫	熊貓	xióng māo	xióng māo	panda	panda / CL: 隻｜只	panda / CL: 隻｜只		
+Culture	西安		Xī ān	Xī ān	Xi'an	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区	Xi'an, sub-provincial city and capital of Shaanxi 陝西省｜陕西省 in northwest China / see 西安區｜西安区		
+Culture	啊		ā   á   ǎ   à   a	ā   á   ǎ   à   a	what	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent	interjection of surprise / Ah! / Oh!  interjection expressing doubt or requiring answer / Eh? / what?  interjection of surprise or doubt / Eh? / My! / what's up?  interjection or grunt of agreement / uhm / Ah, OK / expression of recognition / Oh, it's you!  modal particle ending sentence, showing affirmation, approval, or consent		
 Culture	熊		Xióng   xióng	Xióng   xióng	Bear	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly	surname Xiong  bear / to scold / to rebuke / brilliant light / to shine brightly		熊猫 (Culture), 熊 (Culture)
-Culture	长城	長城	Cháng chéng	Cháng chéng	Great Wall	the Great Wall	the Great Wall		No Matches Found
-Culture	故宫	故宮	Gù gōng   gù gōng	Gù gōng   gù gōng	Forbidden City	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace		No Matches Found
+Culture	长城	長城	Cháng chéng	Cháng chéng	Great Wall	the Great Wall	the Great Wall		
+Culture	故宫	故宮	Gù gōng   gù gōng	Gù gōng   gù gōng	Forbidden City	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace	the Forbidden City / abbr. for 故宮博物院｜故宫博物院  former imperial palace		
 Culture	宫	宮	Gōng   gōng	Gōng   gōng	palace	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale	surname Gong  palace / temple / castration (as corporal punishment) / first note in pentatonic scale		故宫 (Culture), 宫 (Culture), 宫保鸡丁 (Gourmet 2)
 Hobbies 3	山		Shān   shān	Shān   shān	mountain	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable	surname Shan  mountain / hill / anything that resembles a mountain / CL: 座 / bundled straw in which silkworms spin cocoons / gable		山 (Hobbies 3), 爬山 (Hobbies 3)
 Hobbies 3	者		zhě	zhě	Person	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this	(after a verb or adjective) one who (is) ... / (after a noun) person involved in ... / -er / -ist / (used after a number or 後｜后 or 前 to refer to sth mentioned previously) / (used after a term, to mark a pause before defining the term) / (old) (used at the end of a command) / (old) this		者 (Hobbies 3), 或者 (Hobbies 3)
 Hobbies 3	爬		pá	pá	climb	to crawl / to climb / to get up or sit up	to crawl / to climb / to get up or sit up		爬 (Hobbies 3), 爬山 (Hobbies 3)
 Hobbies 3	或		huò	huò	or	maybe / perhaps / might / possibly / or	maybe / perhaps / might / possibly / or		或 (Hobbies 3), 或者 (Hobbies 3)
-Hobbies 3	自行车	自行車	zì xíng chē	zì xíng chē	bicycle	bicycle / bike / CL: 輛｜辆	bicycle / bike / CL: 輛｜辆		No Matches Found
-Hobbies 3	或者		huò zhě	huò zhě	or	or / possibly / maybe / perhaps	or / possibly / maybe / perhaps		No Matches Found
-Hobbies 3	爬山		pá shān	pá shān	Climb	to climb a mountain / to mountaineer / hiking / mountaineering	to climb a mountain / to mountaineer / hiking / mountaineering		No Matches Found
-Hobbies 3	功夫		gōng fu	gōng fu	effort	skill / art / kung fu / labor / effort	skill / art / kung fu / labor / effort		No Matches Found
+Hobbies 3	自行车	自行車	zì xíng chē	zì xíng chē	bicycle	bicycle / bike / CL: 輛｜辆	bicycle / bike / CL: 輛｜辆		
+Hobbies 3	或者		huò zhě	huò zhě	or	or / possibly / maybe / perhaps	or / possibly / maybe / perhaps		
+Hobbies 3	爬山		pá shān	pá shān	Climb	to climb a mountain / to mountaineer / hiking / mountaineering	to climb a mountain / to mountaineer / hiking / mountaineering		
+Hobbies 3	功夫		gōng fu	gōng fu	effort	skill / art / kung fu / labor / effort	skill / art / kung fu / labor / effort		
 Hobbies 3	功		gōng	gōng	Gong	meritorious deed or service / achievement / result / service / accomplishment / work (physics)	meritorious deed or service / achievement / result / service / accomplishment / work (physics)		功夫 (Hobbies 3), 功 (Hobbies 3)
-Hobbies 3	文化		wén huà	wén huà	culture	culture / civilization / cultural / CL: 個｜个, 種｜种	culture / civilization / cultural / CL: 個｜个, 種｜种		No Matches Found
-Hobbies 3	历史	歷史	lì shǐ	lì shǐ	history	history / CL: 門｜门, 段	history / CL: 門｜门, 段		No Matches Found
+Hobbies 3	文化		wén huà	wén huà	culture	culture / civilization / cultural / CL: 個｜个, 種｜种	culture / civilization / cultural / CL: 個｜个, 種｜种		
+Hobbies 3	历史	歷史	lì shǐ	lì shǐ	history	history / CL: 門｜门, 段	history / CL: 門｜门, 段		
 Hobbies 3	兴趣	興趣	xìng qù	xìng qù	interest	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个	interest (desire to know about sth) / interest (thing in which one is interested) / hobby / CL: 個｜个		兴趣 (Hobbies 3), 感兴趣 (Hobbies 3)
-Hobbies 3	感兴趣	感興趣	gǎn xìng qù	gǎn xìng qù	Interested	to be interested	to be interested		No Matches Found
+Hobbies 3	感兴趣	感興趣	gǎn xìng qù	gǎn xìng qù	Interested	to be interested	to be interested		
 Hobbies 3	历	曆	lì   lì	lì   lì	calendar	calendar  to experience / to undergo / to pass through / all / each / every / history	calendar  to experience / to undergo / to pass through / all / each / every / history		历史 (Hobbies 3), 历 (Hobbies 3)
 Hobbies 3	趣		qù	qù	interest	interesting / to interest	interesting / to interest		兴趣 (Hobbies 3), 感兴趣 (Hobbies 3), 趣 (Hobbies 3)
 Hobbies 3	史		Shǐ   shǐ	Shǐ   shǐ	history	surname Shi  history / annals / title of an official historian in ancient China	surname Shi  history / annals / title of an official historian in ancient China		历史 (Hobbies 3), 史 (Hobbies 3)
-Hobbies 3	为了	為了	wèi le	wèi le	in order to	in order to / for the purpose of / so as to	in order to / for the purpose of / so as to		No Matches Found
-Hobbies 3	特别	特別	tè bié	tè bié	particular	especially / special / particular / unusual	especially / special / particular / unusual		No Matches Found
-Hobbies 3	了解		liǎo jiě   liǎo jiě	liǎo jiě   liǎo jiě	To understanding	to understand / to realize / to find out  to understand / to realize / to find out	to understand / to realize / to find out  to understand / to realize / to find out		No Matches Found
-Hobbies 3	麻将	麻將	má jiàng	má jiàng	Mahjong	mahjong / CL: 副	mahjong / CL: 副		No Matches Found
+Hobbies 3	为了	為了	wèi le	wèi le	in order to	in order to / for the purpose of / so as to	in order to / for the purpose of / so as to		
+Hobbies 3	特别	特別	tè bié	tè bié	particular	especially / special / particular / unusual	especially / special / particular / unusual		
+Hobbies 3	了解		liǎo jiě   liǎo jiě	liǎo jiě   liǎo jiě	To understanding	to understand / to realize / to find out  to understand / to realize / to find out	to understand / to realize / to find out  to understand / to realize / to find out		
+Hobbies 3	麻将	麻將	má jiàng	má jiàng	Mahjong	mahjong / CL: 副	mahjong / CL: 副		
 Hobbies 3	特		tè	tè	special	special / unique / distinguished / especially / unusual / very	special / unique / distinguished / especially / unusual / very		特别 (Hobbies 3), 特 (Hobbies 3)
 Hobbies 3	麻		Má   má	Má   má	hemp	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb	surname Ma  generic name for hemp, flax etc / hemp or flax fiber for textile materials / sesame / CL: 縷｜缕 / (of materials) rough or coarse / pocked / pitted / to have pins and needles or tingling / to feel numb		麻将 (Hobbies 3), 麻 (Hobbies 3), 麻烦 (Work 2)
 Hobbies 3	将	將	jiāng   jiàng   qiāng	jiāng   jiàng   qiāng	will	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request	will / shall / to use / to take / to checkmate / just a short while ago / (introduces object of main verb, used in the same way as 把)  general / commander-in-chief (military) / king (chess piece) / to command / to lead  to desire / to invite / to request		麻将 (Hobbies 3), 将 (Hobbies 3)
 Health 3	顾	顧	Gù   gù	Gù   gù	Attend	surname Gu  to look after / to take into consideration / to attend to	surname Gu  to look after / to take into consideration / to attend to		顾 (Health 3), 照顾 (Health 3)
-Health 3	死		sǐ	sǐ	dead	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	to die / impassable / uncrossable / inflexible / rigid / extremely / damned		No Matches Found
-Health 3	闷	悶	mēn   mèn	mēn   mèn	stuffy	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed		No Matches Found
-Health 3	腿		tuǐ   tuǐ	tuǐ   tuǐ	leg	leg / CL: 條｜条  hip bone / old variant of 腿	leg / CL: 條｜条  hip bone / old variant of 腿		No Matches Found
-Health 3	照顾	照顧	zhào gu	zhào gu	Look after	to take care of / to show consideration / to attend to / to look after	to take care of / to show consideration / to attend to / to look after		No Matches Found
-Health 3	公斤		gōng jīn	gōng jīn	kg	kilogram (kg)	kilogram (kg)		No Matches Found
-Health 3	着急	著急	zháo jí	zháo jí	Worry	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]		No Matches Found
-Health 3	瘦		shòu	shòu	thin	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive		No Matches Found
+Health 3	死		sǐ	sǐ	dead	to die / impassable / uncrossable / inflexible / rigid / extremely / damned	to die / impassable / uncrossable / inflexible / rigid / extremely / damned		
+Health 3	闷	悶	mēn   mèn	mēn   mèn	stuffy	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed	stuffy / shut indoors / to smother / to cover tightly  bored / depressed / melancholy / sealed / airtight / tightly closed		
+Health 3	腿		tuǐ   tuǐ	tuǐ   tuǐ	leg	leg / CL: 條｜条  hip bone / old variant of 腿	leg / CL: 條｜条  hip bone / old variant of 腿		
+Health 3	照顾	照顧	zhào gu	zhào gu	Look after	to take care of / to show consideration / to attend to / to look after	to take care of / to show consideration / to attend to / to look after		
+Health 3	公斤		gōng jīn	gōng jīn	kg	kilogram (kg)	kilogram (kg)		
+Health 3	着急	著急	zháo jí	zháo jí	Worry	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]	to worry / to feel anxious / Taiwan pr. [zhao1 ji2]		
+Health 3	瘦		shòu	shòu	thin	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive	thin / to lose weight / (of clothing) tight / (of meat) lean / (of land) unproductive		
 Health 3	斤		jīn	jīn	jin	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g	catty / (PRC) weight equal to 500 g / (Tw) weight equal to 600 g / (HK, Malaysia, Singapore) slightly over 604 g		公斤 (Health 3), 斤 (Health 3)
 Health 3	急		jí	jí	anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious	urgent / pressing / rapid / hurried / worried / to make (sb) anxious		着急 (Health 3), 急 (Health 3)
-Health 3	咳嗽		ké sou	ké sou	cough	to cough / CL: 陣｜阵	to cough / CL: 陣｜阵		No Matches Found
-Health 3	抽烟	抽煙	chōu yān	chōu yān	smokes	to smoke (a cigarette, tobacco)	to smoke (a cigarette, tobacco)		No Matches Found
+Health 3	咳嗽		ké sou	ké sou	cough	to cough / CL: 陣｜阵	to cough / CL: 陣｜阵		
+Health 3	抽烟	抽煙	chōu yān	chōu yān	smokes	to smoke (a cigarette, tobacco)	to smoke (a cigarette, tobacco)		
 Health 3	咳		hāi   ké	hāi   ké	cough	sound of sighing  cough	sound of sighing  cough		咳嗽 (Health 3), 咳 (Health 3)
 Health 3	嗽		sòu	sòu	cough	cough	cough		咳嗽 (Health 3), 嗽 (Health 3)
 Health 3	抽		chōu	chōu	Draw	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash	to draw out / to pull out from in between / to remove part of the whole / (of certain plants) to sprout or bud / to whip or thrash		抽烟 (Health 3), 抽 (Health 3)
@@ -1179,166 +1179,166 @@ Health 3	烟	煙	yān	yān	smoke	cigarette or pipe tobacco / CL: 根 / smoke / m
 Travel 3	际	際	jì	jì	The occasion	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)	border / edge / boundary / interval / between / inter- / to meet / time / occasion / to meet with (circumstances)		际 (Travel 3), 国际 (Travel 3)
 Travel 3	柜		jǔ   guì	jǔ   guì	cabinet	Salix multinervis  cupboard / cabinet / wardrobe	Salix multinervis  cupboard / cabinet / wardrobe		柜 (Travel 3), 柜台 (Travel 3)
 Travel 3	转	轉	zhuǎi   zhuǎn   zhuàn	zhuǎi   zhuǎn   zhuàn	turn	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions	see 轉文｜转文  to turn / to change direction / to transfer / to forward (mail)  to revolve / to turn / to circle about / to walk about / classifier for revolutions (per minute etc): revs, rpm / classifier for repeated actions		转 (Travel 3), 转机 (Travel 3), 转发 (Internet Slang)
-Travel 3	转机	轉機	zhuǎn jī	zhuǎn jī	Connection	(to take) a turn for the better / to change planes	(to take) a turn for the better / to change planes		No Matches Found
-Travel 3	柜台	櫃檯	guì tái	guì tái	counter	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)		No Matches Found
-Travel 3	国际	國際	guó jì	guó jì	International	international	international		No Matches Found
-Travel 3	换钱	換錢	huàn qián	huàn qián	Change money	to change money / to sell	to change money / to sell		No Matches Found
-Travel 3	银行	銀行	yín háng	yín háng	bank	bank / CL: 家, 個｜个	bank / CL: 家, 個｜个		No Matches Found
-Travel 3	充电	充電	chōng diàn	chōng diàn	Charging	to recharge batteries / fig. to rest and recuperate	to recharge batteries / fig. to rest and recuperate		No Matches Found
-Travel 3	国内	國內	guó nèi	guó nèi	domestic	domestic / internal (to a country) / civil	domestic / internal (to a country) / civil		No Matches Found
+Travel 3	转机	轉機	zhuǎn jī	zhuǎn jī	Connection	(to take) a turn for the better / to change planes	(to take) a turn for the better / to change planes		
+Travel 3	柜台	櫃檯	guì tái	guì tái	counter	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)	sales counter / front desk / bar / (of markets, medicines etc) OTC (over-the-counter)		
+Travel 3	国际	國際	guó jì	guó jì	International	international	international		
+Travel 3	换钱	換錢	huàn qián	huàn qián	Change money	to change money / to sell	to change money / to sell		
+Travel 3	银行	銀行	yín háng	yín háng	bank	bank / CL: 家, 個｜个	bank / CL: 家, 個｜个		
+Travel 3	充电	充電	chōng diàn	chōng diàn	Charging	to recharge batteries / fig. to rest and recuperate	to recharge batteries / fig. to rest and recuperate		
+Travel 3	国内	國內	guó nèi	guó nèi	domestic	domestic / internal (to a country) / civil	domestic / internal (to a country) / civil		
 Travel 3	银	銀	yín	yín	silver	silver / silver-colored / relating to money or currency	silver / silver-colored / relating to money or currency		银行 (Travel 3), 银 (Travel 3)
 Travel 3	充		chōng	chōng	Charge	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full	to fill / to satisfy / to fulfill / to act in place of / substitute / sufficient / full		充电 (Travel 3), 充 (Travel 3), 充值 (Travel 3)
 Travel 3	内	內	nèi	nèi	Inside	inside / inner / internal / within / interior	inside / inner / internal / within / interior		国内 (Travel 3), 内 (Travel 3)
-Travel 3	充值		chōng zhí	chōng zhí	Recharge	to recharge (money onto a card)	to recharge (money onto a card)		No Matches Found
-Travel 3	漫游	漫遊	màn yóu	màn yóu	roaming	to travel around / to roam / (mobile telephony) roaming	to travel around / to roam / (mobile telephony) roaming		No Matches Found
-Travel 3	电话卡	電話卡	diàn huà kǎ	diàn huà kǎ	phone card	telephone card	telephone card		No Matches Found
+Travel 3	充值		chōng zhí	chōng zhí	Recharge	to recharge (money onto a card)	to recharge (money onto a card)		
+Travel 3	漫游	漫遊	màn yóu	màn yóu	roaming	to travel around / to roam / (mobile telephony) roaming	to travel around / to roam / (mobile telephony) roaming		
+Travel 3	电话卡	電話卡	diàn huà kǎ	diàn huà kǎ	phone card	telephone card	telephone card		
 Travel 3	值		zhí	zhí	value	value / (to be) worth / to happen to / to be on duty	value / (to be) worth / to happen to / to be on duty		充值 (Travel 3), 值 (Travel 3)
-Travel 3	订房	訂房	dìng fáng	dìng fáng	Booking	to reserve a room	to reserve a room		No Matches Found
-Travel 3	退房		tuì fáng	tuì fáng	check out	to check out of a hotel room	to check out of a hotel room		No Matches Found
-Travel 3	取消		qǔ xiāo	qǔ xiāo	cancel	to cancel / cancellation	to cancel / cancellation		No Matches Found
-Travel 3	导游	導遊	dǎo yóu	dǎo yóu	Tourist guide	tour guide / guidebook / to conduct a tour	tour guide / guidebook / to conduct a tour		No Matches Found
+Travel 3	订房	訂房	dìng fáng	dìng fáng	Booking	to reserve a room	to reserve a room		
+Travel 3	退房		tuì fáng	tuì fáng	check out	to check out of a hotel room	to check out of a hotel room		
+Travel 3	取消		qǔ xiāo	qǔ xiāo	cancel	to cancel / cancellation	to cancel / cancellation		
+Travel 3	导游	導遊	dǎo yóu	dǎo yóu	Tourist guide	tour guide / guidebook / to conduct a tour	tour guide / guidebook / to conduct a tour		
 Travel 3	取		qǔ	qǔ	take	to take / to get / to choose / to fetch	to take / to get / to choose / to fetch		取消 (Travel 3), 取 (Travel 3)
 Travel 3	导	導	dǎo	dǎo	guide	to transmit / to lead / to guide / to conduct / to direct	to transmit / to lead / to guide / to conduct / to direct		导游 (Travel 3), 导 (Travel 3)
 Travel 3	消		xiāo	xiāo	Eliminate	to disappear / to vanish / to eliminate / to spend (time) / have to / need	to disappear / to vanish / to eliminate / to spend (time) / have to / need		取消 (Travel 3), 消 (Travel 3)
 Languages 3	答		dā   dá	dā   dá	answer	to answer / to agree  reply / answer / return / respond / echo	to answer / to agree  reply / answer / return / respond / echo		答 (Languages 3), 回答 (Languages 3)
 Languages 3	句		jù	jù	sentence	sentence / clause / phrase / classifier for phrases or lines of verse	sentence / clause / phrase / classifier for phrases or lines of verse		句 (Languages 3), 句子 (Languages 3)
 Languages 3	简	簡	jiǎn	jiǎn	simple	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)	simple / uncomplicated / letter / to choose / to select / bamboo strips used for writing (old)		简 (Languages 3), 简单 (Languages 3)
-Languages 3	简单	簡單	jiǎn dān	jiǎn dān	simple	simple / not complicated	simple / not complicated		No Matches Found
-Languages 3	句子		jù zi	jù zi	sentence	sentence / CL: 個｜个	sentence / CL: 個｜个		No Matches Found
-Languages 3	回答		huí dá	huí dá	Reply	to reply / to answer / the answer / CL: 個｜个	to reply / to answer / the answer / CL: 個｜个		No Matches Found
-Languages 3	词典	詞典	cí diǎn	cí diǎn	dictionary	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本		No Matches Found
-Languages 3	应用	應用	yìng yòng	yìng yòng	application	to use / to apply / application / applicable	to use / to apply / application / applicable		No Matches Found
-Languages 3	语法	語法	yǔ fǎ	yǔ fǎ	grammar	grammar	grammar		No Matches Found
-Languages 3	流利		liú lì	liú lì	fluent	fluent	fluent		No Matches Found
+Languages 3	简单	簡單	jiǎn dān	jiǎn dān	simple	simple / not complicated	simple / not complicated		
+Languages 3	句子		jù zi	jù zi	sentence	sentence / CL: 個｜个	sentence / CL: 個｜个		
+Languages 3	回答		huí dá	huí dá	Reply	to reply / to answer / the answer / CL: 個｜个	to reply / to answer / the answer / CL: 個｜个		
+Languages 3	词典	詞典	cí diǎn	cí diǎn	dictionary	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本	dictionary (of Chinese compound words) / also written 辭典｜辞典 / CL: 部, 本		
+Languages 3	应用	應用	yìng yòng	yìng yòng	application	to use / to apply / application / applicable	to use / to apply / application / applicable		
+Languages 3	语法	語法	yǔ fǎ	yǔ fǎ	grammar	grammar	grammar		
+Languages 3	流利		liú lì	liú lì	fluent	fluent	fluent		
 Languages 3	词	詞	cí	cí	word	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首	word / statement / speech / lyrics / CL: 組｜组, 個｜个 / a form of lyric poetry, flourishing in the Song dynasty 宋朝 / CL: 首		词典 (Languages 3), 词 (Languages 3)
 Languages 3	流		liú	liú	flow	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade	to flow / to disseminate / to circulate or spread / to move or drift / to degenerate / to banish or send into exile / stream of water or sth resembling one / class, rate or grade		流利 (Languages 3), 流 (Languages 3)
 Languages 3	典		diǎn	diǎn	Code	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn	canon / law / standard work of scholarship / literary quotation or allusion / ceremony / to be in charge of / to mortgage or pawn		词典 (Languages 3), 典 (Languages 3)
-Languages 3	下载	下載	xià zǎi	xià zǎi	download	to download / also pr. [xia4 zai4]	to download / also pr. [xia4 zai4]		No Matches Found
-Languages 3	多邻国		duō lín guó	duō lín guó	Duolingo	duolingo	duolingo		No Matches Found
-Languages 3	翻译	翻譯	fān yì	fān yì	translation	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名		No Matches Found
+Languages 3	下载	下載	xià zǎi	xià zǎi	download	to download / also pr. [xia4 zai4]	to download / also pr. [xia4 zai4]		
+Languages 3	多邻国		duō lín guó	duō lín guó	Duolingo	duolingo	duolingo		
+Languages 3	翻译	翻譯	fān yì	fān yì	translation	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名	to translate / to interpret / translator / interpreter / translation / interpretation / CL: 個｜个, 位, 名		
 Languages 3	翻		fān	fān	turn	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross	to turn over / to flip over / to overturn / to rummage through / to translate / to decode / to double / to climb over or into / to cross		翻译 (Languages 3), 翻 (Languages 3)
 Languages 3	载	載	zǎi   zài	zǎi   zài	Load	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously	to record in writing / to carry (i.e. publish in a newspaper etc) / Taiwan pr. [zai4] / year  to carry / to convey / to load / to hold / to fill up / and / also / as well as / simultaneously		下载 (Languages 3), 载 (Languages 3)
 Languages 3	译	譯	yì	yì	Translate	to translate / to interpret	to translate / to interpret		翻译 (Languages 3), 译 (Languages 3)
-House	把		bǎ   bà	bǎ   bà	The	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle		No Matches Found
+House	把		bǎ   bà	bǎ   bà	The	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle	to hold / to contain / to grasp / to take hold of / handle / particle marking the following noun as a direct object / classifier for objects with handle / classifier for small objects: handful  handle		
 House	灯	燈	dēng	dēng	light	lamp / light / lantern / CL: 盞｜盏	lamp / light / lantern / CL: 盞｜盏		灯 (House), 红绿灯 (Travel 4)
-House	空调	空調	kōng tiáo	kōng tiáo	air conditioning	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台		No Matches Found
-House	画	畫	huà	huà	painting	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划		No Matches Found
-House	厨房	廚房	chú fáng	chú fáng	kitchen	kitchen / CL: 間｜间	kitchen / CL: 間｜间		No Matches Found
-House	客厅	客廳	kè tīng	kè tīng	living room	drawing room (room for arriving guests) / living room / CL: 間｜间	drawing room (room for arriving guests) / living room / CL: 間｜间		No Matches Found
+House	空调	空調	kōng tiáo	kōng tiáo	air conditioning	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台	air conditioning / air conditioner (including units that have a heating mode) / CL: 臺｜台		
+House	画	畫	huà	huà	painting	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划	to draw / picture / painting / CL: 幅, 張｜张 / classifier for paintings etc / variant of 劃｜划		
+House	厨房	廚房	chú fáng	chú fáng	kitchen	kitchen / CL: 間｜间	kitchen / CL: 間｜间		
+House	客厅	客廳	kè tīng	kè tīng	living room	drawing room (room for arriving guests) / living room / CL: 間｜间	drawing room (room for arriving guests) / living room / CL: 間｜间		
 House	厨	廚	chú	chú	Kitchen	kitchen	kitchen		厨房 (House), 厨 (House)
 House	厅	廳	tīng	tīng	hall	(reception) hall / living room / office / provincial government department	(reception) hall / living room / office / provincial government department		客厅 (House), 厅 (House)
-House	客人		kè rén	kè rén	The guests	visitor / guest / customer / client / CL: 位	visitor / guest / customer / client / CL: 位		No Matches Found
-House	打扫	打掃	dǎ sǎo	dǎ sǎo	clean	to clean / to sweep	to clean / to sweep		No Matches Found
-House	干净	乾淨	gān jìng	gān jìng	clean	clean / neat	clean / neat		No Matches Found
+House	客人		kè rén	kè rén	The guests	visitor / guest / customer / client / CL: 位	visitor / guest / customer / client / CL: 位		
+House	打扫	打掃	dǎ sǎo	dǎ sǎo	clean	to clean / to sweep	to clean / to sweep		
+House	干净	乾淨	gān jìng	gān jìng	clean	clean / neat	clean / neat		
 House	扫	掃	sǎo   sào	sǎo   sào	sweep	to sweep  broom	to sweep  broom		打扫 (House), 扫 (House)
 House	净	淨	jìng	jìng	net	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role	clean / completely / only / net (income, exports etc) / (Chinese opera) painted face male role		干净 (House), 净 (House)
-House	电梯	電梯	diàn tī	diàn tī	elevator	elevator / escalator / CL: 臺｜台, 部	elevator / escalator / CL: 臺｜台, 部		No Matches Found
-House	坏	壞	huài	huài	Bad	bad / spoiled / broken / to break down / (suffix) to the utmost	bad / spoiled / broken / to break down / (suffix) to the utmost		No Matches Found
-House	被		bèi	bèi	Is	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with		No Matches Found
-House	厕所	廁所	cè suǒ	cè suǒ	WC	toilet / lavatory / CL: 間｜间, 處｜处	toilet / lavatory / CL: 間｜间, 處｜处		No Matches Found
+House	电梯	電梯	diàn tī	diàn tī	elevator	elevator / escalator / CL: 臺｜台, 部	elevator / escalator / CL: 臺｜台, 部		
+House	坏	壞	huài	huài	Bad	bad / spoiled / broken / to break down / (suffix) to the utmost	bad / spoiled / broken / to break down / (suffix) to the utmost		
+House	被		bèi	bèi	Is	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with	quilt / by / (indicates passive-voice clauses) / (literary) to cover / to meet with		
+House	厕所	廁所	cè suǒ	cè suǒ	WC	toilet / lavatory / CL: 間｜间, 處｜处	toilet / lavatory / CL: 間｜间, 處｜处		
 House	厕	廁	cè   sì	cè   sì	toilet	restroom / toilet / lavatory  see 茅廁｜茅厕	restroom / toilet / lavatory  see 茅廁｜茅厕		厕所 (House), 厕 (House)
 House	梯		tī	tī	ladder	ladder / stairs	ladder / stairs		电梯 (House), 梯 (House)
 Exam	寒		hán	hán	cold	cold / poor / to tremble	cold / poor / to tremble		寒 (Exam), 寒假 (Exam)
 Exam	暑		shǔ	shǔ	Heat	heat / hot weather / summer heat	heat / hot weather / summer heat		暑 (Exam), 暑假 (Exam)
 Exam	复	復	fù   fù	fù   fù	complex	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate	to go and return / to return / to resume / to return to a normal or original state / to repeat / again / to recover / to restore / to turn over / to reply / to answer / to reply to a letter / to retaliate / to carry out  to repeat / to double / to overlap / complex (not simple) / compound / composite / double / diplo- / duplicate / overlapping / to duplicate		复 (Exam), 复习 (Exam), 回复 (Business 1)
-Exam	记得	記得	jì de	jì de	remember	to remember	to remember		No Matches Found
-Exam	复习	復習	fù xí	fù xí	review	to review / revision / CL: 次	to review / revision / CL: 次		No Matches Found
-Exam	数学	數學	shù xué	shù xué	mathematics	mathematics / mathematical	mathematics / mathematical		No Matches Found
-Exam	放假		fàng jià	fàng jià	holiday	to have a holiday or vacation	to have a holiday or vacation		No Matches Found
-Exam	暑假		shǔ jià	shǔ jià	summer vacation	summer vacation / CL: 個｜个	summer vacation / CL: 個｜个		No Matches Found
-Exam	寒假		hán jià	hán jià	winter vacation	winter vacation	winter vacation		No Matches Found
-Exam	终于	終於	zhōng yú	zhōng yú	at last	at last / in the end / finally / eventually	at last / in the end / finally / eventually		No Matches Found
-Exam	结束	結束	jié shù	jié shù	End	termination / to finish / to end / to conclude / to close	termination / to finish / to end / to conclude / to close		No Matches Found
-Exam	放松	放鬆	fàng sōng	fàng sōng	Relax	to loosen / to relax	to loosen / to relax		No Matches Found
-Exam	大学	大學	Dà xué   dà xué	Dà xué   dà xué	the University	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所		No Matches Found
+Exam	记得	記得	jì de	jì de	remember	to remember	to remember		
+Exam	复习	復習	fù xí	fù xí	review	to review / revision / CL: 次	to review / revision / CL: 次		
+Exam	数学	數學	shù xué	shù xué	mathematics	mathematics / mathematical	mathematics / mathematical		
+Exam	放假		fàng jià	fàng jià	holiday	to have a holiday or vacation	to have a holiday or vacation		
+Exam	暑假		shǔ jià	shǔ jià	summer vacation	summer vacation / CL: 個｜个	summer vacation / CL: 個｜个		
+Exam	寒假		hán jià	hán jià	winter vacation	winter vacation	winter vacation		
+Exam	终于	終於	zhōng yú	zhōng yú	at last	at last / in the end / finally / eventually	at last / in the end / finally / eventually		
+Exam	结束	結束	jié shù	jié shù	End	termination / to finish / to end / to conclude / to close	termination / to finish / to end / to conclude / to close		
+Exam	放松	放鬆	fàng sōng	fàng sōng	Relax	to loosen / to relax	to loosen / to relax		
+Exam	大学	大學	Dà xué   dà xué	Dà xué   dà xué	the University	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所	the Great Learning, one of the Four Books 四書｜四书 in Confucianism  university / college / CL: 所		
 Exam	终	終	zhōng	zhōng	end	end / finish	end / finish		终于 (Exam), 终 (Exam)
 Exam	于		Yú   yú   yú	Yú   yú   yú	to	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of	surname Yu  to go / to take / sentence-final interrogative particle / variant of 於｜于  in / at / to / from / by / than / out of		终于 (Exam), 于 (Exam), 关于 (Communication 2)
 Exam	束		Shù   shù	Shù   shù	bundle	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control	surname Shu  to bind / bunch / bundle / classifier for bunches, bundles, beams of light etc / to control		结束 (Exam), 束 (Exam)
-Exam	成绩	成績	chéng jì	chéng jì	Achievement	achievement / performance records / grades / CL: 項｜项, 個｜个	achievement / performance records / grades / CL: 項｜项, 個｜个		No Matches Found
-Exam	担心	擔心	dān xīn	dān xīn	worry	anxious / worried / uneasy / to worry / to be anxious	anxious / worried / uneasy / to worry / to be anxious		No Matches Found
-Exam	专业	專業	zhuān yè	zhuān yè	profession	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional		No Matches Found
+Exam	成绩	成績	chéng jì	chéng jì	Achievement	achievement / performance records / grades / CL: 項｜项, 個｜个	achievement / performance records / grades / CL: 項｜项, 個｜个		
+Exam	担心	擔心	dān xīn	dān xīn	worry	anxious / worried / uneasy / to worry / to be anxious	anxious / worried / uneasy / to worry / to be anxious		
+Exam	专业	專業	zhuān yè	zhuān yè	profession	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional	specialty / specialized field / main field of study (at university) / major / CL: 門｜门, 個｜个 / professional		
 Exam	担	擔	dān   dàn	dān   dàn	Dan	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole	to undertake / to carry / to shoulder / to take responsibility  picul (100 catties, 50 kg) / two buckets full / carrying pole and its load / classifier for loads carried on a shoulder pole		担心 (Exam), 担 (Exam)
 Exam	专	專	zhuān	zhuān	Special	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized	for a particular person, occasion, purpose / focused on one thing / special / expert / particular (to sth) / concentrated / specialized		专业 (Exam), 专 (Exam)
 Exam	绩	績	jì	jì	Merit	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]	to spin (hemp etc) / merit / accomplishment / Taiwan pr. [ji1]		成绩 (Exam), 绩 (Exam)
 Travel 4	景		Jǐng   jǐng	Jǐng   jǐng	view	surname Jing  bright / circumstance / scenery	surname Jing  bright / circumstance / scenery		景 (Travel 4), 风景 (Travel 4)
 Travel 4	街		jiē	jiē	street	street / CL: 條｜条	street / CL: 條｜条		街 (Travel 4), 街道 (Travel 4)
-Travel 4	地图	地圖	dì tú	dì tú	map	map / CL: 張｜张, 本	map / CL: 張｜张, 本		No Matches Found
-Travel 4	街道		jiē dào	jiē dào	street	street / CL: 條｜条 / subdistrict / residential district	street / CL: 條｜条 / subdistrict / residential district		No Matches Found
-Travel 4	红绿灯	紅綠燈	hóng lǜ dēng	hóng lǜ dēng	traffic light	traffic light / traffic signal	traffic light / traffic signal		No Matches Found
-Travel 4	风景	風景	fēng jǐng	fēng jǐng	landscape	scenery / landscape / CL: 個｜个	scenery / landscape / CL: 個｜个		No Matches Found
-Travel 4	司机	司機	sī jī	sī jī	driver	chauffeur / driver / CL: 個｜个	chauffeur / driver / CL: 個｜个		No Matches Found
-Travel 4	接		jiē	jiē	Meet	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb		No Matches Found
-Travel 4	免费	免費	miǎn fèi	miǎn fèi	free	free (of charge)	free (of charge)		No Matches Found
-Travel 4	打车	打車	dǎ chē	dǎ chē	A taxi	to take a taxi (in town) / to hitch a lift	to take a taxi (in town) / to hitch a lift		No Matches Found
-Travel 4	观光	觀光	guān guāng	guān guāng	go sightseeing	to tour / sightseeing / tourism	to tour / sightseeing / tourism		No Matches Found
+Travel 4	地图	地圖	dì tú	dì tú	map	map / CL: 張｜张, 本	map / CL: 張｜张, 本		
+Travel 4	街道		jiē dào	jiē dào	street	street / CL: 條｜条 / subdistrict / residential district	street / CL: 條｜条 / subdistrict / residential district		
+Travel 4	红绿灯	紅綠燈	hóng lǜ dēng	hóng lǜ dēng	traffic light	traffic light / traffic signal	traffic light / traffic signal		
+Travel 4	风景	風景	fēng jǐng	fēng jǐng	landscape	scenery / landscape / CL: 個｜个	scenery / landscape / CL: 個｜个		
+Travel 4	司机	司機	sī jī	sī jī	driver	chauffeur / driver / CL: 個｜个	chauffeur / driver / CL: 個｜个		
+Travel 4	接		jiē	jiē	Meet	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb	to receive / to answer (the phone) / to meet or welcome sb / to connect / to catch / to join / to extend / to take one's turn on duty / to take over for sb		
+Travel 4	免费	免費	miǎn fèi	miǎn fèi	free	free (of charge)	free (of charge)		
+Travel 4	打车	打車	dǎ chē	dǎ chē	A taxi	to take a taxi (in town) / to hitch a lift	to take a taxi (in town) / to hitch a lift		
+Travel 4	观光	觀光	guān guāng	guān guāng	go sightseeing	to tour / sightseeing / tourism	to tour / sightseeing / tourism		
 Travel 4	免		miǎn	miǎn	Avoid	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited	to excuse sb / to exempt / to remove or dismiss from office / to avoid / to avert / to escape / to be prohibited		免费 (Travel 4), 免 (Travel 4), 免 (Business 2)
 Travel 4	观	觀	Guàn   guān   guàn	Guàn   guān   guàn	Watch	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform	surname Guan  to look at / to watch / to observe / to behold / to advise / concept / point of view / outlook  Taoist monastery / palace gate watchtower / platform		观光 (Travel 4), 观 (Travel 4), 参观 (Travel 4)
 Travel 4	光		guāng	guāng	Light	light / ray / CL: 道 / bright / only / merely / to use up	light / ray / CL: 道 / bright / only / merely / to use up		观光 (Travel 4), 光 (Travel 4)
-Travel 4	小心		xiǎo xīn	xiǎo xīn	Be careful	to be careful / to take care	to be careful / to take care		No Matches Found
-Travel 4	时差	時差	shí chā	shí chā	jet lag	time difference / time lag / jet lag	time difference / time lag / jet lag		No Matches Found
-Travel 4	马路	馬路	mǎ lù	mǎ lù	road	street / road / CL: 條｜条	street / road / CL: 條｜条		No Matches Found
-Travel 4	参观	參觀	cān guān	cān guān	Visit	to look around / to tour / to visit	to look around / to tour / to visit		No Matches Found
-Travel 4	博物馆	博物館	bó wù guǎn	bó wù guǎn	museum	museum	museum		No Matches Found
+Travel 4	小心		xiǎo xīn	xiǎo xīn	Be careful	to be careful / to take care	to be careful / to take care		
+Travel 4	时差	時差	shí chā	shí chā	jet lag	time difference / time lag / jet lag	time difference / time lag / jet lag		
+Travel 4	马路	馬路	mǎ lù	mǎ lù	road	street / road / CL: 條｜条	street / road / CL: 條｜条		
+Travel 4	参观	參觀	cān guān	cān guān	Visit	to look around / to tour / to visit	to look around / to tour / to visit		
+Travel 4	博物馆	博物館	bó wù guǎn	bó wù guǎn	museum	museum	museum		
 Travel 4	博		bó	bó	Rich	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble	extensive / ample / rich / obtain / aim / to win / to get / plentiful / to gamble		博物馆 (Travel 4), 博 (Travel 4), 微博 (Internet Slang)
-Travel 4	安排		ān pái	ān pái	arrangement	to arrange / to plan / to set up / arrangements / plans	to arrange / to plan / to set up / arrangements / plans		No Matches Found
-Travel 4	活动	活動	huó dòng	huó dòng	activity	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个		No Matches Found
-Travel 4	表演		biǎo yǎn	biǎo yǎn	Performance	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场		No Matches Found
-Travel 4	海边	海邊	hǎi biān	hǎi biān	seaside	coast / seaside / seashore / beach	coast / seaside / seashore / beach		No Matches Found
+Travel 4	安排		ān pái	ān pái	arrangement	to arrange / to plan / to set up / arrangements / plans	to arrange / to plan / to set up / arrangements / plans		
+Travel 4	活动	活動	huó dòng	huó dòng	activity	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个	to exercise / to move about / to operate / to use connections (personal influence) / loose / shaky / active / movable / activity / campaign / maneuver / behavior / CL: 項｜项, 個｜个		
+Travel 4	表演		biǎo yǎn	biǎo yǎn	Performance	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场	play / show / performance / exhibition / to perform / to act / to demonstrate / CL: 場｜场		
+Travel 4	海边	海邊	hǎi biān	hǎi biān	seaside	coast / seaside / seashore / beach	coast / seaside / seashore / beach		
 Travel 4	活		huó	huó	live	to live / alive / living / work / workmanship	to live / alive / living / work / workmanship		活动 (Travel 4), 活 (Travel 4)
 Travel 4	演		yǎn	yǎn	play	to develop / to evolve / to practice / to perform / to play / to act	to develop / to evolve / to practice / to perform / to play / to act		表演 (Travel 4), 演 (Travel 4)
 Communication 2	邮	郵	yóu	yóu	mail	post (office) / mail	post (office) / mail		邮 (Communication 2), 电子邮件 (Communication 2)
-Communication 2	刚才	剛才	gāng cái   gāng cái	gāng cái   gāng cái	Just now	just now / a moment ago  (just) a moment ago	just now / a moment ago  (just) a moment ago		No Matches Found
-Communication 2	电子邮件	電子郵件	diàn zǐ yóu jiàn	diàn zǐ yóu jiàn	e-mail	email / CL: 封, 份	email / CL: 封, 份		No Matches Found
-Communication 2	主要		zhǔ yào	zhǔ yào	main	main / principal / major / primary	main / principal / major / primary		No Matches Found
-Communication 2	短信		duǎn xìn	duǎn xìn	SMS	text message / SMS	text message / SMS		No Matches Found
-Communication 2	关于	關於	guān yú	guān yú	on	pertaining to / concerning / with regard to / about / a matter of	pertaining to / concerning / with regard to / about / a matter of		No Matches Found
+Communication 2	刚才	剛才	gāng cái   gāng cái	gāng cái   gāng cái	Just now	just now / a moment ago  (just) a moment ago	just now / a moment ago  (just) a moment ago		
+Communication 2	电子邮件	電子郵件	diàn zǐ yóu jiàn	diàn zǐ yóu jiàn	e-mail	email / CL: 封, 份	email / CL: 封, 份		
+Communication 2	主要		zhǔ yào	zhǔ yào	main	main / principal / major / primary	main / principal / major / primary		
+Communication 2	短信		duǎn xìn	duǎn xìn	SMS	text message / SMS	text message / SMS		
+Communication 2	关于	關於	guān yú	guān yú	on	pertaining to / concerning / with regard to / about / a matter of	pertaining to / concerning / with regard to / about / a matter of		
 Communication 2	主		zhǔ	zhǔ	the Lord	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)	owner / master / host / individual or party concerned / God / Lord / main / to indicate or signify / trump card (in card games)		主要 (Communication 2), 主 (Communication 2)
-Communication 2	登录	登錄	dēng lù	dēng lù	log in	to register / to log in	to register / to log in		No Matches Found
-Communication 2	密码	密碼	mì mǎ	mì mǎ	password	secret code / ciphertext / password / PIN	secret code / ciphertext / password / PIN		No Matches Found
-Communication 2	信号	信號	xìn hào	xìn hào	signal	signal	signal		No Matches Found
+Communication 2	登录	登錄	dēng lù	dēng lù	log in	to register / to log in	to register / to log in		
+Communication 2	密码	密碼	mì mǎ	mì mǎ	password	secret code / ciphertext / password / PIN	secret code / ciphertext / password / PIN		
+Communication 2	信号	信號	xìn hào	xìn hào	signal	signal	signal		
 Communication 2	登		dēng	dēng	Ascend	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)	to scale (a height) / to ascend / to mount / to publish or record / to enter (e.g. in a register) / to press down with the foot / to step or tread on / to put on (shoes or trousers) (dialect) / to be gathered and taken to the threshing ground (old)		登录 (Communication 2), 登 (Communication 2)
 Communication 2	密		Mì   mì	Mì   mì	dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense	surname Mi / name of an ancient state  secret / confidential / close / thick / dense		密码 (Communication 2), 密 (Communication 2)
 Communication 2	录	錄	Lù   lù	Lù   lù	record	surname Lu  diary / record / to hit / to copy	surname Lu  diary / record / to hit / to copy		登录 (Communication 2), 录 (Communication 2)
-Communication 2	段		Duàn   duàn	Duàn   duàn	segment	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc		No Matches Found
-Communication 2	其实	其實	qí shí	qí shí	in fact	actually / in fact / really	actually / in fact / really		No Matches Found
-Communication 2	过去	過去	guò qù   guò qu	guò qù   guò qu	past	(in the) past / former / previous / to go over / to pass by  (verb suffix)	(in the) past / former / previous / to go over / to pass by  (verb suffix)		No Matches Found
-Communication 2	谈	談	Tán   tán	Tán   tán	talk	surname Tan  to speak / to talk / to converse / to chat / to discuss	surname Tan  to speak / to talk / to converse / to chat / to discuss		No Matches Found
+Communication 2	段		Duàn   duàn	Duàn   duàn	segment	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc	surname Duan  paragraph / section / segment / stage (of a process) / classifier for stories, periods of time, lengths of thread etc		
+Communication 2	其实	其實	qí shí	qí shí	in fact	actually / in fact / really	actually / in fact / really		
+Communication 2	过去	過去	guò qù   guò qu	guò qù   guò qu	past	(in the) past / former / previous / to go over / to pass by  (verb suffix)	(in the) past / former / previous / to go over / to pass by  (verb suffix)		
+Communication 2	谈	談	Tán   tán	Tán   tán	talk	surname Tan  to speak / to talk / to converse / to chat / to discuss	surname Tan  to speak / to talk / to converse / to chat / to discuss		
 Communication 2	实	實	shí	shí	real	real / true / honest / really / solid / fruit / seed / definitely	real / true / honest / really / solid / fruit / seed / definitely		其实 (Communication 2), 实 (Communication 2)
-Work 2	同意		tóng yì	tóng yì	agree	to agree / to consent / to approve	to agree / to consent / to approve		No Matches Found
-Work 2	决定	決定	jué dìng	jué dìng	Decide	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly		No Matches Found
-Work 2	根据	根據	gēn jù	gēn jù	according to	according to / based on / basis / foundation / CL: 個｜个	according to / based on / basis / foundation / CL: 個｜个		No Matches Found
-Work 2	升职	升職	shēng zhí	shēng zhí	Promotion	to get promoted (at work etc) / promotion	to get promoted (at work etc) / promotion		No Matches Found
+Work 2	同意		tóng yì	tóng yì	agree	to agree / to consent / to approve	to agree / to consent / to approve		
+Work 2	决定	決定	jué dìng	jué dìng	Decide	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly	to decide (to do something) / to resolve / decision / CL: 個｜个, 項｜项 / certainly		
+Work 2	根据	根據	gēn jù	gēn jù	according to	according to / based on / basis / foundation / CL: 個｜个	according to / based on / basis / foundation / CL: 個｜个		
+Work 2	升职	升職	shēng zhí	shēng zhí	Promotion	to get promoted (at work etc) / promotion	to get promoted (at work etc) / promotion		
 Work 2	根		gēn	gēn	root	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)	root / basis / classifier for long slender objects, e.g. cigarettes, guitar strings / CL: 條｜条 / radical (chemistry)		根据 (Work 2), 根 (Work 2)
 Work 2	据		jū   jù	jū   jù	according to	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy	see 拮据  according to / to act in accordance with / to depend on / to seize / to occupy		根据 (Work 2), 据 (Work 2), 据 (Business 1), 收据 (Business 1)
 Work 2	升		shēng	shēng	Rise	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗	to ascend / to rise to the rank of / to promote / to hoist / liter / measure for dry grain equal to one-tenth dou 斗		升职 (Work 2), 升 (Work 2)
 Work 2	职	職	zhí	zhí	Office	office / duty	office / duty		升职 (Work 2), 职 (Work 2)
-Work 2	满意	滿意	mǎn yì	mǎn yì	satisfaction	satisfied / pleased / to one's satisfaction	satisfied / pleased / to one's satisfaction		No Matches Found
-Work 2	认为	認為	rèn wéi	rèn wéi	think	to believe / to think / to consider / to feel	to believe / to think / to consider / to feel		No Matches Found
-Work 2	出差		chū chāi	chū chāi	On a business trip	to go on an official or business trip	to go on an official or business trip		No Matches Found
-Work 2	表现	表現	biǎo xiàn	biǎo xiàn	which performed	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior		No Matches Found
+Work 2	满意	滿意	mǎn yì	mǎn yì	satisfaction	satisfied / pleased / to one's satisfaction	satisfied / pleased / to one's satisfaction		
+Work 2	认为	認為	rèn wéi	rèn wéi	think	to believe / to think / to consider / to feel	to believe / to think / to consider / to feel		
+Work 2	出差		chū chāi	chū chāi	On a business trip	to go on an official or business trip	to go on an official or business trip		
+Work 2	表现	表現	biǎo xiàn	biǎo xiàn	which performed	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior	to show / to show off / to display / to manifest / expression / manifestation / show / display / performance (at work etc) / behavior		
 Work 2	满	滿	Mǎn   mǎn	Mǎn   mǎn	full	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented	Manchu ethnic group  to fill / full / filled / packed / fully / completely / quite / to reach the limit / to satisfy / satisfied / contented		满意 (Work 2), 满 (Work 2)
-Work 2	老板	老闆	Lǎo bǎn   lǎo bǎn	Lǎo bǎn   lǎo bǎn	boss	Robam (brand)  boss / business proprietor / CL: 個｜个	Robam (brand)  boss / business proprietor / CL: 個｜个		No Matches Found
-Work 2	麻烦	麻煩	má fan	má fan	trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble		No Matches Found
-Work 2	开会	開會	kāi huì	kāi huì	Meetings	to hold a meeting / to attend a meeting	to hold a meeting / to attend a meeting		No Matches Found
-Work 2	面试	面試	miàn shì	miàn shì	Interview	to be interviewed (as a candidate) / interview	to be interviewed (as a candidate) / interview		No Matches Found
+Work 2	老板	老闆	Lǎo bǎn   lǎo bǎn	Lǎo bǎn   lǎo bǎn	boss	Robam (brand)  boss / business proprietor / CL: 個｜个	Robam (brand)  boss / business proprietor / CL: 個｜个		
+Work 2	麻烦	麻煩	má fan	má fan	trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble	inconvenient / troublesome / annoying / to trouble or bother sb / to put sb to trouble		
+Work 2	开会	開會	kāi huì	kāi huì	Meetings	to hold a meeting / to attend a meeting	to hold a meeting / to attend a meeting		
+Work 2	面试	面試	miàn shì	miàn shì	Interview	to be interviewed (as a candidate) / interview	to be interviewed (as a candidate) / interview		
 Work 2	烦	煩	fán	fán	bother	to feel vexed / to bother / to trouble / superfluous and confusing / edgy	to feel vexed / to bother / to trouble / superfluous and confusing / edgy		麻烦 (Work 2), 烦 (Work 2)
 Festivals	饼	餅	bǐng	bǐng	cake	round flat cake / cookie / cake / pastry / CL: 張｜张	round flat cake / cookie / cake / pastry / CL: 張｜张		饼 (Festivals), 月饼 (Festivals)
-Festivals	月亮		yuè liang	yuè liang	moon	the moon	the moon		No Matches Found
-Festivals	月饼	月餅	yuè bǐng	yuè bǐng	moon cake	mooncake (esp. for the Mid-Autumn Festival)	mooncake (esp. for the Mid-Autumn Festival)		No Matches Found
-Festivals	中秋节	中秋節	Zhōng qiū jié	Zhōng qiū jié	Mid-Autumn Festival	the Mid-Autumn Festival on 15th of 8th lunar month	the Mid-Autumn Festival on 15th of 8th lunar month		No Matches Found
+Festivals	月亮		yuè liang	yuè liang	moon	the moon	the moon		
+Festivals	月饼	月餅	yuè bǐng	yuè bǐng	moon cake	mooncake (esp. for the Mid-Autumn Festival)	mooncake (esp. for the Mid-Autumn Festival)		
+Festivals	中秋节	中秋節	Zhōng qiū jié	Zhōng qiū jié	Mid-Autumn Festival	the Mid-Autumn Festival on 15th of 8th lunar month	the Mid-Autumn Festival on 15th of 8th lunar month		
 Festivals	圆	圓	yuán	yuán	circle	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify	circle / round / circular / spherical / (of the moon) full / unit of Chinese currency (Yuan) / tactful / to justify		圆 (Festivals), 汤圆 (Festivals)
-Festivals	恭喜		gōng xǐ	gōng xǐ	Congratulation	congratulations / greetings	congratulations / greetings		No Matches Found
-Festivals	红包	紅包	hóng bāo	hóng bāo	Red envelope	money wrapped in red as a gift / bonus payment / kickback / bribe	money wrapped in red as a gift / bonus payment / kickback / bribe		No Matches Found
-Festivals	汤圆	湯圓	tāng yuán	tāng yuán	Dumpling	boiled balls of glutinous rice flour, eaten during the Lantern Festival	boiled balls of glutinous rice flour, eaten during the Lantern Festival		No Matches Found
-Festivals	聚会	聚會	jù huì	jù huì	get together	party / gathering / to meet / to get together	party / gathering / to meet / to get together		No Matches Found
-Festivals	发财	發財	fā cái	fā cái	Make a fortune	to get rich	to get rich		No Matches Found
+Festivals	恭喜		gōng xǐ	gōng xǐ	Congratulation	congratulations / greetings	congratulations / greetings		
+Festivals	红包	紅包	hóng bāo	hóng bāo	Red envelope	money wrapped in red as a gift / bonus payment / kickback / bribe	money wrapped in red as a gift / bonus payment / kickback / bribe		
+Festivals	汤圆	湯圓	tāng yuán	tāng yuán	Dumpling	boiled balls of glutinous rice flour, eaten during the Lantern Festival	boiled balls of glutinous rice flour, eaten during the Lantern Festival		
+Festivals	聚会	聚會	jù huì	jù huì	get together	party / gathering / to meet / to get together	party / gathering / to meet / to get together		
+Festivals	发财	發財	fā cái	fā cái	Make a fortune	to get rich	to get rich		
 Festivals	恭		gōng	gōng	Respectful	respectful	respectful		恭喜 (Festivals), 恭 (Festivals)
 Festivals	聚		jù	jù	Gather	to congregate / to assemble / to mass / to gather together / to amass / to polymerize	to congregate / to assemble / to mass / to gather together / to amass / to polymerize		聚会 (Festivals), 聚 (Festivals)
 Festivals	财	財	cái	cái	fiscal	money / wealth / riches / property / valuables	money / wealth / riches / property / valuables		发财 (Festivals), 财 (Festivals)
-Festivals	端午节	端午節	Duān wǔ jié	Duān wǔ jié	Dragon boat festival	Dragon Boat Festival (5th day of the 5th lunar month)	Dragon Boat Festival (5th day of the 5th lunar month)		No Matches Found
-Festivals	粽子		zòng zi	zòng zi	Zongzi	glutinous rice and choice of filling wrapped in leaves and boiled	glutinous rice and choice of filling wrapped in leaves and boiled		No Matches Found
-Festivals	划		huá   huá   huà	huá   huá   huà	Draw	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character		No Matches Found
-Festivals	龙舟	龍舟	lóng zhōu	lóng zhōu	Dragon Boat	dragon boat / imperial boat	dragon boat / imperial boat		No Matches Found
+Festivals	端午节	端午節	Duān wǔ jié	Duān wǔ jié	Dragon boat festival	Dragon Boat Festival (5th day of the 5th lunar month)	Dragon Boat Festival (5th day of the 5th lunar month)		
+Festivals	粽子		zòng zi	zòng zi	Zongzi	glutinous rice and choice of filling wrapped in leaves and boiled	glutinous rice and choice of filling wrapped in leaves and boiled		
+Festivals	划		huá   huá   huà	huá   huá   huà	Draw	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character	to row / to paddle / profitable / worth (the effort) / it pays (to do sth)  to cut / to slash / to scratch (cut into the surface of sth) / to strike (a match)  to delimit / to transfer / to assign / to plan / to draw (a line) / stroke of a Chinese character		
+Festivals	龙舟	龍舟	lóng zhōu	lóng zhōu	Dragon Boat	dragon boat / imperial boat	dragon boat / imperial boat		
 Festivals	端		duān	duān	end	end / extremity / item / port / to hold sth level with both hands / to carry / regular	end / extremity / item / port / to hold sth level with both hands / to carry / regular		端午节 (Festivals), 端 (Festivals)
 Festivals	粽		zòng	zòng	Dumplings	rice dumplings wrapped in leaves	rice dumplings wrapped in leaves		粽子 (Festivals), 粽 (Festivals)
 Festivals	龙	龍	Lóng   lóng	Lóng   lóng	Dragon	surname Long  dragon / CL: 條｜条 / imperial	surname Long  dragon / CL: 條｜条 / imperial		龙舟 (Festivals), 龙 (Festivals)
@@ -1347,17 +1347,17 @@ Gourmet 2	珠		zhū	zhū	Pearl	bead / pearl / CL: 粒, 顆｜颗	bead / pearl / 
 Gourmet 2	汤	湯	Tāng   shāng   tāng	Tāng   shāng   tāng	soup	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled	surname Tang  rushing current  soup / hot or boiling water / decoction of medicinal herbs / water in which sth has been boiled		汤圆 (Festivals), 汤 (Gourmet 2), 酸辣汤 (Gourmet 2)
 Gourmet 2	酸		suān	suān	acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid	sour / tart / sick at heart / grieved / sore / aching / pedantic / impractical / an acid		酸 (Gourmet 2), 酸辣汤 (Gourmet 2)
 Gourmet 2	珍		zhēn	zhēn	Treasure	precious thing / treasure / culinary delicacy / rare / valuable / to value highly	precious thing / treasure / culinary delicacy / rare / valuable / to value highly		珍 (Gourmet 2), 珍珠奶茶 (Gourmet 2)
-Gourmet 2	珍珠奶茶		zhēn zhū nǎi chá	zhēn zhū nǎi chá	Pearl milk tea	pearl milk tea / tapioca milk tea / bubble milk tea	pearl milk tea / tapioca milk tea / bubble milk tea		No Matches Found
-Gourmet 2	酸辣汤	酸辣湯	suān là tāng	suān là tāng	Hot and sour soup	hot and sour soup / sour and spicy soup	hot and sour soup / sour and spicy soup		No Matches Found
-Gourmet 2	北京烤鸭	北京烤鴨	Běi jīng kǎo yā	Běi jīng kǎo yā	Peking duck	Peking Duck	Peking Duck		No Matches Found
-Gourmet 2	春卷	春捲	chūn juǎn	chūn juǎn	Spring Rolls	egg roll / spring roll	egg roll / spring roll		No Matches Found
-Gourmet 2	豆花		dòu huā	dòu huā	Curd	jellied tofu / soft bean curd	jellied tofu / soft bean curd		No Matches Found
+Gourmet 2	珍珠奶茶		zhēn zhū nǎi chá	zhēn zhū nǎi chá	Pearl milk tea	pearl milk tea / tapioca milk tea / bubble milk tea	pearl milk tea / tapioca milk tea / bubble milk tea		
+Gourmet 2	酸辣汤	酸辣湯	suān là tāng	suān là tāng	Hot and sour soup	hot and sour soup / sour and spicy soup	hot and sour soup / sour and spicy soup		
+Gourmet 2	北京烤鸭	北京烤鴨	Běi jīng kǎo yā	Běi jīng kǎo yā	Peking duck	Peking Duck	Peking Duck		
+Gourmet 2	春卷	春捲	chūn juǎn	chūn juǎn	Spring Rolls	egg roll / spring roll	egg roll / spring roll		
+Gourmet 2	豆花		dòu huā	dòu huā	Curd	jellied tofu / soft bean curd	jellied tofu / soft bean curd		
 Gourmet 2	烤		kǎo	kǎo	grilled	to roast / to bake / to broil	to roast / to bake / to broil		北京烤鸭 (Gourmet 2), 烤 (Gourmet 2)
 Gourmet 2	鸭	鴨	yā	yā	duck	duck / CL: 隻｜只 / (slang) male prostitute	duck / CL: 隻｜只 / (slang) male prostitute		北京烤鸭 (Gourmet 2), 鸭 (Gourmet 2)
 Gourmet 2	卷		juǎn   juàn   juǎn	juǎn   juàn   juǎn	volume	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll	to roll up / roll / classifier for small rolled things (wad of paper money, movie reel etc)  scroll / book / volume / chapter / examination paper / classifier for books, paintings: volume, scroll  to roll (up) / to sweep up / to carry on / roll		春卷 (Gourmet 2), 卷 (Gourmet 2)
-Gourmet 2	宫保鸡丁	宮保雞丁	gōng bǎo jī dīng	gōng bǎo jī dīng	Kung Pao Chicken	Kung Pao Chicken / spicy diced chicken	Kung Pao Chicken / spicy diced chicken		No Matches Found
-Gourmet 2	卤肉饭		lǔ ròu fàn	lǔ ròu fàn	Braised pork on rice	Braised pork on rice	Braised pork on rice		No Matches Found
-Gourmet 2	馒头	饅頭	mán tou	mán tou	steamed bread	steamed roll / steamed bun / steamed bread / CL: 個｜个	steamed roll / steamed bun / steamed bread / CL: 個｜个		No Matches Found
+Gourmet 2	宫保鸡丁	宮保雞丁	gōng bǎo jī dīng	gōng bǎo jī dīng	Kung Pao Chicken	Kung Pao Chicken / spicy diced chicken	Kung Pao Chicken / spicy diced chicken		
+Gourmet 2	卤肉饭		lǔ ròu fàn	lǔ ròu fàn	Braised pork on rice	Braised pork on rice	Braised pork on rice		
+Gourmet 2	馒头	饅頭	mán tou	mán tou	steamed bread	steamed roll / steamed bun / steamed bread / CL: 個｜个	steamed roll / steamed bun / steamed bread / CL: 個｜个		
 Gourmet 2	保		Bǎo   bǎo	Bǎo   bǎo	Insurance	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure	Bulgaria / Bulgarian / abbr. for 保加利亞｜保加利亚  to defend / to protect / to keep / to guarantee / to ensure		宫保鸡丁 (Gourmet 2), 保 (Gourmet 2), 保险 (Business 2), 保持 (Business 2)
 Gourmet 2	卤	滷	lǔ   lǔ	lǔ   lǔ	halogen	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid	to stew in soy sauce and spices  alkaline soil / salt / brine / halogen (chemistry) / crass / stupid		卤肉饭 (Gourmet 2), 卤 (Gourmet 2)
 Gourmet 2	馒	饅	mán	mán	steamed bread	steamed bread	steamed bread		馒头 (Gourmet 2), 馒 (Gourmet 2)
@@ -1365,136 +1365,136 @@ Gourmet 2	丁		Dīng   dīng	Dīng   dīng	Ding	surname Ding  fourth of the ten 
 Internet Slang	豪		háo	háo	Howe	grand / heroic	grand / heroic		豪 (Internet Slang), 土豪 (Internet Slang)
 Internet Slang	宅		zhái	zhái	House	residence / (coll.) to stay in at home / to hang around at home	residence / (coll.) to stay in at home / to hang around at home		宅 (Internet Slang), 宅男 (Internet Slang)
 Internet Slang	土		Tǔ   tǔ	Tǔ   tǔ	soil	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音	Tu (ethnic group) / surname Tu  earth / dust / clay / local / indigenous / crude opium / unsophisticated / one of the eight ancient musical instruments 八音		土 (Internet Slang), 土豪 (Internet Slang)
-Internet Slang	土豪		tǔ háo	tǔ háo	Local tycoon	local tyrant / local strong man / (slang) nouveau riche	local tyrant / local strong man / (slang) nouveau riche		No Matches Found
-Internet Slang	吃货	吃貨	chī huò	chī huò	Food goods	chowhound / foodie / a good-for-nothing	chowhound / foodie / a good-for-nothing		No Matches Found
-Internet Slang	宅男		zhái nán	zhái nán	Takuotoko	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')		No Matches Found
-Internet Slang	菜鸟	菜鳥	cài niǎo	cài niǎo	Rookie	(coll.) sb new to a particular subject / rookie / beginner / newbie	(coll.) sb new to a particular subject / rookie / beginner / newbie		No Matches Found
-Internet Slang	美图		měi tú	měi tú	Mito				No Matches Found
-Internet Slang	萌		méng	méng	Sprout	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)		No Matches Found
-Internet Slang	自拍		zì pāi	zì pāi	Selfie	to take a picture or video of oneself	to take a picture or video of oneself		No Matches Found
-Internet Slang	囧		jiǒng	jiǒng	Oops	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated		No Matches Found
-Internet Slang	美眉		měi méi	měi méi	Meimei	(coll.) pretty girl	(coll.) pretty girl		No Matches Found
-Internet Slang	高富帅	高富帥	gāo fù shuài	gāo fù shuài	Tall, rich and handsome	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)		No Matches Found
+Internet Slang	土豪		tǔ háo	tǔ háo	Local tycoon	local tyrant / local strong man / (slang) nouveau riche	local tyrant / local strong man / (slang) nouveau riche		
+Internet Slang	吃货	吃貨	chī huò	chī huò	Food goods	chowhound / foodie / a good-for-nothing	chowhound / foodie / a good-for-nothing		
+Internet Slang	宅男		zhái nán	zhái nán	Takuotoko	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')	a guy who stays at home all the time, typically spending a lot of time playing online games (derived from Japanese 'otaku')		
+Internet Slang	菜鸟	菜鳥	cài niǎo	cài niǎo	Rookie	(coll.) sb new to a particular subject / rookie / beginner / newbie	(coll.) sb new to a particular subject / rookie / beginner / newbie		
+Internet Slang	美图		měi tú	měi tú	Mito				
+Internet Slang	萌		méng	méng	Sprout	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)	to sprout / to bud / to have a strong affection for (slang) / adorable (loanword from Japanese 萌え moe, slang describing affection for a cute character)		
+Internet Slang	自拍		zì pāi	zì pāi	Selfie	to take a picture or video of oneself	to take a picture or video of oneself		
+Internet Slang	囧		jiǒng	jiǒng	Oops	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated	variant of 冏 / used as emoticon ('smiley') meaning embarrassed, sad :-(, depressed or frustrated		
+Internet Slang	美眉		měi méi	měi méi	Meimei	(coll.) pretty girl	(coll.) pretty girl		
+Internet Slang	高富帅	高富帥	gāo fù shuài	gāo fù shuài	Tall, rich and handsome	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)	Mr Perfect' (i.e. tall, rich and handsome) (Internet slang)		
 Internet Slang	眉		méi	méi	eyebrow	eyebrow / upper margin	eyebrow / upper margin		美眉 (Internet Slang), 眉 (Internet Slang)
 Internet Slang	富		Fù   fù	Fù   fù	rich	surname Fu  rich / abundant / wealthy	surname Fu  rich / abundant / wealthy		高富帅 (Internet Slang), 富 (Internet Slang)
-Internet Slang	微博		wēi bó	wēi bó	BiHiroshi	micro-blogging / microblog	micro-blogging / microblog		No Matches Found
-Internet Slang	微信		Wēi xìn	Wēi xìn	Micro letter	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)		No Matches Found
-Internet Slang	朋友圈		Péng you quān	Péng you quān	Circle of friends	Moments (social networking function of smartphone app WeChat 微信)	Moments (social networking function of smartphone app WeChat 微信)		No Matches Found
+Internet Slang	微博		wēi bó	wēi bó	BiHiroshi	micro-blogging / microblog	micro-blogging / microblog		
+Internet Slang	微信		Wēi xìn	Wēi xìn	Micro letter	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)	Weixin or WeChat (mobile text and voice messaging service developed by Tencent 騰訊｜腾讯)		
+Internet Slang	朋友圈		Péng you quān	Péng you quān	Circle of friends	Moments (social networking function of smartphone app WeChat 微信)	Moments (social networking function of smartphone app WeChat 微信)		
 Internet Slang	微		Wēi   wēi	Wēi   wēi	micro-	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]	surname Wei / ancient Chinese state near present day Chongqing / Taiwan pr. [Wei2]  tiny / miniature / slightly / profound / abtruse / to decline / one millionth part of / micro- / Taiwan pr. [wei2]		微博 (Internet Slang), 微信 (Internet Slang), 微 (Internet Slang)
 Internet Slang	圈		juān   juàn   quān	juān   juàn   quān	ring	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle	to confine / to lock up / to pen in  pen (pig) / a fold  circle / ring / loop / classifier for loops, orbits, laps of race etc / CL: 個｜个 / to surround / to circle		朋友圈 (Internet Slang), 圈 (Internet Slang)
-Internet Slang	关注	關注	guān zhù	guān zhù	attention	to pay attention to / to follow sth closely / concern / interest / attention	to pay attention to / to follow sth closely / concern / interest / attention		No Matches Found
-Internet Slang	赞	贊	zàn	zàn	awesome	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)		No Matches Found
-Internet Slang	转发	轉發	zhuǎn fā	zhuǎn fā	Forwarded	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)		No Matches Found
-Internet Slang	好友		hǎo yǒu	hǎo yǒu	Friends	close friend / pal / (social networking website) friend / CL: 個｜个	close friend / pal / (social networking website) friend / CL: 個｜个		No Matches Found
-Internet Slang	粉丝	粉絲	fěn sī	fěn sī	Fans	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth		No Matches Found
-Internet Slang	分享		fēn xiǎng	fēn xiǎng	share it	to share (let others have some of sth good)	to share (let others have some of sth good)		No Matches Found
-Internet Slang	评论	評論	píng lùn	píng lùn	comment	to comment on / to discuss / comment / commentary / CL: 篇	to comment on / to discuss / comment / commentary / CL: 篇		No Matches Found
+Internet Slang	关注	關注	guān zhù	guān zhù	attention	to pay attention to / to follow sth closely / concern / interest / attention	to pay attention to / to follow sth closely / concern / interest / attention		
+Internet Slang	赞	贊	zàn	zàn	awesome	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)	to patronize / to support / to praise / (Internet slang) to like (an online post on Facebook etc)		
+Internet Slang	转发	轉發	zhuǎn fā	zhuǎn fā	Forwarded	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)	to transmit / to forward (mail, SMS, packets of data) / to pass on / to republish (an article from another publication)		
+Internet Slang	好友		hǎo yǒu	hǎo yǒu	Friends	close friend / pal / (social networking website) friend / CL: 個｜个	close friend / pal / (social networking website) friend / CL: 個｜个		
+Internet Slang	粉丝	粉絲	fěn sī	fěn sī	Fans	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth	bean vermicelli / mung bean starch noodles / Chinese vermicelli / cellophane noodles / CL: 把 / fan (loanword) / enthusiast for sb or sth		
+Internet Slang	分享		fēn xiǎng	fēn xiǎng	share it	to share (let others have some of sth good)	to share (let others have some of sth good)		
+Internet Slang	评论	評論	píng lùn	píng lùn	comment	to comment on / to discuss / comment / commentary / CL: 篇	to comment on / to discuss / comment / commentary / CL: 篇		
 Internet Slang	粉		fěn	fěn	powder	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink	powder / cosmetic face powder / food prepared from starch / noodles or pasta made from any kind of flour / whitewash / white / pink		粉丝 (Internet Slang), 粉 (Internet Slang)
 Internet Slang	丝	絲	sī	sī	wire	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc	silk / thread / trace / (cuisine) shreds or julienne strips / CL: 條｜条 / classifier: a thread (of cloud, smoke etc), a bit, an iota, a hint (of sth) etc		粉丝 (Internet Slang), 丝 (Internet Slang)
 Internet Slang	享		xiǎng	xiǎng	enjoy	to enjoy / to benefit / to have the use of	to enjoy / to benefit / to have the use of		分享 (Internet Slang), 享 (Internet Slang)
 Internet Slang	评	評	píng	píng	Review	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)	to discuss / to comment / to criticize / to judge / to choose (by public appraisal)		评论 (Internet Slang), 评 (Internet Slang)
 Internet Slang	论	論	Lún   lùn	Lún   lùn	s	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)	abbr. for 論語｜论语, The Analects (of Confucius)  opinion / view / theory / doctrine / to discuss / to talk about / to regard / to consider / per / by the (kilometer, hour etc)		评论 (Internet Slang), 论 (Internet Slang)
 Business 1	销	銷	xiāo	xiāo	pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin	to melt (metal) / to cancel or annul / to sell / to spend / to fasten with a bolt / bolt or pin		销 (Business 1), 报销 (Business 1)
-Business 1	收据	收據	shōu jù	shōu jù	receipt	receipt / CL: 張｜张	receipt / CL: 張｜张		No Matches Found
-Business 1	报销	報銷	bào xiāo	bào xiāo	Submit an expense account	to submit an expense account / to apply for reimbursement / to write off / to wipe out	to submit an expense account / to apply for reimbursement / to write off / to wipe out		No Matches Found
-Business 1	费用	費用	fèi yòng	fèi yòng	cost	cost / expenditure / expense / CL: 筆｜笔, 個｜个	cost / expenditure / expense / CL: 筆｜笔, 個｜个		No Matches Found
-Business 1	尽快	儘快	jǐn kuài   jìn kuài	jǐn kuài   jìn kuài	ASAP	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快		No Matches Found
-Business 1	回复	回復	huí fù	huí fù	Reply	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)		No Matches Found
-Business 1	报告	報告	bào gào	bào gào	report	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通		No Matches Found
-Business 1	协议	協議	xié yì	xié yì	protocol	agreement / pact / protocol / CL: 項｜项	agreement / pact / protocol / CL: 項｜项		No Matches Found
+Business 1	收据	收據	shōu jù	shōu jù	receipt	receipt / CL: 張｜张	receipt / CL: 張｜张		
+Business 1	报销	報銷	bào xiāo	bào xiāo	Submit an expense account	to submit an expense account / to apply for reimbursement / to write off / to wipe out	to submit an expense account / to apply for reimbursement / to write off / to wipe out		
+Business 1	费用	費用	fèi yòng	fèi yòng	cost	cost / expenditure / expense / CL: 筆｜笔, 個｜个	cost / expenditure / expense / CL: 筆｜笔, 個｜个		
+Business 1	尽快	儘快	jǐn kuài   jìn kuài	jǐn kuài   jìn kuài	ASAP	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快	as quickly as possible / as soon as possible / with all speed  see 儘快｜尽快		
+Business 1	回复	回復	huí fù	huí fù	Reply	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)	to reply / to recover / to return (to a previous condition) / Re: in reply to (email)		
+Business 1	报告	報告	bào gào	bào gào	report	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通	to inform / to report / to make known / report / speech / talk / lecture / CL: 篇, 份, 個｜个, 通		
+Business 1	协议	協議	xié yì	xié yì	protocol	agreement / pact / protocol / CL: 項｜项	agreement / pact / protocol / CL: 項｜项		
 Business 1	尽	儘	jǐn   jìn	jǐn   jìn	Exhausted	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely	to the greatest extent / (when used before a noun of location) furthest or extreme / to be within the limits of / to give priority to  to use up / to exhaust / to end / to finish / to the utmost / exhausted / finished / to the limit (of sth) / all / entirely		尽快 (Business 1), 尽 (Business 1)
 Business 1	协	協	xié	xié	Assist	to cooperate / to harmonize / to help / to assist / to join	to cooperate / to harmonize / to help / to assist / to join		协议 (Business 1), 协 (Business 1)
-Business 1	合同		hé tong	hé tong	contract	(business) contract / CL: 個｜个	(business) contract / CL: 個｜个		No Matches Found
-Business 1	项目	項目	xiàng mù	xiàng mù	project	item / project / (sports) event / CL: 個｜个	item / project / (sports) event / CL: 個｜个		No Matches Found
-Business 1	签名	簽名	qiān míng	qiān míng	signature	to sign (one's name with a pen etc) / to autograph / signature	to sign (one's name with a pen etc) / to autograph / signature		No Matches Found
-Business 1	汇报	匯報	huì bào   huì bào	huì bào   huì bào	report	to report / to give an account of / to collect information and report back  to report / to give an account of / report	to report / to give an account of / to collect information and report back  to report / to give an account of / report		No Matches Found
+Business 1	合同		hé tong	hé tong	contract	(business) contract / CL: 個｜个	(business) contract / CL: 個｜个		
+Business 1	项目	項目	xiàng mù	xiàng mù	project	item / project / (sports) event / CL: 個｜个	item / project / (sports) event / CL: 個｜个		
+Business 1	签名	簽名	qiān míng	qiān míng	signature	to sign (one's name with a pen etc) / to autograph / signature	to sign (one's name with a pen etc) / to autograph / signature		
+Business 1	汇报	匯報	huì bào   huì bào	huì bào   huì bào	report	to report / to give an account of / to collect information and report back  to report / to give an account of / report	to report / to give an account of / to collect information and report back  to report / to give an account of / report		
 Business 1	合		gě   hé	gě   hé	Close	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒	100 ml / one-tenth of a peck / measure for dry grain equal to one-tenth of sheng 升 or liter, or one-hundredth dou 斗  to close / to join / to fit / to be equal to / whole / together / round (in battle) / conjunction (astronomy) / 1st note of pentatonic scale / old variant of 盒		合同 (Business 1), 合 (Business 1), 合作 (Business 2)
 Business 1	项	項	Xiàng   xiàng	Xiàng   xiàng	item	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc	surname Xiang  back of neck / item / thing / term (in a mathematical formula) / sum (of money) / classifier for principles, items, clauses, tasks, research projects etc		项目 (Business 1), 项 (Business 1)
 Business 1	汇	匯	huì   huì	huì   huì	exchange	to remit / to converge (of rivers) / to exchange  class / collection	to remit / to converge (of rivers) / to exchange  class / collection		汇报 (Business 1), 汇 (Business 1)
-Business 1	广告	廣告	guǎng gào	guǎng gào	ad	to advertise / a commercial / advertisement / CL: 項｜项	to advertise / a commercial / advertisement / CL: 項｜项		No Matches Found
-Business 1	预算	預算	yù suàn	yù suàn	budget	budget	budget		No Matches Found
-Business 1	资本	資本	zī běn	zī běn	capital	capital (economics)	capital (economics)		No Matches Found
-Business 1	低		dī	dī	low	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	low / beneath / to lower (one's head) / to let droop / to hang down / to incline		No Matches Found
+Business 1	广告	廣告	guǎng gào	guǎng gào	ad	to advertise / a commercial / advertisement / CL: 項｜项	to advertise / a commercial / advertisement / CL: 項｜项		
+Business 1	预算	預算	yù suàn	yù suàn	budget	budget	budget		
+Business 1	资本	資本	zī běn	zī běn	capital	capital (economics)	capital (economics)		
+Business 1	低		dī	dī	low	low / beneath / to lower (one's head) / to let droop / to hang down / to incline	low / beneath / to lower (one's head) / to let droop / to hang down / to incline		
 Business 1	广	廣	Guǎng   guǎng	Guǎng   guǎng	wide	surname Guang  wide / numerous / to spread	surname Guang  wide / numerous / to spread		广告 (Business 1), 广 (Business 1)
 Business 1	资	資	zī	zī	Capital	resources / capital / to provide / to supply / to support / money / expense	resources / capital / to provide / to supply / to support / money / expense		资本 (Business 1), 资 (Business 1), 投资 (Business 2), 工资 (Work 3)
 Business 2	险	險	xiǎn	xiǎn	risk	danger / dangerous / rugged	danger / dangerous / rugged		险 (Business 2), 保险 (Business 2), 风险 (Business 2)
 Business 2	投		tóu	tóu	cast	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of	to cast / to send / to throw oneself (into the river etc) / to seek refuge / to place oneself into the hands of		投 (Business 2), 投资 (Business 2)
-Business 2	保险	保險	bǎo xiǎn	bǎo xiǎn	Insurance	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	insurance / to insure / safe / secure / be sure / be bound to / CL: 份		No Matches Found
-Business 2	风险	風險	fēng xiǎn	fēng xiǎn	risk	risk / hazard	risk / hazard		No Matches Found
-Business 2	投资	投資	tóu zī	tóu zī	investment	investment / to invest	investment / to invest		No Matches Found
-Business 2	律师	律師	lǜ shī	lǜ shī	lawyer	lawyer	lawyer		No Matches Found
-Business 2	版权	版權	bǎn quán	bǎn quán	copyright	copyright	copyright		No Matches Found
-Business 2	咨询	咨詢	zī xún	zī xún	advisory	to consult / to seek advice / consultation / (sales) inquiry (formal)	to consult / to seek advice / consultation / (sales) inquiry (formal)		No Matches Found
+Business 2	保险	保險	bǎo xiǎn	bǎo xiǎn	Insurance	insurance / to insure / safe / secure / be sure / be bound to / CL: 份	insurance / to insure / safe / secure / be sure / be bound to / CL: 份		
+Business 2	风险	風險	fēng xiǎn	fēng xiǎn	risk	risk / hazard	risk / hazard		
+Business 2	投资	投資	tóu zī	tóu zī	investment	investment / to invest	investment / to invest		
+Business 2	律师	律師	lǜ shī	lǜ shī	lawyer	lawyer	lawyer		
+Business 2	版权	版權	bǎn quán	bǎn quán	copyright	copyright	copyright		
+Business 2	咨询	咨詢	zī xún	zī xún	advisory	to consult / to seek advice / consultation / (sales) inquiry (formal)	to consult / to seek advice / consultation / (sales) inquiry (formal)		
 Business 2	律		Lǜ   lǜ	Lǜ   lǜ	law	surname Lü  law	surname Lü  law		律师 (Business 2), 律 (Business 2)
 Business 2	版		bǎn	bǎn	Version	a register / block of printing / edition / version / page	a register / block of printing / edition / version / page		版权 (Business 2), 版 (Business 2)
 Business 2	咨		zī	zī	Advisory	to consult	to consult		咨询 (Business 2), 咨 (Business 2)
 Business 2	权	權	Quán   quán	Quán   quán	right	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary	surname Quan  authority / power / right / (literary) to weigh / expedient / temporary		版权 (Business 2), 权 (Business 2)
 Business 2	询	詢	xún	xún	Query	to ask about / to inquire about	to ask about / to inquire about		咨询 (Business 2), 询 (Business 2)
-Business 2	保持		bǎo chí	bǎo chí	maintain	to keep / to maintain / to hold / to preserve	to keep / to maintain / to hold / to preserve		No Matches Found
-Business 2	联系	聯繫	lián xì	lián xì	contact	connection / contact / relation / to get in touch with / to integrate / to link / to touch	connection / contact / relation / to get in touch with / to integrate / to link / to touch		No Matches Found
+Business 2	保持		bǎo chí	bǎo chí	maintain	to keep / to maintain / to hold / to preserve	to keep / to maintain / to hold / to preserve		
+Business 2	联系	聯繫	lián xì	lián xì	contact	connection / contact / relation / to get in touch with / to integrate / to link / to touch	connection / contact / relation / to get in touch with / to integrate / to link / to touch		
 Business 2	联	聯	lián	lián	United	to ally / to unite / to join / (poetry) antithetical couplet	to ally / to unite / to join / (poetry) antithetical couplet		联系 (Business 2), 联 (Business 2)
 Business 2	持		chí	chí	hold	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control	to hold / to grasp / to support / to maintain / to persevere / to manage / to run (i.e. administer) / to control		保持 (Business 2), 持 (Business 2)
-Business 2	合作		hé zuò	hé zuò	Cooperation	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个		No Matches Found
-Business 2	愉快		yú kuài	yú kuài	happy	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted		No Matches Found
-Business 2	辛苦		xīn kǔ	xīn kǔ	hard	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)		No Matches Found
-Business 2	感谢	感謝	gǎn xiè	gǎn xiè	thank	(express) thanks / gratitude / grateful / thankful / thanks	(express) thanks / gratitude / grateful / thankful / thanks		No Matches Found
+Business 2	合作		hé zuò	hé zuò	Cooperation	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个	to cooperate / to collaborate / to work together / cooperation / CL: 個｜个		
+Business 2	愉快		yú kuài	yú kuài	happy	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted	cheerful / cheerily / delightful / pleasant / pleasantly / pleasing / happy / delighted		
+Business 2	辛苦		xīn kǔ	xīn kǔ	hard	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)	exhausting / hard / tough / arduous / to work hard / to go to a lot of trouble / hardship(s)		
+Business 2	感谢	感謝	gǎn xiè	gǎn xiè	thank	(express) thanks / gratitude / grateful / thankful / thanks	(express) thanks / gratitude / grateful / thankful / thanks		
 Business 2	愉		yú	yú	Discovery	pleased	pleased		愉快 (Business 2), 愉 (Business 2)
 Business 2	辛		Xīn   xīn	Xīn   xīn	Xin	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa	surname Xin  (of taste) hot or pungent / hard / laborious / suffering / eighth in order / eighth of the ten Heavenly Stems 十天干 / letter 'H' or roman 'VIII' in list 'A, B, C', or 'I, II, III' etc / ancient Chinese compass point: 285° / octa		辛苦 (Business 2), 辛 (Business 2)
 Emergency	伤	傷	shāng	shāng	hurt	to injure / injury / wound	to injure / injury / wound		伤 (Emergency), 受伤 (Emergency)
 Emergency	受		shòu	shòu	Suffer	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)	to receive / to accept / to suffer / subjected to / to bear / to stand / pleasant / (passive marker)		受 (Emergency), 受伤 (Emergency)
 Emergency	救		jiù	jiù	save	to save / to assist / to rescue	to save / to assist / to rescue		救 (Emergency), 救护车 (Emergency), 救命 (Emergency)
 Emergency	警		jǐng	jǐng	police	to alert / to warn / police	to alert / to warn / police		警 (Emergency), 报警 (Emergency), 警察 (Emergency)
-Emergency	报警	報警	bào jǐng	bào jǐng	Call the police	to sound an alarm / to report sth to the police	to sound an alarm / to report sth to the police		No Matches Found
-Emergency	救护车	救護車	jiù hù chē	jiù hù chē	ambulance	ambulance / CL: 輛｜辆	ambulance / CL: 輛｜辆		No Matches Found
-Emergency	受伤	受傷	shòu shāng	shòu shāng	Injured	to sustain injuries / wounded (in an accident etc) / harmed	to sustain injuries / wounded (in an accident etc) / harmed		No Matches Found
-Emergency	救命		jiù mìng	jiù mìng	Help	to save sb's life / (interj.) Help! / Save me!	to save sb's life / (interj.) Help! / Save me!		No Matches Found
-Emergency	发生	發生	fā shēng	fā shēng	occur	to happen / to occur / to take place / to break out	to happen / to occur / to take place / to break out		No Matches Found
-Emergency	意外		yì wài	yì wài	accident	unexpected / accident / mishap / CL: 個｜个	unexpected / accident / mishap / CL: 個｜个		No Matches Found
-Emergency	严重	嚴重	yán zhòng	yán zhòng	serious	grave / serious / severe / critical	grave / serious / severe / critical		No Matches Found
+Emergency	报警	報警	bào jǐng	bào jǐng	Call the police	to sound an alarm / to report sth to the police	to sound an alarm / to report sth to the police		
+Emergency	救护车	救護車	jiù hù chē	jiù hù chē	ambulance	ambulance / CL: 輛｜辆	ambulance / CL: 輛｜辆		
+Emergency	受伤	受傷	shòu shāng	shòu shāng	Injured	to sustain injuries / wounded (in an accident etc) / harmed	to sustain injuries / wounded (in an accident etc) / harmed		
+Emergency	救命		jiù mìng	jiù mìng	Help	to save sb's life / (interj.) Help! / Save me!	to save sb's life / (interj.) Help! / Save me!		
+Emergency	发生	發生	fā shēng	fā shēng	occur	to happen / to occur / to take place / to break out	to happen / to occur / to take place / to break out		
+Emergency	意外		yì wài	yì wài	accident	unexpected / accident / mishap / CL: 個｜个	unexpected / accident / mishap / CL: 個｜个		
+Emergency	严重	嚴重	yán zhòng	yán zhòng	serious	grave / serious / severe / critical	grave / serious / severe / critical		
 Emergency	严	嚴	Yán   yán	Yán   yán	strict	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father	surname Yan  tight (closely sealed) / stern / strict / rigorous / severe / father		严重 (Emergency), 严 (Emergency)
 Emergency	命		mìng	mìng	Life	life / fate / order or command / to assign a name, title etc	life / fate / order or command / to assign a name, title etc		救命 (Emergency), 命 (Emergency)
-Emergency	偷		tōu	tōu	steal	to steal / to pilfer / to snatch / thief / stealthily	to steal / to pilfer / to snatch / thief / stealthily		No Matches Found
-Emergency	警察		jǐng chá	jǐng chá	Policemen	police / police officer / CL: 個｜个	police / police officer / CL: 個｜个		No Matches Found
+Emergency	偷		tōu	tōu	steal	to steal / to pilfer / to snatch / thief / stealthily	to steal / to pilfer / to snatch / thief / stealthily		
+Emergency	警察		jǐng chá	jǐng chá	Policemen	police / police officer / CL: 個｜个	police / police officer / CL: 個｜个		
 Emergency	察		Chá   chá	Chá   chá	Observe	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident	short name for Chahar Province 察哈爾｜察哈尔  to examine / to inquire / to observe / to inspect / to look into / obvious / clearly evident		警察 (Emergency), 察 (Emergency)
 Work 3	奖	獎	jiǎng	jiǎng	prize	prize / award / encouragement / CL: 個｜个	prize / award / encouragement / CL: 個｜个		奖 (Work 3), 奖金 (Work 3)
-Work 3	工资	工資	gōng zī	gōng zī	wage	wages / pay / CL: 個｜个, 份, 月	wages / pay / CL: 個｜个, 份, 月		No Matches Found
-Work 3	加班		jiā bān	jiā bān	Overtime	to work overtime	to work overtime		No Matches Found
-Work 3	奖金	獎金	jiǎng jīn	jiǎng jīn	bonus	premium / award money / bonus	premium / award money / bonus		No Matches Found
-Work 3	生意		shēng yì   shēng yi	shēng yì   shēng yi	business	life force / vitality  business / CL: 筆｜笔	life force / vitality  business / CL: 筆｜笔		No Matches Found
-Work 3	压力	壓力	yā lì	yā lì	pressure	pressure	pressure		No Matches Found
-Work 3	责任	責任	zé rèn	zé rèn	responsibility	responsibility / blame / duty / CL: 個｜个	responsibility / blame / duty / CL: 個｜个		No Matches Found
-Work 3	商量		shāng liang	shāng liang	discuss	to consult / to talk over / to discuss	to consult / to talk over / to discuss		No Matches Found
-Work 3	意见	意見	yì jiàn	yì jiàn	opinion	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条		No Matches Found
+Work 3	工资	工資	gōng zī	gōng zī	wage	wages / pay / CL: 個｜个, 份, 月	wages / pay / CL: 個｜个, 份, 月		
+Work 3	加班		jiā bān	jiā bān	Overtime	to work overtime	to work overtime		
+Work 3	奖金	獎金	jiǎng jīn	jiǎng jīn	bonus	premium / award money / bonus	premium / award money / bonus		
+Work 3	生意		shēng yì   shēng yi	shēng yì   shēng yi	business	life force / vitality  business / CL: 筆｜笔	life force / vitality  business / CL: 筆｜笔		
+Work 3	压力	壓力	yā lì	yā lì	pressure	pressure	pressure		
+Work 3	责任	責任	zé rèn	zé rèn	responsibility	responsibility / blame / duty / CL: 個｜个	responsibility / blame / duty / CL: 個｜个		
+Work 3	商量		shāng liang	shāng liang	discuss	to consult / to talk over / to discuss	to consult / to talk over / to discuss		
+Work 3	意见	意見	yì jiàn	yì jiàn	opinion	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条	idea / opinion / suggestion / objection / complaint / CL: 點｜点, 條｜条		
 Work 3	压	壓	yā   yà	yā   yà	Press	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿	to press / to push down / to keep under (control) / pressure  see 壓根兒｜压根儿		压力 (Work 3), 压 (Work 3)
 Work 3	责	責	zé	zé	responsibility	duty / responsibility / to reproach / to blame	duty / responsibility / to reproach / to blame		责任 (Work 3), 责 (Work 3)
 Work 3	任		Rén   rèn	Rén   rèn	Any	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)	surname Ren / Ren County 任縣｜任县 in Hebei  to assign / to appoint / to take up a post / office / responsibility / to let / to allow / to give free rein to / no matter (how, what etc) / classifier for terms served in office, or for spouses, girlfriends etc (as in 前任男友)		责任 (Work 3), 任 (Work 3)
-Work 3	误会	誤會	wù huì	wù huì	misunderstanding	to misunderstand / to mistake / misunderstanding / CL: 個｜个	to misunderstand / to mistake / misunderstanding / CL: 個｜个		No Matches Found
-Work 3	抱歉		bào qiàn	bào qiàn	Sorry	to be sorry / to feel apologetic / sorry!	to be sorry / to feel apologetic / sorry!		No Matches Found
-Work 3	原谅	原諒	yuán liàng	yuán liàng	forgive	to excuse / to forgive / to pardon	to excuse / to forgive / to pardon		No Matches Found
+Work 3	误会	誤會	wù huì	wù huì	misunderstanding	to misunderstand / to mistake / misunderstanding / CL: 個｜个	to misunderstand / to mistake / misunderstanding / CL: 個｜个		
+Work 3	抱歉		bào qiàn	bào qiàn	Sorry	to be sorry / to feel apologetic / sorry!	to be sorry / to feel apologetic / sorry!		
+Work 3	原谅	原諒	yuán liàng	yuán liàng	forgive	to excuse / to forgive / to pardon	to excuse / to forgive / to pardon		
 Work 3	误	誤	wù	wù	error	mistake / error / to miss / to harm / to delay / to neglect / mistakenly	mistake / error / to miss / to harm / to delay / to neglect / mistakenly		误会 (Work 3), 误 (Work 3)
 Work 3	抱		bào	bào	hold	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish	to hold / to carry (in one's arms) / to hug / to embrace / to surround / to cherish		抱歉 (Work 3), 抱 (Work 3)
 Work 3	原		Yuán   yuán	Yuán   yuán	original	Hara (Japanese surname)  former / original / primary / raw / level / cause / source	Hara (Japanese surname)  former / original / primary / raw / level / cause / source		原谅 (Work 3), 原 (Work 3)
 Work 3	歉		qiàn	qiàn	apologize	to apologize / to regret / deficient	to apologize / to regret / deficient		抱歉 (Work 3), 歉 (Work 3)
 Work 3	谅	諒	liàng	liàng	Forgive	to show understanding / to excuse / to presume / to expect	to show understanding / to excuse / to presume / to expect		原谅 (Work 3), 谅 (Work 3)
-Weather 2	干燥	乾燥	gān zào	gān zào	dry	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid		No Matches Found
-Weather 2	暖和		nuǎn huo	nuǎn huo	warm	warm / nice and warm	warm / nice and warm		No Matches Found
-Weather 2	凉快	涼快	liáng kuai	liáng kuai	Cool off	nice and cold / pleasantly cool	nice and cold / pleasantly cool		No Matches Found
+Weather 2	干燥	乾燥	gān zào	gān zào	dry	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid	to dry (of weather, paint, cement etc) / desiccation / dull / uninteresting / arid		
+Weather 2	暖和		nuǎn huo	nuǎn huo	warm	warm / nice and warm	warm / nice and warm		
+Weather 2	凉快	涼快	liáng kuai	liáng kuai	Cool off	nice and cold / pleasantly cool	nice and cold / pleasantly cool		
 Weather 2	燥		zào	zào	dry	dry / parched / impatient	dry / parched / impatient		干燥 (Weather 2), 燥 (Weather 2)
 Weather 2	暖		nuǎn	nuǎn	warm	warm / to warm	warm / to warm		暖和 (Weather 2), 暖 (Weather 2)
 Weather 2	凉	涼	Liáng   liáng   liàng	Liáng   liáng   liàng	cool	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down	the five Liang of the Sixteen Kingdoms, namely: Former Liang 前涼｜前凉 (314-376), Later Liang 後涼｜后凉 (386-403), Northern Liang 北涼｜北凉 (398-439), Southern Liang 南涼｜南凉 (397-414), Western Liang 西涼｜西凉 (400-421)  cool / cold  to let sth cool down		凉快 (Weather 2), 凉 (Weather 2)
-Weather 2	温度	溫度	wēn dù	wēn dù	temperature	temperature / CL: 個｜个	temperature / CL: 個｜个		No Matches Found
-Weather 2	大约	大約	dà yuē	dà yuē	about	approximately / probably	approximately / probably		No Matches Found
+Weather 2	温度	溫度	wēn dù	wēn dù	temperature	temperature / CL: 個｜个	temperature / CL: 個｜个		
+Weather 2	大约	大約	dà yuē	dà yuē	about	approximately / probably	approximately / probably		
 Weather 2	温	溫	Wēn   wēn	Wēn   wēn	temperature	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟	surname Wen  warm / lukewarm / temperature / to warm up / mild / soft / tender / to review (a lesson etc) / fever (TCM) / old variant of 瘟		温度 (Weather 2), 温 (Weather 2)
 Duo	鹰	鷹	yīng	yīng	eagle	eagle / falcon / hawk	eagle / falcon / hawk		鹰 (Duo), 猫头鹰 (Duo)
 Duo	羽		yǔ	yǔ	feather	feather / 5th note in pentatonic scale	feather / 5th note in pentatonic scale		羽 (Duo), 羽毛 (Duo)
-Duo	橙		chéng	chéng	Orange	orange tree / orange (color)	orange tree / orange (color)		No Matches Found
-Duo	猫头鹰	貓頭鷹	māo tóu yīng	māo tóu yīng	owl	owl	owl		No Matches Found
-Duo	羽毛		yǔ máo	yǔ máo	feather	feather / plumage / plume	feather / plumage / plume		No Matches Found
-Duo	多儿		duō er	duō er	And more children				No Matches Found
-Duo	鼓励	鼓勵	gǔ lì	gǔ lì	encourage	to encourage	to encourage		No Matches Found
-Duo	提醒		tí xǐng	tí xǐng	remind	to remind / to call attention to / to warn of	to remind / to call attention to / to warn of		No Matches Found
-Duo	懒	懶	lǎn	lǎn	lazy	lazy	lazy		No Matches Found
-Duo	放弃	放棄	fàng qì	fàng qì	give up	to renounce / to abandon / to give up	to renounce / to abandon / to give up		No Matches Found
+Duo	橙		chéng	chéng	Orange	orange tree / orange (color)	orange tree / orange (color)		
+Duo	猫头鹰	貓頭鷹	māo tóu yīng	māo tóu yīng	owl	owl	owl		
+Duo	羽毛		yǔ máo	yǔ máo	feather	feather / plumage / plume	feather / plumage / plume		
+Duo	多儿		duō er	duō er	And more children				
+Duo	鼓励	鼓勵	gǔ lì	gǔ lì	encourage	to encourage	to encourage		
+Duo	提醒		tí xǐng	tí xǐng	remind	to remind / to call attention to / to warn of	to remind / to call attention to / to warn of		
+Duo	懒	懶	lǎn	lǎn	lazy	lazy	lazy		
+Duo	放弃	放棄	fàng qì	fàng qì	give up	to renounce / to abandon / to give up	to renounce / to abandon / to give up		
 Duo	鼓		gǔ	gǔ	drum	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell	drum / CL: 通, 面 / to drum / to strike / to rouse / to bulge / to swell		鼓励 (Duo), 鼓 (Duo)
 Duo	励	勵	Lì   lì	Lì   lì	Encourage	surname Li  to encourage / to urge	surname Li  to encourage / to urge		鼓励 (Duo), 励 (Duo)
 Duo	醒		xǐng	xǐng	wake	to wake up / to be awake / to become aware / to sober up / to come to	to wake up / to be awake / to become aware / to sober up / to come to		提醒 (Duo), 醒 (Duo)


### PR DESCRIPTION
The purpose of this column is to allow a user to see all occurrences of this character within the Duolingo curriculum.  For example, the character "名" occurs in 4 places in the Duolingo curriculum, or in 3 lessons:
1) 名字 (Name)
2) 名 (Name)
3) 有名 (Culture)
4) 签名 (Business 1)

The "Alternate Occurrences" column lists all vocabulary words and lessons in which this character appears.  Although this column may not appear in the final Anki deck, there are several use cases for this column.  For the moment, this column can serve as a "tag" so that we are only creating one card for each character, but later one we may find the need to insert that card into multiple decks.  An Anki user of our deck may want one deck for each Duolingo lesson or section.  This tag helps us or them to identify which decks a single card may belong to.  

Also, the Javascript code I wrote in order to do this will likely be useful in later steps of this project.